### PR TITLE
Make `FAQ.Question` and `FAQ.Subheading` adjustable

### DIFF
--- a/apps/docs/content/components/FAQ.mdx
+++ b/apps/docs/content/components/FAQ.mdx
@@ -398,12 +398,13 @@ render(<App />)
 
 <h3 id="faq-subheading">FAQ.Subheading</h3>
 
-| Name        | Type              | Default | Description                              |
-| :---------- | :---------------- | :-----: | :--------------------------------------- |
-| `children`  | `string`          |         | Sub-heading text                         |
-| `className` | `string`          |         | Sub-heading custom class                 |
-| `id`        | `string`          |         | Sets a custom id                         |
-| `ref`       | `React.RefObject` |         | Forward a Ref to the underlying DOM node |
+| Name        | Type                                                            | Default | Description                              |
+| :---------- | :-------------------------------------------------------------- | :-----: | :--------------------------------------- |
+| `children`  | `string`                                                        |         | Sub-heading text                         |
+| `className` | `string`                                                        |         | Sub-heading custom class                 |
+| `id`        | `string`                                                        |         | Sets a custom id                         |
+| `as`        | <PropTableValues values={HeadingTags.slice(1)} addLineBreaks /> | `'h3'`  | Applies the underlying HTML element      |
+| `ref`       | `React.RefObject`                                               |         | Forward a Ref to the underlying DOM node |
 
 <h3 id="faq-item">FAQ.Item</h3>
 
@@ -417,12 +418,13 @@ render(<App />)
 
 <h3 id="faq-question">FAQ.Question</h3>
 
-| Name        | Type              | Default | Description                              |
-| :---------- | :---------------- | :-----: | :--------------------------------------- |
-| `className` | `string`          |         | Sets a custom class on the root element  |
-| `children`  | `string`          |         | Question text                            |
-| `id`        | `string`          |         | Sets a custom id                         |
-| `ref`       | `React.RefObject` |         | Forward a Ref to the underlying DOM node |
+| Name        | Type                                                            | Default | Description                              |
+| :---------- | :-------------------------------------------------------------- | :-----: | :--------------------------------------- |
+| `className` | `string`                                                        |         | Sets a custom class on the root element  |
+| `children`  | `string`                                                        |         | Question text                            |
+| `id`        | `string`                                                        |         | Sets a custom id                         |
+| `as`        | <PropTableValues values={HeadingTags.slice(1)} addLineBreaks /> | `'h4'`  | Applies the underlying HTML element      |
+| `ref`       | `React.RefObject`                                               |         | Forward a Ref to the underlying DOM node |
 
 <h3 id="faq-answer">FAQ.Answer</h3>
 

--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -53,13 +53,14 @@ export const AccordionRoot = forwardRef<HTMLDetailsElement, AccordionRootProps>(
 type AccordionHeadingProps = BaseProps<HTMLHeadingElement> & {
   className?: string
   children: string
+  as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 }
 
 export const AccordionHeading = forwardRef<HTMLHeadingElement, AccordionHeadingProps>(
-  ({children, className, ...rest}, ref) => {
+  ({children, className, as = 'h4', ...rest}, ref) => {
     return (
       <summary className={clsx(styles.Accordion__summary, className)} ref={ref} {...rest}>
-        <Heading as="h4" className={styles['Accordion__summary-heading']}>
+        <Heading as={as} className={styles['Accordion__summary-heading']}>
           {children}
         </Heading>
       </summary>

--- a/packages/react/src/FAQ/FAQ.tsx
+++ b/packages/react/src/FAQ/FAQ.tsx
@@ -85,12 +85,13 @@ const FAQHeading = forwardRef<HTMLHeadingElement, FAQHeadingProps>(
 
 type FAQSubheadingProps = BaseProps<HTMLHeadingElement> & {
   align?: 'start' | 'center'
+  as?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   children: string
 }
 
-function FAQSubheading({children, className, ...rest}: FAQSubheadingProps) {
+function FAQSubheading({children, className, as = 'h3', ...rest}: FAQSubheadingProps) {
   return (
-    <Heading as="h3" className={clsx(styles.FAQ__subheading, className)} {...rest}>
+    <Heading as={as} className={clsx(styles.FAQ__subheading, className)} {...rest}>
       {children}
     </Heading>
   )


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->
Allows `FAQ.Subheading` and `FAQ.Question` to be adjusted.

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Allows usage of `as` with `FAQ.Subheading` and `FAQ.Question` (restricted to heading levels: `h2 | h3 | h4 | h5 | h6`)

<!-- ## What should reviewers focus on?

-
-
-->

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Ensure that `FAQ.Subheading` & `FAQ.Question` can be adjusted through `as`, and that it's restricted to headings.

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/primer/brand/issues/191.

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

<!-- ## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

 </td>
<td valign="top">

</td>
</tr>
</table>
-->