### PR TITLE
Remove subsections in navigation

### DIFF
--- a/apps/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/apps/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -26,6 +26,8 @@
       url: /components/ButtonGroup
     - title: Card
       url: /components/Card
+    - title: Checkbox
+      url: /components/Checkbox
     - title: Comparison table
       url: /components/ComparisonTable
     - title: CTA banner
@@ -34,6 +36,12 @@
       url: /components/CTAForm
     - title: FAQ
       url: /components/FAQ
+    - title: Form control
+      url: /components/FormControl
+    - title: Grid
+      url: /components/Grid
+    - title: Heading
+      url: /components/Heading
     - title: Hero
       url: /components/Hero
     - title: Image
@@ -46,42 +54,25 @@
       url: /components/OrderedList
     - title: Pillar
       url: /components/Pillar
+    - title: Radio
+      url: /components/Radio
     - title: River
       url: /components/River
     - title: Section intro
       url: /components/SectionIntro
+    - title: Select
+      url: /components/Select
+    - title: Stack
+      url: /components/Stack
     - title: Subdomain nav bar
       url: /components/SubdomainNavBar
     - title: Testimonial
       url: /components/Testimonial
-    - title: Unordered list
-      url: /components/UnorderedList
-
-- title: Forms
-  children:
-    - title: Checkbox
-      url: /components/Checkbox
-    - title: Form control
-      url: /components/FormControl
-    - title: Radio
-      url: /components/Radio
-    - title: Select
-      url: /components/Select
+    - title: Text
+      url: /components/Text
     - title: Textarea
       url: /components/Textarea
     - title: Text input
       url: /components/TextInput
-
-- title: Layout
-  children:
-    - title: Grid
-      url: /components/Grid
-    - title: Stack
-      url: /components/Stack
-
-- title: Typography
-  children:
-    - title: Heading
-      url: /components/Heading
-    - title: Text
-      url: /components/Text
+    - title: Unordered list
+      url: /components/UnorderedList


### PR DESCRIPTION
## Summary

Remove component sub-sections in the documentation navigation and list all components under a single `component` section. This aligns the navigation to the interface guidelines IA. 

cc @emilybrick 

## List of notable changes:

- **removed** component sub-sections, and re-order all components under a single `Components` section

## What should reviewers focus on?

- Documentation:

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="189" alt="Screenshot 2023-06-16 at 08 38 12" src="https://github.com/primer/brand/assets/912236/ec3c0a24-83f0-4f96-abe4-51cc8b3e9ef8">

 </td>
<td valign="top">

<img width="227" alt="Screenshot 2023-06-16 at 08 37 56" src="https://github.com/primer/brand/assets/912236/a135dc33-a6c1-4131-920b-1e97ae2af55e">

</td>
</tr>
</table>
