### PR TITLE
Use Icon type from octicons

### DIFF
--- a/packages/react/src/Card/Card.tsx
+++ b/packages/react/src/Card/Card.tsx
@@ -18,6 +18,7 @@ import '@primer/brand-primitives/lib/design-tokens/css/tokens/functional/compone
  */
 import styles from './Card.module.css'
 import stylesLink from '../Link/Link.module.css'
+import {Icon as IconProps} from '@primer/octicons-react'
 
 export const CardIconColors = Colors
 
@@ -124,7 +125,7 @@ const CardRoot = forwardRef<HTMLAnchorElement, CardProps>(
 )
 
 type CardIconProps = BaseProps<HTMLSpanElement> & {
-  icon: React.ReactNode
+  icon: React.ReactNode | IconProps
   color?: typeof CardIconColors[number]
   hasBackground?: boolean
 }
@@ -147,7 +148,7 @@ function CardIcon({
       {...rest}
     >
       {typeof Icon === 'function' ? (
-        <Icon size="20" />
+        <Icon size={20} />
       ) : (
         React.isValidElement(Icon) &&
         React.cloneElement(Icon, {


### PR DESCRIPTION
## Summary

Potential fix to avoid typescript errors when passing Octicons function into `Card.Icon`

Issue: https://github.com/primer/brand/pull/242#issuecomment-1523478707

## List of notable changes:

- **updated** Card Icon type to use `React.ReactNode | IconProps`

## What should reviewers focus on?

-
-

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1.
1.
1.

## Supporting resources (related issues, external links, etc):

-
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
