### PR TITLE
[CTABanner] Fix container width

### DIFF
--- a/packages/react/src/CTABanner/CTABanner.module.css
+++ b/packages/react/src/CTABanner/CTABanner.module.css
@@ -3,6 +3,7 @@
   margin: 0 auto;
   display: flex;
   max-width: var(--brand-breakpoint-xlarge);
+  width: 100%;
 }
 
 .CTABanner--shadow::before {


### PR DESCRIPTION
## Summary

Adjust width property to avoid shrinking when using `Stack` or `Grid` components as wrappers.

## List of notable changes:

- **added** `width: 100%` to `.CTABanner`

## What should reviewers focus on?

- Using `Stack` or `Grid` components on a `CTABanner` works as expected and doesn't shrink the wrapper 

## Steps to test:


1. Open the CTABanner component in storybook
2. Add `display:flex` to the parent
3. Verify that CTABanner behaves as described in the following issue.

## Supporting resources (related issues, external links, etc):

- Slack thread: https://github.slack.com/archives/C04E44ZPNEA/p1683546014522099

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
