### PR TITLE
Remove Containers from inline code snippets

### DIFF
--- a/docs/content/components/FAQ.mdx
+++ b/docs/content/components/FAQ.mdx
@@ -20,7 +20,7 @@ import {FAQ} from '@primer/react-brand'
 ### Default
 
 ```jsx live
-<Container p={3}>
+<>
   <FAQ>
     <FAQ.Heading>Frequently asked questions</FAQ.Heading>
     <FAQ.Item>
@@ -114,7 +114,7 @@ import {FAQ} from '@primer/react-brand'
       </FAQ.Answer>
     </FAQ.Item>
   </FAQ>
-</Container>
+</>
 ```
 
 ### Grouped FAQs
@@ -131,61 +131,58 @@ Use `FAQ.Subheading` to create a visual separation between your `FAQ.Question` d
 </Note>
 
 ```jsx live
-<Container p={3}>
-  <FAQ>
-    <FAQ.Heading>Frequently asked questions</FAQ.Heading>
-    <FAQ.Subheading>Subscriptions & Payments</FAQ.Subheading>
-    <FAQ.Item>
-      <FAQ.Question>
-        What are the differences between GitHub Free, GitHub Pro, GitHub Team
-        and GitHub Enterprise plans?
-      </FAQ.Question>
-      <FAQ.Answer>
-        <p>
-          GitHub Free is our basic plan created for individuals and small teams
-          to collaborate on private and public repositories.
-        </p>
-      </FAQ.Answer>
-    </FAQ.Item>
-    <FAQ.Item>
-      <FAQ.Question>How do I view and manage my subscription?</FAQ.Question>
-      <FAQ.Answer>
-        <p>
-          You can view your account's subscription, your other paid features and
-          products, and your next billing date in your account's billing
-          settings.
-        </p>
-      </FAQ.Answer>
-    </FAQ.Item>
-    <FAQ.Subheading>Actions & Packages</FAQ.Subheading>
-    <FAQ.Item>
-      <FAQ.Question>
-        Which plans include access to GitHub Actions and Packages?
-      </FAQ.Question>
-      <FAQ.Answer>
-        <p>
-          GitHub Actions and Packages are free for public repositories and
-          packages on all our current per-user plans, while private repositories
-          and packages receive a set amount of free minutes, storage, and data
-          transfer depending on the per-user plan. Legacy per-repository plans
-          (Bronze, Silver, Gold etc) do not come with access to GitHub Actions
-          and Packages but they can be upgraded to a current per-user plan.
-        </p>
-      </FAQ.Answer>
-    </FAQ.Item>
-    <FAQ.Item>
-      <FAQ.Question>
-        How do I manage my spending for Actions and Packages?
-      </FAQ.Question>
-      <FAQ.Answer>
-        <p>
-          You can manage your spending for Actions and Packages in your billing
-          settings page under the payment information tab.
-        </p>
-      </FAQ.Answer>
-    </FAQ.Item>
-  </FAQ>
-</Container>
+<FAQ>
+  <FAQ.Heading>Frequently asked questions</FAQ.Heading>
+  <FAQ.Subheading>Subscriptions & Payments</FAQ.Subheading>
+  <FAQ.Item>
+    <FAQ.Question>
+      What are the differences between GitHub Free, GitHub Pro, GitHub Team and
+      GitHub Enterprise plans?
+    </FAQ.Question>
+    <FAQ.Answer>
+      <p>
+        GitHub Free is our basic plan created for individuals and small teams to
+        collaborate on private and public repositories.
+      </p>
+    </FAQ.Answer>
+  </FAQ.Item>
+  <FAQ.Item>
+    <FAQ.Question>How do I view and manage my subscription?</FAQ.Question>
+    <FAQ.Answer>
+      <p>
+        You can view your account's subscription, your other paid features and
+        products, and your next billing date in your account's billing settings.
+      </p>
+    </FAQ.Answer>
+  </FAQ.Item>
+  <FAQ.Subheading>Actions & Packages</FAQ.Subheading>
+  <FAQ.Item>
+    <FAQ.Question>
+      Which plans include access to GitHub Actions and Packages?
+    </FAQ.Question>
+    <FAQ.Answer>
+      <p>
+        GitHub Actions and Packages are free for public repositories and
+        packages on all our current per-user plans, while private repositories
+        and packages receive a set amount of free minutes, storage, and data
+        transfer depending on the per-user plan. Legacy per-repository plans
+        (Bronze, Silver, Gold etc) do not come with access to GitHub Actions and
+        Packages but they can be upgraded to a current per-user plan.
+      </p>
+    </FAQ.Answer>
+  </FAQ.Item>
+  <FAQ.Item>
+    <FAQ.Question>
+      How do I manage my spending for Actions and Packages?
+    </FAQ.Question>
+    <FAQ.Answer>
+      <p>
+        You can manage your spending for Actions and Packages in your billing
+        settings page under the payment information tab.
+      </p>
+    </FAQ.Answer>
+  </FAQ.Item>
+</FAQ>
 ```
 
 ### Rendering with dynamic data
@@ -277,21 +274,19 @@ const App = () => {
   ]
 
   return (
-    <Container>
-      <FAQ>
-        <FAQ.Heading>Frequently asked questions</FAQ.Heading>
-        <>
-          {fixtureData.map(({question, answer}) => {
-            return (
-              <FAQ.Item key={question} open={false}>
-                <FAQ.Question>{question}</FAQ.Question>
-                <FAQ.Answer>{answer}</FAQ.Answer>
-              </FAQ.Item>
-            )
-          })}
-        </>
-      </FAQ>
-    </Container>
+    <FAQ>
+      <FAQ.Heading>Frequently asked questions</FAQ.Heading>
+      <>
+        {fixtureData.map(({question, answer}) => {
+          return (
+            <FAQ.Item key={question} open={false}>
+              <FAQ.Question>{question}</FAQ.Question>
+              <FAQ.Answer>{answer}</FAQ.Answer>
+            </FAQ.Item>
+          )
+        })}
+      </>
+    </FAQ>
   )
 }
 

--- a/docs/content/components/Heading.mdx
+++ b/docs/content/components/Heading.mdx
@@ -19,22 +19,20 @@ import {Heading} from '@primer/react-brand'
 ### Default
 
 ```jsx live
-<Container pl={3}>
-  <Heading>This is my super sweet heading</Heading>
-</Container>
+<Heading>This is my super sweet heading</Heading>
 ```
 
 ### Scale
 
 ```jsx live
-<Container pl={3}>
+<>
   <Heading as="h1">Heading 1</Heading>
   <Heading as="h2">Heading 2</Heading>
   <Heading as="h3">Heading 3</Heading>
   <Heading as="h4">Heading 4</Heading>
   <Heading as="h5">Heading 5</Heading>
   <Heading as="h6">Heading 6</Heading>
-</Container>
+</>
 ```
 
 ### Sizes
@@ -42,9 +40,7 @@ import {Heading} from '@primer/react-brand'
 The `Heading` size is determined by the type of HTML element specified. E.g. `h1`, `h2`, `h3`, `h4`, `h5` or `h6`.
 
 ```jsx live
-<Container pl={3}>
-  <Heading as="h6">This is my super sweet heading</Heading>
-</Container>
+<Heading as="h6">This is my super sweet heading</Heading>
 ```
 
 ## Component props

--- a/docs/content/components/River.mdx
+++ b/docs/content/components/River.mdx
@@ -22,7 +22,7 @@ import {River} from '@primer/react-brand'
 ### Default
 
 ```jsx live
-<Container p={3}>
+<>
   <River>
     <River.Visual>
       <img
@@ -74,13 +74,13 @@ import {River} from '@primer/react-brand'
       <Link href="#">Call to action</Link>
     </River.Content>
   </River>
-</Container>
+</>
 ```
 
 ### Image to text ratio
 
 ```jsx live
-<Container p={3}>
+<>
   {/* 50/50 (default) example */}
   <River>
     <River.Visual>
@@ -109,43 +109,41 @@ import {River} from '@primer/react-brand'
       <Text>This example applies an optional 60/40 image to text split.</Text>
     </River.Content>
   </River>
-</Container>
+</>
 ```
 
 ### Video
 
 ```jsx live
-<Container p={3}>
-  <River imageTextRatio="60:40">
-    <River.Visual hasShadow={false}>
-      <video
-        loop
-        playsInline
-        autoPlay
-        muted
-        aria-hidden="true"
-        poster="https://github.githubassets.com/images/modules/site/issues/issue-tasks-progress-placeholder.png"
-      >
-        <source
-          type="video/mp4; codecs=hevc,mp4a.40.2"
-          src="https://github.githubassets.com/images/modules/site/issues/issue-tasks-progress.hevc.mp4"
-        />
-        <source
-          type="video/mp4; codecs=avc1.4D401E,mp4a.40.2"
-          src="https://github.githubassets.com/images/modules/site/issues/issue-tasks-progress.h264.mp4"
-        />
-      </video>
-    </River.Visual>
-    <River.Content>
-      <Heading>Break issues into actionable tasks</Heading>
-      <Text>
-        Tackle complex issues with task lists and track their status with new
-        progress indicators. Convert tasks into their own issues and navigate
-        your work hierarchy.
-      </Text>
-    </River.Content>
-  </River>
-</Container>
+<River imageTextRatio="60:40">
+  <River.Visual hasShadow={false}>
+    <video
+      loop
+      playsInline
+      autoPlay
+      muted
+      aria-hidden="true"
+      poster="https://github.githubassets.com/images/modules/site/issues/issue-tasks-progress-placeholder.png"
+    >
+      <source
+        type="video/mp4; codecs=hevc,mp4a.40.2"
+        src="https://github.githubassets.com/images/modules/site/issues/issue-tasks-progress.hevc.mp4"
+      />
+      <source
+        type="video/mp4; codecs=avc1.4D401E,mp4a.40.2"
+        src="https://github.githubassets.com/images/modules/site/issues/issue-tasks-progress.h264.mp4"
+      />
+    </video>
+  </River.Visual>
+  <River.Content>
+    <Heading>Break issues into actionable tasks</Heading>
+    <Text>
+      Tackle complex issues with task lists and track their status with new
+      progress indicators. Convert tasks into their own issues and navigate your
+      work hierarchy.
+    </Text>
+  </River.Content>
+</River>
 ```
 
 ## Component props

--- a/docs/content/components/Text.mdx
+++ b/docs/content/components/Text.mdx
@@ -26,32 +26,30 @@ import {Text} from '@primer/react-brand'
 ### Default
 
 ```jsx live
-<Container pl={3}>
-  <Text>With GitHub Copilot, you’re always in charge.</Text>
-</Container>
+<Text>With GitHub Copilot, you’re always in charge.</Text>
 ```
 
 ### Scale
 
 ```jsx live
-<Container pl={3}>
+<>
   {TextSizes.map((size) => (
     <Text key={size} size={size} as="p">
       Text {size}
     </Text>
   ))}
-</Container>
+</>
 ```
 
 ### Variants
 
 ```jsx live
-<Container pl={3}>
+<>
   <Text as="p">With GitHub Copilot, you’re always in charge.</Text>
   <Text as="p" variant="muted">
     With GitHub Copilot, you’re always in charge.
   </Text>
-</Container>
+</>
 ```
 
 ### Polymorphism
@@ -59,9 +57,7 @@ import {Text} from '@primer/react-brand'
 The `Text` component can render as a `span`, `p` or `div` HTML element.
 
 ```jsx live
-<Container pl={3}>
-  <Text as="p">With GitHub Copilot, you’re always in charge.</Text>
-</Container>
+<Text as="p">With GitHub Copilot, you’re always in charge.</Text>
 ```
 
 ## Component props

--- a/docs/content/getting-started/theming.mdx
+++ b/docs/content/getting-started/theming.mdx
@@ -63,29 +63,27 @@ const Example = () => {
       colorMode={colorMode}
       style={{backgroundColor: 'var(--brand-color-canvas-default)'}}
     >
-      <Container p={3}>
-        <River>
-          <River.Visual>
-            <img
-              src="https://via.placeholder.com/600x400/f5f5f5/f5f5f5.png"
-              alt="placeholder, blank area with an off-white background color"
-            />
-          </River.Visual>
-          <River.Content>
-            <Heading>Heading</Heading>
-            <Text>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sapien
-              sit ullamcorper id. Aliquam luctus sed turpis felis nam pulvinar
-              risus elementum.
-            </Text>
-            <Link href="#" onClick={handleChange}>
-              {colorMode === 'dark'
-                ? "I'm in dark mode now"
-                : 'Switch to dark mode'}
-            </Link>
-          </River.Content>
-        </River>
-      </Container>
+      <River>
+        <River.Visual>
+          <img
+            src="https://via.placeholder.com/600x400/f5f5f5/f5f5f5.png"
+            alt="placeholder, blank area with an off-white background color"
+          />
+        </River.Visual>
+        <River.Content>
+          <Heading>Heading</Heading>
+          <Text>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sapien
+            sit ullamcorper id. Aliquam luctus sed turpis felis nam pulvinar
+            risus elementum.
+          </Text>
+          <Link href="#" onClick={handleChange}>
+            {colorMode === 'dark'
+              ? "I'm in dark mode now"
+              : 'Switch to dark mode'}
+          </Link>
+        </River.Content>
+      </River>
     </ThemeProvider>
   )
 }

--- a/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/live-preview-wrapper.js
@@ -48,7 +48,9 @@ export default function LivePreviewWrapper({children}) {
                 </ActionMenu.Overlay>
               </ActionMenu>
             </Box>
-            {children}
+            <Box px={5} py={3}>
+              {children}
+            </Box>
           </Box>
         </ThemeProvider>
       </Box>


### PR DESCRIPTION
## Summary

Removes usage of `<Container>`  in docs code snippets and hoists it into the code snippet decorator.

This removes redundant boilerplate from code snippets and will help remove these changes from https://github.com/primer/brand/pull/69

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- added `Container` to  Doctocat code preview
- removed `Container` declarations in all code snippets

## What should reviewers focus on?

- Checking the docs still look okay 🙏 
- There should be no visual regression or changes as it's a like-for-like switch.


<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->


