### PR TITLE
fix visual ordering on mobile for River content

### DIFF
--- a/src/River/River.module.css
+++ b/src/River/River.module.css
@@ -7,6 +7,7 @@
 
 .River__visual {
   position: relative;
+  order: 2;
 }
 
 .River--align-center {
@@ -69,6 +70,7 @@
 
   .River__visual {
     grid-area: visual;
+    order: unset;
   }
 
   .River--align-center {


### PR DESCRIPTION
On mobile, the content wasn't appearing before the image

Before
![Screenshot 2022-06-10 at 16 41 32](https://user-images.githubusercontent.com/13340707/173102145-4671d01e-4996-4980-b6cd-1cdcf67e41cb.png)


Afte
![Screenshot 2022-06-10 at 16 42 33](https://user-images.githubusercontent.com/13340707/173102153-436b6837-11e6-4b6a-99a9-6ae10789d1d3.png)
r