### PR TITLE
Added Subtle Variant to Button

### DIFF
--- a/.changeset/cyan-geckos-fly.md
+++ b/.changeset/cyan-geckos-fly.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Added a subtle variant for button component

--- a/packages/react/src/Button/Button.module.css
+++ b/packages/react/src/Button/Button.module.css
@@ -50,6 +50,15 @@
   box-shadow: inset 0 0 0 2px var(--brand-color-neutral-emphasisPlus);
 }
 
+.Button--subtle {
+  color: var(--brand-color-text-default);
+  transition: box-shadow 200ms;
+}
+
+.Button--subtle:hover {
+  box-shadow: inset 0 0 0 2px var(--brand-color-neutral-emphasisPlus);
+}
+
 .Button--size-medium {
   padding: var(--base-size-16) var(--base-size-24);
 }

--- a/packages/react/src/Button/Button.stories.tsx
+++ b/packages/react/src/Button/Button.stories.tsx
@@ -26,6 +26,14 @@ Secondary.args = {
   children: 'Secondary action'
 }
 
+export const Subtle = Template.bind({})
+Subtle.args = {
+  as: 'a',
+  variant: 'subtle',
+  href: '#',
+  children: 'Subtle action'
+}
+
 export const Large = Template.bind({})
 Large.args = {
   as: 'a',

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -8,7 +8,7 @@ import styles from './Button.module.css'
 
 export type ButtonProps<C extends React.ElementType> = BaseProps<C> & {
   as?: C
-  variant?: 'primary' | 'secondary'
+  variant?: 'primary' | 'secondary' | 'subtle'
   size?: 'medium' | 'large'
   hasArrow?: boolean
 } & React.ComponentPropsWithoutRef<C>

--- a/packages/react/src/Button/Button.visual.spec.ts
+++ b/packages/react/src/Button/Button.visual.spec.ts
@@ -19,6 +19,12 @@ test.describe('Visual Comparison: Button', () => {
     expect(await page.screenshot()).toMatchSnapshot()
   })
 
+  test('Button / Subtle', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-button--subtle&viewMode=story')
+
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Button / Large', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-button--large&viewMode=story')
 


### PR DESCRIPTION
## Summary

Adding a subtle variant to the Button component.

## List of notable changes:

- **added** subtle variant for button component because it will be used on future marketing pages.

## What should reviewers focus on?

- Review that the variant can be applied correctly and that other variants are not affected.

## Steps to test:

1. Go to Button story in Storybook
3. Verify that subtle variant behaves as described in the following issue.

## Supporting resources (related issues, external links, etc):

- https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=373%3A8028
- https://github.com/github/primer/issues/1417

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://user-images.githubusercontent.com/31220082/196480560-23a9e672-eb33-4c13-b9bd-7febfe5dfb27.png)

 </td>
<td valign="top">

![image](https://user-images.githubusercontent.com/31220082/196480282-16524e55-1a4c-4ef0-8422-54562fca2193.png)

</td>
</tr>
</table>
