### PR TITLE
Fix zoom issue in `SubdomainNavbar`

### DIFF
--- a/.changeset/loud-eels-perform.md
+++ b/.changeset/loud-eels-perform.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixes zoom issue in `SubdomainNavBar` where secondary CTA link would disappear at 200% zoom, or specified width

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
@@ -155,7 +155,7 @@
   }
 }
 
-@media screen and (min-width: 750px) {
+@media screen and (min-width: 768px) {
   .SubdomainNavBar-primary-nav-list {
     max-width: 100px;
   }

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.module.css
@@ -154,15 +154,22 @@
     /* overflow: hidden; */
   }
 }
+
+@media screen and (min-width: 750px) {
+  .SubdomainNavBar-primary-nav-list {
+    max-width: 100px;
+  }
+}
+
 @media screen and (min-width: 850px) {
   .SubdomainNavBar-primary-nav-list {
-    max-width: 320px;
+    max-width: 200px;
   }
 }
 
 @media screen and (min-width: 1024px) {
   .SubdomainNavBar-primary-nav-list {
-    max-width: 340px;
+    max-width: 300px;
   }
 }
 
@@ -475,12 +482,6 @@
 .SubdomainNavBar-cta-button {
   height: 48px; /*TODO: investigate why this is shorter than medium default height*/
   white-space: nowrap;
-}
-
-@media screen and (min-width: 48rem) and (max-width: 1023px) {
-  .SubdomainNavBar-cta-button--secondary {
-    display: none;
-  }
 }
 
 @media screen and (min-width: 1024px) {


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

Adds additional media query rules to prevent CTA links from not being visible at select viewports and 200% zoom.

Resolves: https://github.com/github/primer/issues/2009

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Adjusts media queries 

## What should reviewers focus on?

- Secondary CTA link stays present at 200% zoom **or** when viewport width is between `768px` and `1023px`
- Ensure navigation links do not overlap when viewport width shrinks

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Go to the [component on Storybook](https://primer.style/brand/storybook/iframe.html?args=&id=components-subdomainnavbar--playground&viewMode=story)
2. Set browser zoom to 200% ([Chrome](https://support.google.com/chrome/answer/96810?hl=en&co=GENIE.Platform%3DDesktop), [Firefox](https://support.mozilla.org/en-US/kb/font-size-and-zoom-increase-size-of-web-pages#w_zoom-in-and-out-of-a-website))
3. **(Optional)** Set viewport width to a value between `768px` and `1023px`
4. Ensure secondary CTA link is still present

## Supporting resources (related issues, external links, etc):

- https://github.com/github/primer/issues/2009

## Contributor checklist:

- [x] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

https://user-images.githubusercontent.com/26746305/234057323-56ce6aac-f1cd-4414-a166-e0d141faa7bf.mov

Video example of viewport width changing slowly. When viewport width reaches `1023px` and below, the secondary CTA link disappears from view. 

 </td>

<td valign="top">

<!-- Insert "after" screenshot here -->

https://user-images.githubusercontent.com/26746305/234057413-c9fb7749-9473-471e-88f4-6b6b6070b8a0.mov

Video example of viewport width changing slowly. When viewport width reaches `1023px` and below, the secondary CTA link stays present. 
</td>
</tr>
</table>
