### PR TITLE
Fix runtime warnings in Select and Checkbox components

### DIFF
--- a/docs/content/components/FormControl.mdx
+++ b/docs/content/components/FormControl.mdx
@@ -43,8 +43,8 @@ import {FormControl} from '@primer/react-brand'
 <Box sx={{display: 'inline-grid', gap: 3}}>
   <FormControl>
     <FormControl.Label>Select</FormControl.Label>
-    <Select defaultValue="unselected">
-      <Select.Option value="unselected" disabled>
+    <Select defaultValue="">
+      <Select.Option value="" disabled>
         Select a handle
       </Select.Option>
       <Select.Option value="mona">Monalisa</Select.Option>

--- a/docs/content/components/FormControl.mdx
+++ b/docs/content/components/FormControl.mdx
@@ -43,8 +43,8 @@ import {FormControl} from '@primer/react-brand'
 <Box sx={{display: 'inline-grid', gap: 3}}>
   <FormControl>
     <FormControl.Label>Select</FormControl.Label>
-    <Select>
-      <Select.Option value="" selected disabled>
+    <Select defaultValue="unselected">
+      <Select.Option value="unselected" disabled>
         Select a handle
       </Select.Option>
       <Select.Option value="mona">Monalisa</Select.Option>
@@ -88,8 +88,8 @@ An example of a typical layout composed using `FormControl`:
     >
       <FormControl fullWidth>
         <FormControl.Label>Title</FormControl.Label>
-        <Select>
-          <Select.Option value="" selected disabled>
+        <Select defaultValue="">
+          <Select.Option value="" disabled>
             Title
           </Select.Option>
           <Select.Option value="miss">Miss</Select.Option>
@@ -120,8 +120,8 @@ An example of a typical layout composed using `FormControl`:
 
     <FormControl fullWidth required>
       <FormControl.Label>Country</FormControl.Label>
-      <Select>
-        <Select.Option value="" selected disabled>
+      <Select defaultValue="">
+        <Select.Option value="" disabled>
           Country
         </Select.Option>
         <Select.Option value="us">United States of America</Select.Option>
@@ -277,7 +277,7 @@ render(App)
 <FormControl>
   <FormControl.Label>Select</FormControl.Label>
   <Select>
-    <Select.Option value="" selected disabled>
+    <Select.Option value="" disabled>
       Select a handle
     </Select.Option>
     <Select.Option value="mona">Monalisa</Select.Option>

--- a/docs/content/components/Select.mdx
+++ b/docs/content/components/Select.mdx
@@ -37,8 +37,8 @@ import {Select} from '@primer/react-brand'
 ### Placeholder
 
 ```jsx live
-<Select>
-  <Select.Option value="" selected disabled>
+<Select defaultValue="">
+  <Select.Option value="" disabled>
     Select a handle
   </Select.Option>
   <Select.Option value="mona">Monalisa</Select.Option>
@@ -49,8 +49,8 @@ import {Select} from '@primer/react-brand'
 ### Option groups
 
 ```jsx live
-<Select>
-  <Select.Option value="" selected disabled>
+<Select defaultValue="">
+  <Select.Option value="" disabled>
     Select a country
   </Select.Option>
 
@@ -79,8 +79,8 @@ Use `Select` alongside `FormControl` to ensure the control has a corresponding f
 ```jsx live
 <FormControl>
   <FormControl.Label>Country</FormControl.Label>
-  <Select>
-    <Select.Option value="" selected disabled>
+  <Select defaultValue="">
+    <Select.Option value="" disabled>
       Select a country
     </Select.Option>
     <Select.Option value="cn">China</Select.Option>
@@ -155,8 +155,8 @@ Use `Select` alongside `FormControl` to ensure the control has a corresponding f
 Pass the `required` prop to ensure that the input field must be filled out before submitting the form.
 
 ```jsx live
-<Select required>
-  <Select.Option value="" disabled selected>
+<Select required defaultValue="">
+  <Select.Option value="" disabled>
     Select a handle
   </Select.Option>
   <Select.Option value="mona">Monalisa</Select.Option>
@@ -194,8 +194,8 @@ const App = () => {
       >
         <FormControl fullWidth>
           <FormControl.Label>Name</FormControl.Label>
-          <Select ref={selectRef}>
-            <Select.Option value="" disabled selected>
+          <Select ref={selectRef} defaultValue="">
+            <Select.Option value="" disabled>
               Select a handle
             </Select.Option>
             <Select.Option value="mona">Monalisa</Select.Option>

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.4.1",
-        "@types/react": "^17.0.37",
+        "@types/react": "^17.0.50",
         "@types/react-dom": "^17.0.11",
         "@types/webpack": "^4.41.25",
         "@typescript-eslint/eslint-plugin": "^5.17.0",
@@ -15465,9 +15465,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
-      "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
+      "version": "17.0.50",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
+      "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -51043,9 +51043,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
-      "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
+      "version": "17.0.50",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.50.tgz",
+      "integrity": "sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@testing-library/react-hooks": "^7.0.2",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.4.1",
-    "@types/react": "^17.0.37",
+    "@types/react": "^17.0.50",
     "@types/react-dom": "^17.0.11",
     "@types/webpack": "^4.41.25",
     "@typescript-eslint/eslint-plugin": "^5.17.0",

--- a/src/forms/Checkbox/Checkbox.tsx
+++ b/src/forms/Checkbox/Checkbox.tsx
@@ -1,9 +1,10 @@
-import React, {forwardRef, InputHTMLAttributes, ReactElement, RefObject, useLayoutEffect, useRef} from 'react'
+import React, {forwardRef, InputHTMLAttributes, ReactElement, RefObject, useRef} from 'react'
 import clsx from 'clsx'
 import {useId} from '@reach/auto-id' // TODO: Replace with useId from React v18 after upgrade
 
 import type {BaseProps} from '../../component-helpers'
 import type {FormValidationStatus} from '../form-types'
+import useLayoutEffect from '../../hooks/useIsomorphicLayoutEffect'
 
 import styles from './Checkbox.module.css'
 
@@ -54,7 +55,6 @@ const _Checkbox = (
   const inputRef: RefObject<HTMLInputElement> | null = useRef<HTMLInputElement>(ref || null)
   const uniqueId = useId(id)
 
-  // replace with isomorphic useEffect
   useLayoutEffect(() => {
     if (inputRef.current) {
       inputRef.current.indeterminate = indeterminate || false

--- a/src/forms/FormControl/FormControl.stories.tsx
+++ b/src/forms/FormControl/FormControl.stories.tsx
@@ -217,8 +217,8 @@ export const SelectPlayground = args => {
       size={args.size}
     >
       <FormControl.Label visuallyHidden={args.visuallyHidden ? true : false}>{args.label}</FormControl.Label>
-      <Select disabled={args.disabled}>
-        <Select.Option value="" selected disabled>
+      <Select defaultValue="" disabled={args.disabled}>
+        <Select.Option value="" disabled>
           Country
         </Select.Option>
         <Select.Option value="us">United States of America</Select.Option>

--- a/src/forms/Select/Select.stories.tsx
+++ b/src/forms/Select/Select.stories.tsx
@@ -53,8 +53,8 @@ export default {
 } as ComponentMeta<typeof Select>
 
 export const Playground: ComponentStory<typeof Select> = args => (
-  <Select {...args} aria-label="Standalone select input">
-    <Select.Option value="" selected disabled>
+  <Select {...args} aria-label="Standalone select input" defaultValue="select a handle">
+    <Select.Option value="select a handle" disabled>
       Select a handle
     </Select.Option>
     <Select.Option value="mona">Monalisa</Select.Option>

--- a/src/forms/form.stories.tsx
+++ b/src/forms/form.stories.tsx
@@ -107,7 +107,7 @@ export const GitHubEnterprise = args => {
           <FormControl required fullWidth validationStatus={args.validationStatus}>
             <FormControl.Label>Country</FormControl.Label>
             <Select disabled={args.disabled}>
-              <Select.Option value="" selected disabled>
+              <Select.Option value="" disabled>
                 Country
               </Select.Option>
               <Select.Option value="us">United States of America</Select.Option>

--- a/src/forms/form.stories.tsx
+++ b/src/forms/form.stories.tsx
@@ -106,7 +106,7 @@ export const GitHubEnterprise = args => {
 
           <FormControl required fullWidth validationStatus={args.validationStatus}>
             <FormControl.Label>Country</FormControl.Label>
-            <Select disabled={args.disabled}>
+            <Select disabled={args.disabled} defaultValue="">
               <Select.Option value="" disabled>
                 Country
               </Select.Option>

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,10 @@
+import {useEffect, useLayoutEffect} from 'react'
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' &&
+  typeof window.document !== 'undefined' &&
+  typeof window.document.createElement !== 'undefined'
+    ? useLayoutEffect
+    : useEffect
+
+export default useIsomorphicLayoutEffect


### PR DESCRIPTION
## Summary

Our consumer integration tests are failing in https://github.com/primer/brand/pull/77 because the Select and Checkbox components display runtime errors in both Create React App and Astro.

This _should_ fix it.

## List of notable changes:

- **updated** Select examples in docs and storybook
- **added** useIsomorphicLayoutEffect hook and replaced in Checkbox
- **updated** React type definitions dependency as it was causing typescript errors


## What should reviewers focus on?

- CI tests still passing without visual changes detected

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Screenshots:
n/a
