### PR TITLE
Added Polymorphic MinimalFooter link

### DIFF
--- a/.changeset/giant-dryers-cheer.md
+++ b/.changeset/giant-dryers-cheer.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Added polymorphism to the MinimalFooter link element

--- a/packages/react/src/MinimalFooter/MinimalFooter.features.stories.tsx
+++ b/packages/react/src/MinimalFooter/MinimalFooter.features.stories.tsx
@@ -61,6 +61,21 @@ export const MaximumLinks = () => (
 )
 MaximumLinks.storyName = 'Maximum Links (5)'
 
+export const ButtonLinks = () => (
+  <MinimalFooter socialLinks={false}>
+    <MinimalFooter.Link as="button" onClick={() => alert('You have clicked Button one')}>
+      Button one
+    </MinimalFooter.Link>
+    <MinimalFooter.Link as="button" onClick={() => alert('You have clicked Button two')}>
+      Button two
+    </MinimalFooter.Link>
+    <MinimalFooter.Link as="button" onClick={() => alert('You have clicked Button three')}>
+      Button three
+    </MinimalFooter.Link>
+  </MinimalFooter>
+)
+MaximumLinks.storyName = 'Button Links'
+
 export const NoSocialLinks = () => <MinimalFooter socialLinks={false} />
 
 export const FilteredSocialLinks = () => <MinimalFooter socialLinks={['facebook', 'twitter']} />

--- a/packages/react/src/MinimalFooter/MinimalFooter.module.css
+++ b/packages/react/src/MinimalFooter/MinimalFooter.module.css
@@ -93,7 +93,12 @@
   align-self: flex-start;
   color: var(--brand-color-text-muted);
   text-decoration: none;
+  border-top: none;
+  border-right: none;
+  border-left: none;
   border-bottom: var(--brand-borderWidth-thin) solid transparent;
+  background-color: inherit;
+  cursor: pointer;
   padding-bottom: var(--base-size-4);
   transition: border 300ms cubic-bezier(0.33, 1, 0.68, 1);
 }

--- a/packages/react/src/MinimalFooter/MinimalFooter.tsx
+++ b/packages/react/src/MinimalFooter/MinimalFooter.tsx
@@ -274,21 +274,22 @@ function SocialLogomarks({socialLinks, logoHref}: SocialLogomarksProps) {
   )
 }
 
-type LinkProps = {
-  href: string
-} & BaseProps<HTMLAnchorElement>
+type LinkProps<C extends React.ElementType> = BaseProps<C> & {as?: C} & Omit<React.ComponentPropsWithoutRef<C>, keyof C>
 
-function Link({href, children}: PropsWithChildren<LinkProps>) {
+const Link = <C extends React.ElementType = 'a'>({as, children, ...rest}: PropsWithChildren<LinkProps<C>>) => {
+  const Component = as || 'a'
   return (
-    <a
-      href={href}
+    <Component
       className={styles['Footer__link']}
-      data-analytics-event={`{"category":"Footer","action":"go to ${href}","label":"text:${children}"}`}
+      data-analytics-event={
+        rest['href'] ? `{"category":"Footer","action":"go to ${rest['href']}","label":"text:${children}"}` : undefined
+      }
+      {...rest}
     >
       <Text variant="muted" size="300">
         {children}
       </Text>
-    </a>
+    </Component>
   )
 }
 


### PR DESCRIPTION
## Summary

We're looking to replace the custom Footer we have on some pages of https://resources.github.com/ with MinimalFooter. To do this, we need the option to allow button as alternative to MinimalFooter.Link.

Example: as you can see at the bottom of https://resources.github.com/enterprise/trial/, we have a button in the footer for "Manage cookies", which opens an overlay to manage cookie settings. The styling should be the same as the text link.

## List of notable changes:

- **updated** MinimalFooter.Link element to allow for polymorphism

## What should reviewers focus on?

- Making sure that the Storybook feature Button Links works as expected.

## Steps to test:

1. Open the MinimalFooter component in CI-deployed preview environment
2. Go to ButtonLinks feature story in Storybook
3. Verify that the Button Links story behaves as expected

## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/issues/264

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change