### PR TITLE
Add Storybook Storysource addon

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,7 +5,8 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    'storybook-css-modules-preset'
+    'storybook-css-modules-preset',
+    '@storybook/addon-storysource'
   ],
   framework: '@storybook/react',
   core: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@primer/react-brand",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@primer/react-brand",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "clsx": "^1.1.1"
@@ -24,6 +24,7 @@
         "@storybook/addon-essentials": "^6.5.6",
         "@storybook/addon-interactions": "^6.5.12",
         "@storybook/addon-links": "^6.5.6",
+        "@storybook/addon-storysource": "^6.5.12",
         "@storybook/builder-webpack5": "^6.5.6",
         "@storybook/jest": "^0.0.10",
         "@storybook/manager-webpack5": "^6.5.6",
@@ -7258,6 +7259,248 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-6.5.12.tgz",
+      "integrity": "sha512-FpqEbBET2buZ3tzf0I902zokf0zhbeUWmkq8wUxygn4SKhog8yVbvzTIjG7l0kh53t+y/udirzjjAt66LgR2hA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.5.12",
+        "@storybook/api": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/components": "6.5.12",
+        "@storybook/router": "6.5.12",
+        "@storybook/source-loader": "6.5.12",
+        "@storybook/theming": "6.5.12",
+        "core-js": "^3.8.2",
+        "estraverse": "^5.2.0",
+        "loader-utils": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "react-syntax-highlighter": "^15.4.5",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/addons": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.5.12.tgz",
+      "integrity": "sha512-y3cgxZq41YGnuIlBJEuJjSFdMsm8wnvlNOGUP9Q+Er2dgfx8rJz4Q22o4hPjpvpaj4XdBtxCJXI2NeFpN59+Cw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/api": "6.5.12",
+        "@storybook/channels": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/core-events": "6.5.12",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/router": "6.5.12",
+        "@storybook/theming": "6.5.12",
+        "@types/webpack-env": "^1.16.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/api": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.5.12.tgz",
+      "integrity": "sha512-DuUZmMlQxkFNU9Vgkp9aNfCkAongU76VVmygvCuSpMVDI9HQ2lG0ydL+ppL4XKoSMCCoXTY6+rg4hJANnH+1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/core-events": "6.5.12",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/router": "6.5.12",
+        "@storybook/semver": "^7.3.2",
+        "@storybook/theming": "6.5.12",
+        "core-js": "^3.8.2",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7",
+        "store2": "^2.12.0",
+        "telejson": "^6.0.8",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/channels": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.5.12.tgz",
+      "integrity": "sha512-X5XaKbe4b7LXJ4sUakBo00x6pXnW78JkOonHoaKoWsccHLlEzwfBZpVVekhVZnqtCoLT23dB8wjKgA71RYWoiw==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/client-logger": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.5.12.tgz",
+      "integrity": "sha512-IrkMr5KZcudX935/C2balFbxLHhkvQnJ78rbVThHDVckQ7l3oIXTh66IMzldeOabVFDZEMiW8AWuGEYof+JtLw==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "global": "^4.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/components": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.5.12.tgz",
+      "integrity": "sha512-NAAGl5PDXaHdVLd6hA+ttmLwH3zAVGXeUmEubzKZ9bJzb+duhFKxDa9blM4YEkI+palumvgAMm0UgS7ou680Ig==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/theming": "6.5.12",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/core-events": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.12.tgz",
+      "integrity": "sha512-0AMyMM19R/lHsYRfWqM8zZTXthasTAK2ExkSRzYi2GkIaVMxRKtM33YRwxKIpJ6KmIKIs8Ru3QCXu1mfCmGzNg==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/router": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.5.12.tgz",
+      "integrity": "sha512-xHubde9YnBbpkDY5+zGO4Pr6VPxP8H9J2v4OTF3H82uaxCIKR0PKG0utS9pFKIsEiP3aM62Hb9qB8nU+v1nj3w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.12",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/source-loader": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.5.12.tgz",
+      "integrity": "sha512-4iuILFsKNV70sEyjzIkOqgzgQx7CJ8kTEFz590vkmWXQNKz7YQzjgISIwL7GBw/myJgeb04bl5psVgY0cbG5vg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "core-js": "^3.8.2",
+        "estraverse": "^5.2.0",
+        "global": "^4.4.0",
+        "loader-utils": "^2.0.0",
+        "lodash": "^4.17.21",
+        "prettier": ">=2.2.1 <=2.3.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/@storybook/theming": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.12.tgz",
+      "integrity": "sha512-uWOo84qMQ2R6c1C0faZ4Q0nY01uNaX7nXoJKieoiJ6ZqY9PSYxJl1kZLi3uPYnrxLZjzjVyXX8MgdxzbppYItA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.12",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/@storybook/addon-toolbars": {
@@ -44933,6 +45176,168 @@
             "core-js": "^3.8.2",
             "regenerator-runtime": "^0.13.7"
           }
+        }
+      }
+    },
+    "@storybook/addon-storysource": {
+      "version": "6.5.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-6.5.12.tgz",
+      "integrity": "sha512-FpqEbBET2buZ3tzf0I902zokf0zhbeUWmkq8wUxygn4SKhog8yVbvzTIjG7l0kh53t+y/udirzjjAt66LgR2hA==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.5.12",
+        "@storybook/api": "6.5.12",
+        "@storybook/client-logger": "6.5.12",
+        "@storybook/components": "6.5.12",
+        "@storybook/router": "6.5.12",
+        "@storybook/source-loader": "6.5.12",
+        "@storybook/theming": "6.5.12",
+        "core-js": "^3.8.2",
+        "estraverse": "^5.2.0",
+        "loader-utils": "^2.0.0",
+        "prop-types": "^15.7.2",
+        "react-syntax-highlighter": "^15.4.5",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.5.12.tgz",
+          "integrity": "sha512-y3cgxZq41YGnuIlBJEuJjSFdMsm8wnvlNOGUP9Q+Er2dgfx8rJz4Q22o4hPjpvpaj4XdBtxCJXI2NeFpN59+Cw==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.5.12",
+            "@storybook/channels": "6.5.12",
+            "@storybook/client-logger": "6.5.12",
+            "@storybook/core-events": "6.5.12",
+            "@storybook/csf": "0.0.2--canary.4566f4d.1",
+            "@storybook/router": "6.5.12",
+            "@storybook/theming": "6.5.12",
+            "@types/webpack-env": "^1.16.0",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.5.12.tgz",
+          "integrity": "sha512-DuUZmMlQxkFNU9Vgkp9aNfCkAongU76VVmygvCuSpMVDI9HQ2lG0ydL+ppL4XKoSMCCoXTY6+rg4hJANnH+1AQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.5.12",
+            "@storybook/client-logger": "6.5.12",
+            "@storybook/core-events": "6.5.12",
+            "@storybook/csf": "0.0.2--canary.4566f4d.1",
+            "@storybook/router": "6.5.12",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.5.12",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^6.0.8",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.5.12.tgz",
+          "integrity": "sha512-X5XaKbe4b7LXJ4sUakBo00x6pXnW78JkOonHoaKoWsccHLlEzwfBZpVVekhVZnqtCoLT23dB8wjKgA71RYWoiw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.5.12.tgz",
+          "integrity": "sha512-IrkMr5KZcudX935/C2balFbxLHhkvQnJ78rbVThHDVckQ7l3oIXTh66IMzldeOabVFDZEMiW8AWuGEYof+JtLw==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.5.12.tgz",
+          "integrity": "sha512-NAAGl5PDXaHdVLd6hA+ttmLwH3zAVGXeUmEubzKZ9bJzb+duhFKxDa9blM4YEkI+palumvgAMm0UgS7ou680Ig==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "6.5.12",
+            "@storybook/csf": "0.0.2--canary.4566f4d.1",
+            "@storybook/theming": "6.5.12",
+            "core-js": "^3.8.2",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.12.tgz",
+          "integrity": "sha512-0AMyMM19R/lHsYRfWqM8zZTXthasTAK2ExkSRzYi2GkIaVMxRKtM33YRwxKIpJ6KmIKIs8Ru3QCXu1mfCmGzNg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.5.12.tgz",
+          "integrity": "sha512-xHubde9YnBbpkDY5+zGO4Pr6VPxP8H9J2v4OTF3H82uaxCIKR0PKG0utS9pFKIsEiP3aM62Hb9qB8nU+v1nj3w==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "6.5.12",
+            "core-js": "^3.8.2",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/source-loader": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-6.5.12.tgz",
+          "integrity": "sha512-4iuILFsKNV70sEyjzIkOqgzgQx7CJ8kTEFz590vkmWXQNKz7YQzjgISIwL7GBw/myJgeb04bl5psVgY0cbG5vg==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "6.5.12",
+            "@storybook/client-logger": "6.5.12",
+            "@storybook/csf": "0.0.2--canary.4566f4d.1",
+            "core-js": "^3.8.2",
+            "estraverse": "^5.2.0",
+            "global": "^4.4.0",
+            "loader-utils": "^2.0.0",
+            "lodash": "^4.17.21",
+            "prettier": ">=2.2.1 <=2.3.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.5.12",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.12.tgz",
+          "integrity": "sha512-uWOo84qMQ2R6c1C0faZ4Q0nY01uNaX7nXoJKieoiJ6ZqY9PSYxJl1kZLi3uPYnrxLZjzjVyXX8MgdxzbppYItA==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "6.5.12",
+            "core-js": "^3.8.2",
+            "memoizerific": "^1.11.3",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "prettier": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+          "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@storybook/addon-essentials": "^6.5.6",
     "@storybook/addon-interactions": "^6.5.12",
     "@storybook/addon-links": "^6.5.6",
+    "@storybook/addon-storysource": "^6.5.12",
     "@storybook/builder-webpack5": "^6.5.6",
     "@storybook/jest": "^0.0.10",
     "@storybook/manager-webpack5": "^6.5.6",


### PR DESCRIPTION
## Summary

[Storysource](https://storybook.js.org/addons/@storybook/addon-storysource) adds a panel with a code snippet of the story "source" code for easy copy/paste. The source code view depends on the format of the story, and unfortunately isn't compatible with `template.bind()` syntax. However, if we treat "Feature" stories as code snippets and allow the Playground story to use controls, we kind of get the best of both worlds. We might consider investing in our own source code addon that is more consistent.

Closes https://github.com/github/primer/issues/1385

## What should reviewers focus on?

Are we okay with some of the existing stories showing code like this?

<img width="530" alt="image" src="https://user-images.githubusercontent.com/18661030/194588484-afbdd93e-b8a2-4364-99aa-6d5d3868c555.png">


## Steps to test:

- Open the Storybook PR preview deploy
- Navigate to the "Story" tab in the addon panel

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [x] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [x] Check that tests prove the feature works and covers both happy and unhappy paths
- [x] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<img width="508" alt="image" src="https://user-images.githubusercontent.com/18661030/194588546-bf13b324-b4c1-450d-81d0-a8de637ce3b8.png">