### PR TITLE
`SubdomainNavBar` a11y fixes

### DIFF
--- a/.changeset/brown-zebras-smash.md
+++ b/.changeset/brown-zebras-smash.md
@@ -1,0 +1,9 @@
+---
+'@primer/react-brand': patch
+---
+
+Introduces accessibility fixes for `SubdomainNavBar`
+
+- Improves `ARIA` usage across the component
+- Adjusts some landmarks to reduce verbosity
+- Fixes some `aria-expanded` states

--- a/packages/react/src/SubdomainNavBar/NavigationVisbilityObserver.tsx
+++ b/packages/react/src/SubdomainNavBar/NavigationVisbilityObserver.tsx
@@ -71,7 +71,6 @@ function AnchoredOverlay({children, className, visibilityMap}: React.PropsWithCh
     <li className={clsx(styles['SubdomainNavBar-primary-nav-list-item--overflow'], className)} ref={ref}>
       <button
         aria-expanded={open ? 'true' : 'false'}
-        aria-label="more"
         aria-controls="more-navigation"
         aria-haspopup="true"
         onClick={handleClick}

--- a/packages/react/src/SubdomainNavBar/NavigationVisbilityObserver.tsx
+++ b/packages/react/src/SubdomainNavBar/NavigationVisbilityObserver.tsx
@@ -80,7 +80,7 @@ function AnchoredOverlay({children, className, visibilityMap}: React.PropsWithCh
         <ChevronDownIcon />
       </button>
 
-      <nav
+      <div
         id="more-navigation"
         style={{display: open ? 'block' : 'none'}}
         className={clsx(styles['SubdomainNavBar-overflow-menu'])}
@@ -104,7 +104,7 @@ function AnchoredOverlay({children, className, visibilityMap}: React.PropsWithCh
             return null
           })}
         </ul>
-      </nav>
+      </div>
     </li>
   )
 }

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
@@ -593,7 +593,15 @@
     var(--brand-SubdomainNavBar-search-results-border-default, #b7bfc7);
 }
 
-.SubdomainNavBar-search-result-item-heading a {
+.SubdomainNavBar-search-result-item-container {
+  font-weight: var(--brand-heading-weight-400);
+  line-height: var(--brand-text-lineHeight-400);
+  font-family: var(--brand-heading-fontFamily);
+  letter-spacing: var(--brand-heading-letterSpacing-400);
+  font-size: var(--brand-text-size-400);
+}
+
+.SubdomainNavBar-search-result-item-container a {
   display: block;
   color: var(--base-color-scale-black-0);
   text-decoration: none;

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
@@ -594,9 +594,6 @@
 }
 
 .SubdomainNavBar-search-result-item-container {
-  font-weight: var(--brand-heading-weight-400);
-  line-height: var(--brand-text-lineHeight-400);
-  font-family: var(--brand-heading-fontFamily);
   letter-spacing: var(--brand-heading-letterSpacing-400);
   font-size: var(--brand-text-size-400);
 }
@@ -607,6 +604,9 @@
   text-decoration: none;
   margin: 0 0 var(--base-size-12);
   font-size: var(--base-size-16);
+  font-weight: var(--brand-heading-weight-400);
+  font-family: var(--brand-heading-fontFamily);
+  line-height: var(--brand-text-lineHeight-400);
 }
 
 .SubdomainNavBar-search-result-item-desc {

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css.d.ts
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css.d.ts
@@ -46,7 +46,7 @@ declare const styles: {
   readonly "SubdomainNavBar-search-results": string;
   readonly "SubdomainNavBar-search-results-heading": string;
   readonly "SubdomainNavBar-search-result-item": string;
-  readonly "SubdomainNavBar-search-result-item-heading": string;
+  readonly "SubdomainNavBar-search-result-item-container": string;
   readonly "SubdomainNavBar-search-result-item-desc": string;
 };
 export = styles;

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.stories.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.stories.tsx
@@ -524,7 +524,7 @@ export const OverflowMenuOpen = Template.bind({})
 OverflowMenuOpen.play = async ({canvasElement}) => {
   const canvas = within(canvasElement)
   await waitFor(async () => {
-    const overflowMenu = await canvas.getByLabelText('more')
+    const overflowMenu = await canvas.getByText('More')
     await userEvent.click(overflowMenu)
   })
 }

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.test.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.test.tsx
@@ -52,7 +52,6 @@ describe('SubdomainNavBar', () => {
 
     expect(getByRole('banner')).toBeInTheDocument() // <header>
     expect(getAllByRole('navigation').length > 0).toBeTruthy() // <nav>
-    expect(getByRole('search')).toBeInTheDocument() // role="search"
   })
 
   it('has no a11y violations by default', async () => {
@@ -73,14 +72,16 @@ describe('SubdomainNavBar', () => {
       }
     ]
 
-    const {getByTestId, getByLabelText} = render(<Component searchResults={mockResultsData} />)
+    const {getByTestId, getByRole} = render(<Component searchResults={mockResultsData} />)
     const searchTrigger = getByTestId('toggle-search')
 
     fireEvent.click(searchTrigger)
 
-    const searchResultsDialog = getByLabelText('search menu dialog')
+    const searchResultsDialog = getByRole('dialog')
+    const searchResultsLandmark = getByRole('search')
 
     expect(searchResultsDialog).toBeInTheDocument()
+    expect(searchResultsLandmark).toBeInTheDocument()
   })
 
   it('applies "/" as the default title href', async () => {

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -341,9 +341,9 @@ const _SearchInternal = (
                       id={`subdomainnavbar-search-result-${index}`}
                       className={styles['SubdomainNavBar-search-result-item']}
                     >
-                      <Heading as="h6" className={styles['SubdomainNavBar-search-result-item-heading']}>
+                      <div className={styles['SubdomainNavBar-search-result-item-container']}>
                         <a href={result.url}>{result.title}</a>
-                      </Heading>
+                      </div>
 
                       <Text as="p" size="200" className={styles['SubdomainNavBar-search-result-item-desc']}>
                         {result.description}

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -2,7 +2,7 @@ import React, {useState, useRef, PropsWithChildren, forwardRef, useMemo} from 'r
 import clsx from 'clsx'
 import {ChevronLeftIcon, MarkGithubIcon, SearchIcon, XIcon} from '@primer/octicons-react'
 
-import {Button, FormControl, Heading, Text, TextInput} from '..'
+import {Button, FormControl, Text, TextInput} from '..'
 import {NavigationVisbilityObserver} from './NavigationVisbilityObserver'
 import {useOnClickOutside} from '../hooks/useOnClickOutside'
 

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -173,7 +173,7 @@ function Root({
 
             {hasLinks && (
               <button
-                aria-expanded="true"
+                aria-expanded={!menuHidden}
                 aria-label="Menu"
                 aria-controls="menu-navigation"
                 aria-haspopup="true"
@@ -300,7 +300,7 @@ const _SearchInternal = (
                   autoFocus
                   name="search"
                   role="combobox"
-                  aria-expanded="true"
+                  aria-expanded={!!searchResults && searchResults.length > 0}
                   aria-controls="listbox-search-results"
                   placeholder={`Search ${title}`}
                   onChange={onChange}

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -270,7 +270,7 @@ const _SearchInternal = (
 
   return (
     <>
-      <div role="search" className={clsx(styles['SubdomainNavBar-search-trigger'])} aria-label="open search">
+      <div className={clsx(styles['SubdomainNavBar-search-trigger'])}>
         <button
           aria-label="search"
           className={styles['SubdomainNavBar-search-button']}
@@ -284,13 +284,12 @@ const _SearchInternal = (
         <div
           ref={dialogRef}
           role="dialog"
-          aria-label="search menu dialog"
-          title={`Search ${title}`}
+          aria-label={`Search ${title}`}
           aria-modal="true"
           className={clsx(styles['SubdomainNavBar-search-dialog'])}
         >
           <div className={clsx(styles['SubdomainNavBar-search-dialog-control-area'])}>
-            <form className={clsx(styles['SubdomainNavBar-search-form'])} onSubmit={onSubmit}>
+            <form className={clsx(styles['SubdomainNavBar-search-form'])} onSubmit={onSubmit} role="search">
               <FormControl fullWidth size="large">
                 <FormControl.Label visuallyHidden>Search</FormControl.Label>
                 <TextInput
@@ -331,7 +330,6 @@ const _SearchInternal = (
                 </Text>
                 <ul
                   role="listbox"
-                  aria-label="search results"
                   aria-labelledby="subdomainnavbar-search-results-heading"
                   aria-activedescendant="subdomainnavbar-search-result-1"
                   className={clsx(styles['SubdomainNavBar-search-results'])}


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

Addresses some accessibility issues found in the [a11y eng review of `SubdomainNavBar`](https://github.com/github/primer/issues/1668).

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Removes unneeded `ARIA` usage
- Adjusts some landmarks to reduce verbosity
- Fixes some `aria-expanded` states

## What should reviewers focus on?

This PR should not introduce any style changes. if using a screen reader, test to ensure that states are properly announced (i.e. "more" disclosure, mobile "menu", `combobox`).

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Go to the component in Storybook
2. Ensure that `aria-expanded` is being set properly on expandable components
3. Observe changes made in "search results" listbox, and landmarks (`role="search"`, `<nav>`)

## Supporting resources (related issues, external links, etc):

- https://github.com/github/primer/issues/1668

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

<!-- ## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

 </td>
<td valign="top">

</td>
</tr>
</table>
-->