### PR TITLE
Fix npm badge in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Good pull requests are a fantastic help. They should remain focused in scope and
    - See [changesets/changesets](https://github.com/changesets/changesets) for more information.
 1. Push your branch and open a pull request. **Please use the supplied pull request template**.
 1. Wait for CI tests to complete.
-   - If the tests pass, you should see a status check advising you that a canary build of `@primer/brand` has been published, and ready to test in-app.
+   - If the tests pass, you should see a status check advising you that a canary build of `@primer/react-brand` has been published, and ready to test in-app.
    - If the tests fail, review the logs and address any issues.
    - If the builds fail for any other reason (as they occasionally do), they may need to be manually restarted.
 1. Pat yourself on the back and wait for your pull request to be reviewed.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 </p>
 
 <p align="center">
-  <a aria-label="npm package" href="https://www.npmjs.com/package/@primer/brand">
-    <img alt="" src="https://img.shields.io/npm/v/@primer/brand.svg">
+  <a aria-label="npm package" href="https://www.npmjs.com/package/@primer/react-brand">
+    <img alt="" src="https://img.shields.io/npm/v/@primer/react-brand.svg">
   </a>
   <a aria-label="build status" href="https://github.com/primer/brand/actions/workflows/ci.yml">
     <img alt="" src="https://github.com/primer/brand/actions/workflows/ci.yml/badge.svg">


### PR DESCRIPTION
## Summary

Fixes NPM badge in readme, which incorrectly references `@primer/brand` as the npm package name. 


## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![current badge](https://user-images.githubusercontent.com/13340707/188601926-dff34a95-f61a-45b9-bd83-444c3bbf9712.png)


 </td>
<td valign="top">

![new badge](https://user-images.githubusercontent.com/13340707/188602098-ffb594e0-9b72-47e6-ba5f-6ea3c61c0dd8.png)


</td>
</tr>
</table>
