### PR TITLE
AnchorNav Bug Fix

### DIFF
--- a/.changeset/short-apples-press.md
+++ b/.changeset/short-apples-press.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed bug on AnchorNav when offset moves the first menu item out of the viewport

--- a/packages/react/src/AnchorNav/AnchorNav.tsx
+++ b/packages/react/src/AnchorNav/AnchorNav.tsx
@@ -90,7 +90,7 @@ function _AnchorNav({children, enableDefaultBgColor = false, ...props}: AnchorNa
   useEffect(() => {
     const handler = () => {
       if (initialYOffset) {
-        const isPastInitialYOffset = window.pageYOffset > initialYOffset
+        const isPastInitialYOffset = window.scrollY === initialYOffset
         isPastInitialYOffset ? setNavShouldFix(true) : setNavShouldFix(false)
       }
     }


### PR DESCRIPTION
## Summary

Fixing [an issue](https://github.com/primer/brand/issues/319) with the AnchorNav where the first title would not appear on scroll if it was below the viewport.

## List of notable changes:

- **changed** an identifier for determining if the specific anchor nav element was in scope


## What should reviewers focus on?

- Making sure the same visual test is followed to ensure it works as expected

## Steps to test:

1. Go to [Storybook](https://primer-0ccdaad22e-26139705.drafts.github.io/storybook/?path=/story/components-anchornav-features--fewer-anchor-links&args=offset:1000)
```bash
2. Make sure the offset is, at least, `500px`
3. Use a narrow screen size
4. Scroll slowly until seeing the `AnchorNav` component
5. See error is not longer there
```

## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/issues/319

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

https://github.com/primer/brand/assets/3042654/1336d3a3-c510-47cc-9288-76bc0c898556

 </td>
<td valign="top">

https://github.com/primer/brand/assets/31220082/6966ac5c-9b24-46b4-a822-cfbf8684da47

</td>
</tr>
</table>
