### PR TITLE
Fixing integration tests

### DIFF
--- a/.github/workflows/integration_test_astro.yml
+++ b/.github/workflows/integration_test_astro.yml
@@ -54,7 +54,7 @@ jobs:
           CI: 1
         # print Cypress and OS info
         run: |
-          cypress install
+          DEBUG="cypress:*" npx cypress install --force
           DEBUG="cypress:*" npx cypress verify
           DEBUG="cypress:*" npx cypress info
           DEBUG="cypress:*" npx cypress version

--- a/.github/workflows/integration_test_astro.yml
+++ b/.github/workflows/integration_test_astro.yml
@@ -54,6 +54,7 @@ jobs:
           CI: 1
         # print Cypress and OS info
         run: |
+          cypress install
           DEBUG="cypress:*" npx cypress verify
           DEBUG="cypress:*" npx cypress info
           DEBUG="cypress:*" npx cypress version

--- a/.github/workflows/integration_test_astro.yml
+++ b/.github/workflows/integration_test_astro.yml
@@ -54,13 +54,13 @@ jobs:
           CI: 1
         # print Cypress and OS info
         run: |
-          npx cypress verify
-          npx cypress info
-          npx cypress version
-          npx cypress version --component package
-          npx cypress version --component binary
-          npx cypress version --component electron
-          npx cypress version --component node
+          DEBUG="cypress:*" npx cypress verify
+          DEBUG="cypress:*" npx cypress info
+          DEBUG="cypress:*" npx cypress version
+          DEBUG="cypress:*" npx cypress version --component package
+          DEBUG="cypress:*" npx cypress version --component binary
+          DEBUG="cypress:*" npx cypress version --component electron
+          DEBUG="cypress:*" npx cypress version --component node
 
       - name: Build
         run: npm run build:lib

--- a/.github/workflows/integration_test_astro.yml
+++ b/.github/workflows/integration_test_astro.yml
@@ -54,14 +54,14 @@ jobs:
           CI: 1
         # print Cypress and OS info
         run: |
-          DEBUG="cypress:*" npx cypress install --force
-          DEBUG="cypress:*" npx cypress verify
-          DEBUG="cypress:*" npx cypress info
-          DEBUG="cypress:*" npx cypress version
-          DEBUG="cypress:*" npx cypress version --component package
-          DEBUG="cypress:*" npx cypress version --component binary
-          DEBUG="cypress:*" npx cypress version --component electron
-          DEBUG="cypress:*" npx cypress version --component node
+          npx cypress install --force
+          npx cypress verify
+          npx cypress info
+          npx cypress version
+          npx cypress version --component package
+          npx cypress version --component binary
+          npx cypress version --component electron
+          npx cypress version --component node
 
       - name: Build
         run: npm run build:lib

--- a/.github/workflows/integration_test_cra.yml
+++ b/.github/workflows/integration_test_cra.yml
@@ -54,6 +54,7 @@ jobs:
           CI: 1
         # print Cypress and OS info
         run: |
+          npx cypress install --force
           npx cypress verify
           npx cypress info
           npx cypress version

--- a/.github/workflows/integration_test_nextjs.yml
+++ b/.github/workflows/integration_test_nextjs.yml
@@ -54,6 +54,7 @@ jobs:
           CI: 1
         # print Cypress and OS info
         run: |
+          npx cypress install --force
           npx cypress verify
           npx cypress info
           npx cypress version

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-canary:
-    if: ${{ github.repository == 'primer/brand' }}
+    if: false
     name: Canary
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release_canary.yml
+++ b/.github/workflows/release_canary.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-canary:
-    if: false
+    if: ${{ github.repository == 'primer/brand' }}
     name: Canary
     runs-on: ubuntu-latest
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
     },
     "apps/storybook": {
       "name": "@primer/brand-storybook",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@storybook/addon-a11y": "^6.5.12",
@@ -36290,7 +36290,7 @@
     },
     "packages/design-tokens": {
       "name": "@primer/brand-primitives",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@primer/primitives": "^7.9.0",
@@ -36304,7 +36304,7 @@
     },
     "packages/e2e": {
       "name": "@primer/brand-e2e",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.24.0"
@@ -36316,7 +36316,7 @@
     },
     "packages/fonts": {
       "name": "@primer/brand-fonts",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -36325,7 +36325,7 @@
     },
     "packages/react": {
       "name": "@primer/react-brand",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "clsx": "^1.1.1"
@@ -36389,7 +36389,7 @@
     },
     "packages/repo-configs": {
       "name": "@primer/brand-config",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT"
     }
   },


### PR DESCRIPTION
Fixes failing integration tests, which were due to missing cached binaries for cypress. Fixed by manually reinstalling them.
