### PR TITLE
Fix box-shadow transition bug

### DIFF
--- a/packages/react/src/Button/Button.module.css
+++ b/packages/react/src/Button/Button.module.css
@@ -74,7 +74,7 @@
   background: var(--brand-Button-background-overlay);
 }
 
-.Button--primary:not(.Button--disabled):hover {
+.Button--primary:not(.Button--disabled[disabled]):hover {
   box-shadow: var(--brand-Button-shadow-primary-hover);
 }
 


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

Fixes #206.

Adds `[disabled]` to `:hover` style to ensure it retains priority over `:focus` box-shadow rule. This also fixes the issue where the `:focus` box-shadow transitions into the `:hover` box-shadow, causing the effect in #206.

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Adds `[disabled]` rule to `:hover` style.

## What should reviewers focus on?

- Ensure that `:focus` box-shadow doesn't overrule `:hover` box-shadow.

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. [ To Add ]

<!-- ## Supporting resources (related issues, external links, etc):

-
-

--> 
## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

https://user-images.githubusercontent.com/26746305/224808953-f850cbf8-d73e-4f1b-b075-4f3ef89bc5e1.mov

Video of cursor clicking Brand Primary `<Button>` which shows the initial `:focus` box-shadow style being applied as the outline for the button. Clicking it triggers a form error which moves focus away from the button, causing the `:focus` box-shadow style to transition to the `:hover` box-shadow style.

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

https://user-images.githubusercontent.com/26746305/224812759-116f45c1-7ce7-4d69-8a5e-a10aff1540f2.mov

Video of cursor clicking Brand Primary `<Button>` which shows the `:hover` box-shadow style initially. Clicking it triggers a form error which causes focus to move away from the button. No longer transitions from `:focus` style to `:hover` style, as it now retains the `:hover` styles. 
</td>
</tr>
</table>
