### PR TITLE
Fix Avatar type definitions

### DIFF
--- a/.changeset/serious-crews-arrive-primitives.md
+++ b/.changeset/serious-crews-arrive-primitives.md
@@ -1,0 +1,13 @@
+---
+'@primer/brand-primitives': minor
+---
+
+New `ActionMenu` component-specific tokens have been added to the `@primer/brand-primitives` package.
+
+```css
+  --brand-ActionMenu-color-border-rest
+  --brand-ActionMenu-color-border-hover
+  --brand-ActionMenu-color-border-active
+  --brand-ActionMenu-color-item-hover
+  --brand-ActionMenu-color-scrollbar-thumb-bg
+```

--- a/.changeset/serious-crews-arrive.md
+++ b/.changeset/serious-crews-arrive.md
@@ -1,7 +1,8 @@
 ---
-'@primer/brand-primitives': minor
 '@primer/react-brand': minor
 ---
+
+### React
 
 Added new ActionMenu component
 

--- a/.changeset/yellow-clocks-join.md
+++ b/.changeset/yellow-clocks-join.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-`Avatar` now correctly forwards native `img` attributes through the Avatar component. This includes `loading`, `decoding`, and `crossOrigin` attributes.
+`Avatar` now correctly forwards native `img` attributes. This includes `loading`, `decoding`, and `crossOrigin` attributes.

--- a/.changeset/yellow-clocks-join.md
+++ b/.changeset/yellow-clocks-join.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+`Avatar` now correctly forwards native `img` attributes through the Avatar component. This includes `loading`, `decoding`, and `crossOrigin` attributes.

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -21,7 +21,7 @@ export type AvatarProps = BaseProps<HTMLImageElement> & {
   src: string
   alt: string
   ['data-testid']?: string
-} & React.HTMLAttributes<HTMLImageElement>
+} & React.ImgHTMLAttributes<HTMLImageElement>
 
 const testIds = {
   root: 'Avatar',


### PR DESCRIPTION
## Summary

Fixes Avatar type definitions by correctly forwarding native `img` attributes.

Also split out the changeset for ActionMenu, so that the correct information goes into appropriate changelogs

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![Screenshot 2023-03-20 at 09 44 25](https://user-images.githubusercontent.com/13340707/226308596-bfd967a3-2d2d-4d6b-8a92-2a0faaec3087.png)


 </td>
<td valign="top">

![Screenshot 2023-03-20 at 09 44 11](https://user-images.githubusercontent.com/13340707/226308615-4b1286a2-2bb4-4612-a0b5-dfc2008b3088.png)

</td>
</tr>
</table>
