### PR TITLE
Add a11yReviewed badges

### DIFF
--- a/apps/docs/content/components/Label/react.mdx
+++ b/apps/docs/content/components/Label/react.mdx
@@ -4,6 +4,7 @@ status: Experimental
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=6084-28401'
 source: https://github.com/primer/brand/blob/main/packages/react/src/Label/Label.tsx
 storybook: '/brand/storybook/?path=/story/components-label--default'
+a11yReviewed: true
 description: Use labels to add metadata or indicate the status of items.
 ---
 

--- a/apps/docs/content/components/Pillar/react.mdx
+++ b/apps/docs/content/components/Pillar/react.mdx
@@ -3,6 +3,7 @@ title: Pillar
 status: Experimental
 source: https://github.com/primer/brand/tree/main/packages/react/src/Pillar/Pillar.tsx
 storybook: '/brand/storybook/?path=/story/components-pillar--default'
+a11yReviewed: true
 description: Use pillars to group related content together.
 figma: https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=6849-31364&mode=design
 ---


### PR DESCRIPTION
## Summary

Add missing `Reviewed for accessibility` labels in docs for `Pillar` and `Label`. 


## List of notable changes:

- **added** a11yReviewed variable in the frontmatter

## What should reviewers focus on?

- Documentation pages for `Pillar` and `Label`

## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/pull/273
- https://github.com/primer/brand/pull/301

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
