### PR TITLE
Fix href prop of `<SubdomainNavBar.SecondaryAction />`

### DIFF
--- a/.changeset/healthy-dingos-look.md
+++ b/.changeset/healthy-dingos-look.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fix href prop of `<SubdomainNavBar.SecondaryAction />`

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -377,7 +377,7 @@ function SecondaryAction({children, href, ...rest}: PropsWithChildren<CTAActionP
   return (
     <Button
       as="a"
-      href="#"
+      href={href}
       className={clsx(styles['SubdomainNavBar-cta-button'], styles['SubdomainNavBar-cta-button--secondary'])}
       hasArrow={false}
       {...rest}


### PR DESCRIPTION
## Summary

Fix href prop of `<SubdomainNavBar.SecondaryAction />`.

## List of notable changes

_None._

## What should reviewers focus on?

This is a bug fix.

## Steps to test

## Supporting resources

_None._

## Contributor checklist

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots

_None._