### PR TITLE
Fixed grid column appearance at medium breakpoints

### DIFF
--- a/.changeset/lovely-zoos-bake.md
+++ b/.changeset/lovely-zoos-bake.md
@@ -1,0 +1,20 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed grid column appearance at medium breakpoints for columns that span beyond `9`. Required styles, which were previously missing have been backfilled.
+
+```jsx
+<Grid>
+  <Grid.Column
+    span={{
+      medium: 9,
+    }}
+  ></Grid.Column>
+  <Grid.Column
+    span={{
+      medium: 3,
+    }}
+  ></Grid.Column>
+</Grid>
+```

--- a/packages/react/src/Grid/Grid.module.css
+++ b/packages/react/src/Grid/Grid.module.css
@@ -366,6 +366,22 @@
     grid-column: auto / span 8;
   }
 
+  .Grid__column--medium-span-9 {
+    grid-column: auto / span 9;
+  }
+
+  .Grid__column--medium-span-10 {
+    grid-column: auto / span 10;
+  }
+
+  .Grid__column--medium-span-11 {
+    grid-column: auto / span 11;
+  }
+
+  .Grid__column--medium-span-12 {
+    grid-column: auto / span 12;
+  }
+
   /* MEDIUM start */
   .Grid__column--medium-start-1 {
     grid-column-start: 1;

--- a/packages/react/src/Grid/Grid.module.css.d.ts
+++ b/packages/react/src/Grid/Grid.module.css.d.ts
@@ -82,6 +82,10 @@ declare const styles: {
   readonly "Grid__column--medium-span-6": string;
   readonly "Grid__column--medium-span-7": string;
   readonly "Grid__column--medium-span-8": string;
+  readonly "Grid__column--medium-span-9": string;
+  readonly "Grid__column--medium-span-10": string;
+  readonly "Grid__column--medium-span-11": string;
+  readonly "Grid__column--medium-span-12": string;
   readonly "Grid__column--medium-start-1": string;
   readonly "Grid__column--medium-start-2": string;
   readonly "Grid__column--medium-start-3": string;


### PR DESCRIPTION
## Summary

Closes #340 

Backfills missing styles for medium breakpoint columns in `Grid`.

## What should reviewers focus on?

- Code review

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

Try using a 9/3 two column combo in documentation, and verify it appears correctly.

## Supporting resources (related issues, external links, etc):

- #340 

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="872" alt="Screenshot 2023-07-13 at 22 25 43" src="https://github.com/primer/brand/assets/13340707/dbf9d1d5-a8ac-4f34-b946-ce602a201148">

 </td>
<td valign="top">

<img width="873" alt="Screenshot 2023-07-13 at 22 25 07" src="https://github.com/primer/brand/assets/13340707/abac1b89-b9b9-48ac-8004-886e7252ae88">


</td>
</tr>
</table>
