### PR TITLE
Hotfix and root cause analysis (RCA): Failing integration tests

### DIFF
--- a/.github/workflows/integration_test_astro.yml
+++ b/.github/workflows/integration_test_astro.yml
@@ -67,7 +67,7 @@ jobs:
         run: cd packages/react/ && npm pack
 
       - name: Configuring Astro React / TypeScript project
-        run: npm create astro@latest ${{env.ASTRO_FOLDER}} -- --template framework-react
+        run: yes | npm create astro@latest ${{env.ASTRO_FOLDER}} -- --template framework-react
 
       - name: Retrieving package version
         id: package-version

--- a/.github/workflows/integration_test_astro.yml
+++ b/.github/workflows/integration_test_astro.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *' # end of each day (UTC)
   pull_request:
 
 env:

--- a/.github/workflows/integration_test_astro.yml
+++ b/.github/workflows/integration_test_astro.yml
@@ -67,7 +67,9 @@ jobs:
         run: cd packages/react/ && npm pack
 
       - name: Configuring Astro React / TypeScript project
-        run: yes | npm create astro@latest ${{env.ASTRO_FOLDER}} -- --template framework-react
+        # lock version to 1.1.0 due to non-tty support removed in 1.2.0
+        # TODO: review Astro updates regularly to using @latest
+        run: npm create astro@1.1.0 ${{env.ASTRO_FOLDER}} -- --template framework-react
 
       - name: Retrieving package version
         id: package-version

--- a/.github/workflows/integration_test_cra.yml
+++ b/.github/workflows/integration_test_cra.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *' # end of each day (UTC)
   pull_request:
 
 env:

--- a/.github/workflows/integration_test_nextjs.yml
+++ b/.github/workflows/integration_test_nextjs.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Installing local build
         run: |
-          cd ${{env.NEXTJS_FOLDER}} 
+          cd ${{env.NEXTJS_FOLDER}}
           cp ../packages/react/primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz ./
           npm install primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz
 
@@ -89,6 +89,7 @@ jobs:
       - name: Copying required files
         run: |
           cp ./packages/e2e/integration-tests/nextjs/index.tsx ./${{env.NEXTJS_FOLDER}}/pages
+          cp ./packages/e2e/integration-tests/nextjs/.eslintrc ./${{env.NEXTJS_FOLDER}}
           cp ./packages/e2e/cypress.config.js ./${{env.NEXTJS_FOLDER}}
           mkdir ${{env.NEXTJS_FOLDER}}/integration-tests
           cp -r ./packages/e2e/integration-tests/fixtures ./${{env.NEXTJS_FOLDER}}/integration-tests
@@ -104,6 +105,10 @@ jobs:
 
       - name: Excluded cypress tests in-place
         run: npx json -I -f ${{env.NEXTJS_FOLDER}}/tsconfig.json -e 'this.exclude=["node_modules", "**/*.cy.ts"]'
+
+      - name: Fix monorepo-related linting issues
+        run: |
+          npm run lint -- --fix
 
       - name: Testing compile-time build
         run: cd ${{env.NEXTJS_FOLDER}} && npm run build

--- a/.github/workflows/integration_test_nextjs.yml
+++ b/.github/workflows/integration_test_nextjs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *' # end of each day (UTC)
   pull_request:
 
 env:

--- a/.github/workflows/integration_test_remix.yml
+++ b/.github/workflows/integration_test_remix.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *' # end of each day (UTC)
   pull_request:
 
 env:

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-canary:
-    if: ${{ github.repository == 'primer/brand' }}
+    if: false
     name: Canary
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-canary:
-    if: false
+    if: ${{ github.repository == 'primer/brand' }}
     name: Canary
     runs-on: ubuntu-latest
     steps:

--- a/packages/e2e/integration-tests/nextjs/.eslintrc
+++ b/packages/e2e/integration-tests/nextjs/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "extends": "next",
+  "rules": {
+    "eslint-comments/no-unlimited-disable": "off",
+    "eslint-comments/no-use": "off",
+    "react/react-in-jsx-scope": "off"
+  }
+}


### PR DESCRIPTION
## Description
End-to-end integration tests for Astro and Next.js were - rather coincidentally - failing at the same time.

This was first detected in PR's, but hasn't impacted main branch yet as it hasn't run the integration tests since its last push.

**This PR fixes the issue and serves as an RCA for what occurred, and how the problem was remediated.**

## Timeline*

<table>
<tr>
<th>Date</th>
<th> Event </th>
</tr>
<tr>
<td>26 Oct 2022</td>
<td>Last commit to `main` branch</td>
</tr>
<tr>
<td>27 Oct 2022</td>
<td> Astro release v1.2.0, which includes a breaking change for non-tty users of its CLI package (create astro)</td>
</tr>
<tr>
<td>1 Nov 2022 (~1pm GMT)</td>
<td>Integration test for Astro first observed to fail in a newly created pull request</td>
</tr>
<tr>
<td>1 Nov 2022  (~3pm GMT)</td>
<td> Next.js release `v13.0.1` which includes new pre-build linting</td>
</tr>
<tr>
<td>1 Nov 2022  (~5pm GMT)</td>
<td>Integration tests for Next.js first observed to fail in a newly created _and_ existing pull requests</td>
</tr>
<tr>
<td>2 Nov 2022</td>
<td>Remediation PR raised</td>
</tr>
</table>

* using approximate times


## Contributing Factors (Root Causes, Triggers)

- Astro CLI stopped accepting non-tty standard input in its create astro CLI tooling, which Primer Brand relied on for test environment scaffolding. ([Issue](https://github.com/withastro/astro/issues/5227))
- Next.js added `next lint` as a prebuild step in `v13.0.1`. This caused linting issues to fail the Next.js integration test
- `main` branch didn't fail and notify maintainers because it hadn't run since the above packages were last updated.

## Stabilization Steps

- Manually debug steps to reproduce errors and remediate
- Merge PR that verified fixes work, and push to `main`.

## Lessons Learned
- We needed `main` branch to notice these errors sooner. There was a gap of >4 days between release of the breaking change in Astro and when we first observed the failing build.
- Our integration tests are great at catching build-time and runtime issues
- We should expect UI frameworks to occasionally issue unintentional breaking changes as patch updates

## Corrective Actions in this PR
- This PR adds a daily cron schedule to all integration tests on the `main` branch.
- Fix Astro by pegging release to v1.1, which still accepts non-tty stdin
- Fix Next.js by a) prelinting and b) ignoring fixture related warnings

## Next steps
- Automatically create issues that notify maintainers on failing tests on `main` branch.