### PR TITLE
Fix type issues in `Hero`

### DIFF
--- a/.changeset/small-hats-itch.md
+++ b/.changeset/small-hats-itch.md
@@ -5,7 +5,15 @@
 
 Provides the `Hero` component with a composable API.
 
-Before:
+> **Warning**
+> This is a breaking change to the `Hero` component. Please review the following carefully.
+
+<table>
+<tr>
+<th> Before</th> <th> After </th>
+</tr>
+<tr>
+<td valign="top">
 
 ```jsx
 <Hero
@@ -19,7 +27,8 @@ Before:
 />
 ```
 
-After:
+ </td>
+<td valign="top">
 
 ```jsx
 <Hero>
@@ -28,3 +37,7 @@ After:
   <Hero.PrimaryAction href="#">Primary action</Hero.PrimaryAction>
 </Hero>
 ```
+
+</td>
+</tr>
+</table>

--- a/apps/docs/content/components/Hero.mdx
+++ b/apps/docs/content/components/Hero.mdx
@@ -90,6 +90,8 @@ Forwards `size` and `weight` props from the [Text component](/components/Text).
 | `href`      | `string`      |         | `href` for primary link             |
 | `as`        | `a`, `button` | `a`     | Applies the underlying HTML element |
 
+Forwards all props from the [Button component](/components/Button).
+
 ### Hero.SecondaryAction
 
 | name        | type          | default | description                         |
@@ -97,3 +99,5 @@ Forwards `size` and `weight` props from the [Text component](/components/Text).
 | `className` | `string`      |         | Secondary link custom class         |
 | `href`      | `string`      |         | `href` for secondary link           |
 | `as`        | `a`, `button` | `a`     | Applies the underlying HTML element |
+
+Forwards all props from the [Button component](/components/Button).

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -1,8 +1,10 @@
 import clsx from 'clsx'
 import React, {forwardRef, useCallback, type Ref, ReactElement} from 'react'
-import {ExpandableArrow} from '../ExpandableArrow'
-import {Text} from '../Text'
+import type {Icon} from '@primer/octicons-react'
 import '@primer/brand-primitives/lib/design-tokens/css/tokens/functional/components/button/colors-with-modes.css'
+import {Text} from '../Text'
+import {ExpandableArrow} from '../ExpandableArrow'
+
 import type {BaseProps} from '../component-helpers'
 import styles from './Button.module.css'
 
@@ -16,11 +18,11 @@ export type ButtonBaseProps = {
   /**
    * The leading visual appears before the button content
    */
-  leadingVisual?: ReactElement
+  leadingVisual?: ReactElement | Icon
   /**
    * The trailing visual appears after the button content
    */
-  trailingVisual?: ReactElement
+  trailingVisual?: ReactElement | Icon
   /**
    * The styling variations available in Button
    */
@@ -80,7 +82,7 @@ export const _Button = forwardRef(
     const isDisabled =
       disabled || ariaDisabled === 'true' || (typeof ariaDisabled === 'boolean' && ariaDisabled === true)
 
-    const returnValidComponent = useCallback((component?: ReactElement) => {
+    const returnValidComponent = useCallback((component?: ReactElement | Icon) => {
       if (React.isValidElement(component)) {
         return component
       }

--- a/packages/react/src/Hero/Hero.features.stories.tsx
+++ b/packages/react/src/Hero/Hero.features.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {ComponentStory, ComponentMeta} from '@storybook/react'
 import {INITIAL_VIEWPORTS} from '@storybook/addon-viewport'
+import {HeartFillIcon, StarFillIcon} from '@primer/octicons-react'
 
 import {Hero} from '.'
 
@@ -70,6 +71,24 @@ export const Issues: ComponentStory<typeof Hero> = _args => (
     <Hero.SecondaryAction href="#">Start using project tables</Hero.SecondaryAction>
   </Hero>
 )
+
+export const WithCustomIconAndVariant: ComponentStory<typeof Hero> = _args => (
+  <Hero align="center">
+    <Hero.Heading>This is my super sweet hero heading</Hero.Heading>
+    <Hero.Description>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sapien sit ullamcorper id. Aliquam luctus sed turpis
+      felis nam pulvinar risus elementum.
+    </Hero.Description>
+    <Hero.PrimaryAction href="#" leadingVisual={HeartFillIcon}>
+      Primary action with leading icon
+    </Hero.PrimaryAction>
+    <Hero.SecondaryAction href="#" trailingVisual={StarFillIcon} variant="subtle">
+      Subtle action with trailing icon
+    </Hero.SecondaryAction>
+  </Hero>
+)
+
+WithCustomIconAndVariant.storyName = 'With custom icon and variant'
 
 export const NarrowView: ComponentStory<typeof Hero> = _args => (
   <Hero>

--- a/packages/react/src/Hero/Hero.tsx
+++ b/packages/react/src/Hero/Hero.tsx
@@ -74,9 +74,7 @@ function HeroDescription({size = '400', weight, children}: PropsWithChildren<Her
 
 type HeroActions = {
   href: string
-  leadingVisual?: React.ReactNode
-  trailingVisual?: React.ReactNode
-} & Omit<ButtonBaseProps, 'trailingVisual' | 'leadingVisual'>
+} & ButtonBaseProps
 
 function HeroPrimaryAction({href, children, ...rest}: PropsWithChildren<HeroActions>) {
   return (

--- a/packages/react/src/Hero/Hero.tsx
+++ b/packages/react/src/Hero/Hero.tsx
@@ -74,7 +74,9 @@ function HeroDescription({size = '400', weight, children}: PropsWithChildren<Her
 
 type HeroActions = {
   href: string
-} & Omit<ButtonBaseProps, 'variant'>
+  leadingVisual?: React.ReactNode
+  trailingVisual?: React.ReactNode
+} & Omit<ButtonBaseProps, 'trailingVisual' | 'leadingVisual'>
 
 function HeroPrimaryAction({href, children, ...rest}: PropsWithChildren<HeroActions>) {
   return (


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

Adjusts types for `HeroActions` type. 
* Remove `Omit` for `variant` prop
* Fix `leadingVisual` and `trailingVisual` type issue

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Adjusts TS types for `HeroActions`

## What should reviewers focus on?

- The ability to use props stemming from `Button`
- Added story to showcase icon support and `variant` usage

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

* Ensure no TypeScript errors are present when utilizing props from the [Brand `Button` component](https://primer-5dccbf8f09-26139705.drafts.github.io/components/Button#component-props).

## Contributor checklist:

- [x] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
