### PR TITLE
Fix id and name prefixing in FormControl

### DIFF
--- a/src/forms/FormControl/FormControl.test.tsx
+++ b/src/forms/FormControl/FormControl.test.tsx
@@ -43,7 +43,7 @@ describe('FormControl', () => {
 
   it('generates a unique ID and forwards to relevant children', async () => {
     const {container, getByRole, getByTestId} = render(
-      <FormControl id={mockFormControlId} data-testid={mockTestId}>
+      <FormControl data-testid={mockTestId}>
         <FormControl.Label>{mockFormControlLabel}</FormControl.Label>
         <TextInput />
       </FormControl>
@@ -59,7 +59,8 @@ describe('FormControl', () => {
 
     expect(inputIdValue).toEqual(labelForValue)
     expect(inputNameValue).toEqual(labelForValue)
-    expect(rootEl.getAttribute('id')).toBe(mockFormControlId)
+
+    expect(rootEl.getAttribute('id')).toBe(`FormControl--${inputIdValue}`)
   })
 
   it('can forward an ID override to relevant children', async () => {
@@ -79,9 +80,12 @@ describe('FormControl', () => {
     const inputIdValue = inputEl.getAttribute('id')
     const inputNameValue = inputEl.getAttribute('name')
 
+    expect(inputIdValue).toEqual(mockFormControlId)
     expect(inputIdValue).toEqual(labelForValue)
     expect(inputNameValue).toEqual(labelForValue)
-    expect(rootEl.getAttribute('id')).toBe(mockFormControlId)
+    expect(inputNameValue).toEqual(mockFormControlId)
+
+    expect(rootEl.getAttribute('id')).toBe(`FormControl--${mockFormControlId}`)
   })
 
   it('applies error state to the inputs and form validation', async () => {

--- a/src/forms/FormControl/FormControl.tsx
+++ b/src/forms/FormControl/FormControl.tsx
@@ -56,14 +56,16 @@ const Root = ({
   validationStatus,
   ...rest
 }: FormControlProps) => {
-  const uniqueId = useId(id)
+  const generatedId = useId(id)
+  const uniqueId = id || generatedId
+
   const isCheckboxControl = React.Children.toArray(children).some(
     child => React.isValidElement(child) && child.type === Checkbox
   )
 
   return (
     <section
-      id={uniqueId}
+      id={`FormControl--${uniqueId}`}
       className={clsx(
         styles.FormControl,
         fullWidth && styles[`FormControl--fullWidth`],
@@ -75,7 +77,7 @@ const Root = ({
     >
       {React.Children.map(children, child => {
         if (child) {
-          const inputId = `FormControl--${uniqueId}`
+          const inputId = `${uniqueId}`
 
           /**
            * TextInput


### PR DESCRIPTION
## Summary

`FormControl` accepts a top-level `id` value, which it propagates down to both the label and inputs. 

Currently, this is prefixed with `FormControl` before being forwarded, which results in the following problems downstream in an application where tests expect the id to be forwarded verbatim.

![unit test in resources hub](https://user-images.githubusercontent.com/13340707/190374681-fd02e62f-ba48-4a48-83a8-d43af6731c5d.png)

This PR prevents the prefixing or `for`, `id` and `name` attributes by forwarding the id verbatim, or if an id isn't passed, it will generate a unique id instead per the existing behavior.

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- removed prefixing from ids
- hoisted prefixing to parent wrapper instead, in case it's still useful
- updated tests to reflect changes

## What should reviewers focus on?

- Check tests pass
- Code review

## Supporting resources (related issues, external links, etc):

- Corresponding [pull request in resources.github.com](https://github.com/github/resources-hub/pull/492), which helped identify this issue.

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![Screenshot 2022-09-15 at 11 01 19](https://user-images.githubusercontent.com/13340707/190376047-15f82ff2-6444-4eae-bbf9-3af1e78b610f.png)


 </td>
<td valign="top">

![Screenshot 2022-09-15 at 10 52 34](https://user-images.githubusercontent.com/13340707/190376081-cc2edb27-d511-48cb-b87f-5448abb148a2.png)


</td>
</tr>
</table>
