### PR TITLE
Fix focus order for mobile menu in `SubdomainNavbar`

### DIFF
--- a/.changeset/wild-turtles-confess.md
+++ b/.changeset/wild-turtles-confess.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixes focus navigation within mobile menu in `SubdomainNavbar`

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
@@ -126,6 +126,11 @@
   .SubdomainNavBar-primary-nav-list {
     display: none;
   }
+
+  .SubdomainNavBar-primary-nav-list--invisible {
+    display: none;
+  }
+
   .SubdomainNavBar-primary-nav-list--visible {
     display: block;
     margin: 0;

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css.d.ts
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css.d.ts
@@ -13,6 +13,7 @@ declare const styles: {
   readonly "SubdomainNavBar-title": string;
   readonly "SubdomainNavBar-primary-nav": string;
   readonly "SubdomainNavBar-primary-nav-list": string;
+  readonly "SubdomainNavBar-primary-nav-list--invisible": string;
   readonly "SubdomainNavBar-primary-nav-list--visible": string;
   readonly "fade-in-down": string;
   readonly "SubdomainNavBar-primary-nav-list-item": string;

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -90,6 +90,24 @@ function Root({
       []
     ).length > 0
 
+  const menuItems = React.Children.toArray(children)
+    .map((child, index) => {
+      if (React.isValidElement(child) && typeof child.type !== 'string') {
+        if (child.type === Link) {
+          return React.cloneElement(child, {
+            'data-navitemid': child.props.children,
+            href: child.props.href,
+            children: child.props.children,
+            style: {
+              [`--animation-order`]: index
+            }
+          })
+        }
+        return null
+      }
+    })
+    .filter(Boolean)
+
   return (
     <div
       className={clsx(
@@ -133,26 +151,8 @@ function Root({
               className={styles['SubdomainNavBar-primary-nav']}
               data-testid={testIds.menuLinks}
             >
-              <NavigationVisbilityObserver
-                className={clsx(!menuHidden && styles['SubdomainNavBar-primary-nav-list--visible'])}
-              >
-                {React.Children.toArray(children)
-                  .map((child, index) => {
-                    if (React.isValidElement(child) && typeof child.type !== 'string') {
-                      if (child.type === Link) {
-                        return React.cloneElement(child, {
-                          'data-navitemid': child.props.children,
-                          href: child.props.href,
-                          children: child.props.children,
-                          style: {
-                            [`--animation-order`]: index
-                          }
-                        })
-                      }
-                      return null
-                    }
-                  })
-                  .filter(Boolean)}
+              <NavigationVisbilityObserver className={clsx(styles['SubdomainNavBar-primary-nav-list--invisible'])}>
+                {menuItems}
               </NavigationVisbilityObserver>
             </nav>
           )}
@@ -191,6 +191,12 @@ function Root({
                 <div className={clsx(styles['SubdomainNavBar-menu-button-bar'])}></div>
                 <div className={clsx(styles['SubdomainNavBar-menu-button-bar'])}></div>
               </button>
+            )}
+
+            {hasLinks && !menuHidden && (
+              <NavigationVisbilityObserver className={clsx(styles['SubdomainNavBar-primary-nav-list--visible'])}>
+                {menuItems}
+              </NavigationVisbilityObserver>
             )}
 
             <div

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -90,23 +90,27 @@ function Root({
       []
     ).length > 0
 
-  const menuItems = React.Children.toArray(children)
-    .map((child, index) => {
-      if (React.isValidElement(child) && typeof child.type !== 'string') {
-        if (child.type === Link) {
-          return React.cloneElement(child, {
-            'data-navitemid': child.props.children,
-            href: child.props.href,
-            children: child.props.children,
-            style: {
-              [`--animation-order`]: index
+  const menuItems = useMemo(
+    () =>
+      React.Children.toArray(children)
+        .map((child, index) => {
+          if (React.isValidElement(child) && typeof child.type !== 'string') {
+            if (child.type === Link) {
+              return React.cloneElement(child, {
+                'data-navitemid': child.props.children,
+                href: child.props.href,
+                children: child.props.children,
+                style: {
+                  [`--animation-order`]: index
+                }
+              })
             }
-          })
-        }
-        return null
-      }
-    })
-    .filter(Boolean)
+            return null
+          }
+        })
+        .filter(Boolean),
+    [children]
+  )
 
   return (
     <div


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

Fixes focus order issue when mobile menu is present.

Related: https://github.com/github/primer/issues/1668

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Splits up usage of menu items to handle desktop and mobile menu views

## What should reviewers focus on?

- Focus order when mobile menu is present
- No visual changes are present

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Open up Storybook environment provided by this PR
2. Open "Mobile Menu" example of `SubdomainNavbar`
3. Expand the mobile menu, and navigate to the menu items via tabbing

## Supporting resources (related issues, external links, etc):

- https://github.com/github/primer/issues/1668
- [Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html)

## Contributor checklist:

- [x] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td align="center">

<!-- Insert "before" screenshot here -->

https://user-images.githubusercontent.com/26746305/234039220-bcb8b286-a026-435f-9354-7617efec5e56.mov

Video showing an example of focus navigation within mobile view of `SubdomainNavBar`. Video shows user tabbing to mobile menu button to expand, then tabbing through the menu items. Focus goes directly to the "CTA" links within the menu pane and not the menu links directly below trigger. User then has to tab backwards (<kbd>Shift</kbd> + <kbd>Tab</kbd>) to navigate to the menu item links.
 </td>
<td align="center">

<!-- Insert "after" screenshot here -->

https://user-images.githubusercontent.com/26746305/234039277-6a8238ad-b56d-4bac-b1ef-1549d91dd284.mov

Video showing an example of focus navigation within mobile view of `SubdomainNavBar`. Video shows user tabbing to mobile menu button to expand, then tabbing through the menu items. Focus goes to the menu items directly below the trigger, then proceeds to the "CTA" links.
</td>
</tr>
</table>
