### PR TITLE
Update header navigation

### DIFF
--- a/apps/docs/gatsby-config.js
+++ b/apps/docs/gatsby-config.js
@@ -3,7 +3,10 @@ const path = require('path')
 module.exports = {
   siteMetadata: {
     title: 'Primer Brand',
-    shortName: 'Primer Brand',
+    header: {
+      title: 'Primer Design System',
+    },
+    shortName: 'Brand',
     description: 'React components for GitHub marketing pages',
   },
   plugins: [

--- a/apps/docs/src/@primer/gatsby-theme-doctocat/primer-nav.yml
+++ b/apps/docs/src/@primer/gatsby-theme-doctocat/primer-nav.yml
@@ -1,0 +1,6 @@
+- title: Brand
+  url: https://primer.style/brand
+- title: View Components
+  url: https://primer.style/view-components
+- title: React Components
+  url: https://primer.style/react


### PR DESCRIPTION
## Summary

Similar to https://github.com/primer/design/pull/509 and https://github.com/primer/react/pull/3435

## List of notable changes:

- Updates top-level nav links as described in https://github.com/github/primer/issues/2323
- Updates header to say "Primer Design System / React" instead of "Primer / React"

<img width="1840" alt="Screenshot 2023-06-21 at 17 15 30" src="https://github.com/primer/brand/assets/912236/ca9ed8bc-dfa8-4634-a8c5-cc17382d12b9">

## What should reviewers focus on?

- Documentation 👁️ : https://primer-798660e1be-26139705.drafts.github.io/

