### PR TITLE
Fix className forwarding in SubdomainNavBar and Avatar forwardRef error

### DIFF
--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.test.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.test.tsx
@@ -121,4 +121,13 @@ describe('SubdomainNavBar', () => {
 
     expect(menuButtonEl).toBe(null)
   })
+
+  it('can append a classname to the root element', () => {
+    const mockClass = 'custom-class'
+    const {getByTestId} = render(<SubdomainNavBar title="Subdomain" className={mockClass} />)
+
+    const headerEl = getByTestId(SubdomainNavBar.testIds.root)
+
+    expect(headerEl.classList).toContain(mockClass)
+  })
 })

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -64,6 +64,7 @@ const testIds = {
 
 function Root({
   children,
+  className,
   fixed = true,
   fullWidth = false,
   logoHref = 'https://github.com',
@@ -94,7 +95,7 @@ function Root({
         fixed && styles['SubdomainNavBar-outer-container--fixed']
       )}
     >
-      <header className={styles['SubdomainNavBar']} {...rest}>
+      <header className={clsx(styles['SubdomainNavBar'], className)} data-testid={testIds.root} {...rest}>
         <div
           className={clsx(
             styles['SubdomainNavBar-inner-container'],

--- a/packages/react/src/Testimonial/Testimonial.tsx
+++ b/packages/react/src/Testimonial/Testimonial.tsx
@@ -154,7 +154,7 @@ function _Avatar({size, ...rest}: AvatarProps) {
   return <BaseAvatar size={48} {...rest} />
 }
 
-const Avatar = forwardRef(_Avatar)
+const Avatar = _Avatar
 
 /**
  * Use Testimonial to display a quote from a customer or user.


### PR DESCRIPTION
## Summary

Fixes two issues

1. Allows forwarding a custom class to the root element of the SubdomainNavBar. This is required for app-level customisation and is currently replacing the internal styling completely, which is a bug.
2. Fixed Avatar console warnings around forwardRef, which are appearing in tests and also in the console of apps that use Primer Brand

  ![Screenshot 2023-03-02 at 12 01 27](https://user-images.githubusercontent.com/13340707/222425148-963ce44d-f233-41d5-9a4d-045f224b4ca6.png)

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:
