### PR TITLE
Supporting Image SrcSet

### DIFF
--- a/packages/react/src/Image/Image.test.tsx
+++ b/packages/react/src/Image/Image.test.tsx
@@ -213,19 +213,6 @@ describe('Image', () => {
         src="https://via.placeholder.com/600x400/d3d9df/d3d9df.png"
         as="picture"
         alt="alternative text"
-        srcSet="https://via.placeholder.com/600x400/d3d9df/d3d9df.png, https://via.placeholder.com/900x600/d3d9df/d3d9df.png 1.5x"
-      />
-    )
-
-    expect(container.querySelector('source')).toBeInTheDocument()
-  })
-
-  it('should create a source element when as is equal to picture and the srcSet property is set.', async () => {
-    const {container} = render(
-      <Image
-        src="https://via.placeholder.com/600x400/d3d9df/d3d9df.png"
-        as="picture"
-        alt="alternative text"
         sources={[
           {
             srcset: 'https://via.placeholder.com/600x400/d3d9df/d3d9df.png',

--- a/packages/react/src/Image/Image.test.tsx
+++ b/packages/react/src/Image/Image.test.tsx
@@ -208,6 +208,17 @@ describe('Image', () => {
   })
 
   it('should create a source element when as is equal to picture and the srcSet property is set.', async () => {
+    const testSrcSet =
+      'https://via.placeholder.com/600x400/d3d9df/d3d9df.png, https://via.placeholder.com/1200x800/d3d9df/d3d9df.png 2x'
+    const testAltText = 'alternative text'
+    const {getByAltText} = render(
+      <Image src="https://via.placeholder.com/600x400/d3d9df/d3d9df.png" alt={testAltText} srcSet={testSrcSet} />
+    )
+
+    expect(getByAltText(testAltText).getAttribute('srcset')).toEqual(testSrcSet)
+  })
+
+  it('should create a source element when as is equal to picture and the srcSet property is set.', async () => {
     const {container} = render(
       <Image
         src="https://via.placeholder.com/600x400/d3d9df/d3d9df.png"

--- a/packages/react/src/Image/Image.test.tsx
+++ b/packages/react/src/Image/Image.test.tsx
@@ -207,7 +207,7 @@ describe('Image', () => {
     expect(container.querySelector('span')).toBeInTheDocument()
   })
 
-  it('should create a source element when as is equal to picture and the srcSet property is set.', async () => {
+  it('should set the srcSet property correctly on the img component', async () => {
     const testSrcSet =
       'https://via.placeholder.com/600x400/d3d9df/d3d9df.png, https://via.placeholder.com/1200x800/d3d9df/d3d9df.png 2x'
     const testAltText = 'alternative text'

--- a/packages/react/src/Image/Image.tsx
+++ b/packages/react/src/Image/Image.tsx
@@ -11,10 +11,11 @@ export type ImageProps = React.ImgHTMLAttributes<HTMLImageElement> &
     alt: string
     aspectRatio?: AspectRatio
     media?: string
+    srcSet?: Pick<React.ImgHTMLAttributes<HTMLImageElement>, 'srcSet'>
   } & (
     | {
         as?: 'img' // assuming this is true for others to be required
-        srcSet?: 'string'
+        srcSet?: Pick<React.ImgHTMLAttributes<HTMLImageElement>, 'srcSet'>
       }
     | {
         as: 'picture' // assuming this is true for others to be required
@@ -22,6 +23,7 @@ export type ImageProps = React.ImgHTMLAttributes<HTMLImageElement> &
           srcset: string
           media: string
         }[]
+        srcSet?: undefined
       }
   )
 


### PR DESCRIPTION
## Summary

Fixing a bug where the `srcSet` prop was only allowed when the `as` prop was used

Removed test related to using srcSet on picture when the sources array should be used instead.

## What should reviewers focus on?

- Ensuring this prop works as expected

## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/pull/242#issuecomment-1523478707

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
