### PR TITLE
Button Focus Transition Fix

### DIFF
--- a/.changeset/red-fans-reflect.md
+++ b/.changeset/red-fans-reflect.md
@@ -1,0 +1,37 @@
+---
+'@primer/react-brand': patch
+---
+
+Applies a transition: none rule to `:focus` on the `<Button>` component. Ensures that the existing box-shadow on :hover does not interfere with the the :focus box-shadow.
+
+<table>
+<caption>Before/After</caption>
+<tr>
+<th> Version 0.12.0 </th> <th> Version 0.12.1 (current)</th> <th> PR version </th> 
+</tr>
+<tr>
+<td valign="top">
+
+https://user-images.githubusercontent.com/26746305/219712759-d814db66-dae2-4b74-9a48-c411cb7705c3.mov
+
+Video shows the cursor moving over the button. When pressed and hovered off of, the `box-shadow` border appears on the button in a bottom-to-top transition animation.
+
+Video also shows cursor hovering over button when focused, removing the `box-shadow` border before displaying it back when hovered off of.
+
+</td>
+<td valign="top">
+
+https://user-images.githubusercontent.com/26746305/219712378-7d0f0cb7-2068-463b-a3da-548729c8f6e0.mov
+
+Video shows cursor moving over the button. When pressed the `box-shadow` border appears over the button instantly, showing the same bottom-to-top transition effect as the previous cell example.
+
+ </td>
+<td valign="top">
+
+https://user-images.githubusercontent.com/26746305/219712490-347af6ce-6900-496d-a6cb-bc2c0c27b453.mov
+
+Video shows cursor moving over the button and then pressing the button. The `box-shadow` border displays over the button instantly, showing no transition animation.
+
+</td>
+</tr>
+</table>

--- a/packages/react/src/Button/Button.module.css
+++ b/packages/react/src/Button/Button.module.css
@@ -16,6 +16,7 @@
 .Button:focus:not(.Button--disabled[disabled]) {
   outline: none;
   box-shadow: 0 0 0 2px var(--brand-color-canvas-default), 0 0 0 5px var(--brand-color-focus);
+  transition: none;
 }
 
 .Button--label {


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->
Fixes #188.

Applies a `transition: none` rule to `:focus` on the `<Button>` component. This is to ensure that the existing `box-shadow` on `:hover` does not interfere with the the `:focus` `box-shadow`.

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Adds `transition: none` to `.Button:focus`.

## What should reviewers focus on?

- The differences between `<Button>` focus indication on current version, and the changes within this PR.

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Open up the preview environment for this PR, and proceed to the [docs for `CTABanner`. ](https://primer-0a3811813b-26139705.drafts.github.io/components/CTABanner)
2. Open up the current version of Primer Brand docs and proceed to the [docs for `CTABanner` on our current release build](https://primer.style/brand/components/CTABanner).
3. Go to any example with `<Button>` present, and ensure that component is in "dark" themed mode.
4. Observe the differences between versions when you press & hold the `Button`.

## Supporting resources (related issues, external links, etc):

- [Preview environment for PR](https://primer-0a3811813b-26139705.drafts.github.io/) 
- [Preview Storybook environment](https://primer-0a3811813b-26139705.drafts.github.io/storybook/)

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Version 0.12.0 </th> <th> Version 0.12.1 (current)</th> <th> PR version </th> 
</tr>
<tr>
<td valign="top">

https://user-images.githubusercontent.com/26746305/219712759-d814db66-dae2-4b74-9a48-c411cb7705c3.mov

Video shows the cursor moving over the button. When pressed and hovered off of, the `box-shadow` border appears on the button in a bottom-to-top transition animation. 

Video also shows cursor hovering over button when focused, removing the `box-shadow` border before displaying it back when hovered off of.
</td>
<td valign="top">

https://user-images.githubusercontent.com/26746305/219712378-7d0f0cb7-2068-463b-a3da-548729c8f6e0.mov

Video shows cursor moving over the button. When pressed the `box-shadow` border appears over the button instantly, showing the same bottom-to-top transition effect as the previous cell example.
 </td>
<td valign="top">

https://user-images.githubusercontent.com/26746305/219712490-347af6ce-6900-496d-a6cb-bc2c0c27b453.mov

Video shows cursor moving over the button and then pressing the button. The `box-shadow` border displays over the button instantly, showing no transition animation. 
</td>
</tr>
</table>



