### PR TITLE
Fix LogoSuite react doc (label size) 

### DIFF
--- a/apps/docs/content/components/LogoSuite/react.mdx
+++ b/apps/docs/content/components/LogoSuite/react.mdx
@@ -10,7 +10,7 @@ description: Use a logo suite to present a list logos, such as sponsors or vendo
 import ComponentLayout from '../../../src/layouts/component-layout'
 export default ComponentLayout
 
-import {Label} from '@primer/react-brand'
+import {Label} from '@primer/react'
 import {Box as Container} from '@primer/react'
 import {PropTableValues} from '../../../src/components'
 

--- a/apps/docs/content/components/LogoSuite/react.mdx
+++ b/apps/docs/content/components/LogoSuite/react.mdx
@@ -422,7 +422,7 @@ Logobars using the `emphasis` variant will appear with relatively higher contras
 | `align`      | <PropTableValues values={['start', 'center', 'justify']} addLineBreaks /> | `'center'` | The horizontal alignment of the LogoSuite.                  |
 | `hasDivider` | `boolean`                                                                 | `true`     | Whether to render a divider immediately after the LogoSuite |
 
-### LogoSuite.Heading <Label size="small">Required</Label>
+### LogoSuite.Heading <Label>Required</Label>
 
 | Name             | Type      | Default     | Description                                |
 | :--------------- | :-------- | :---------- | :----------------------------------------- |


### PR DESCRIPTION
- Delete the small variant option on the `required` button for props  to create consistency with other pages
- Changed `label` to be from primer brand
    - the other libraries use this version

## Summary
Fixing the label size for the `required` props.
🔗 [doc](https://primer-55243873a7-26139705.drafts.github.io/)


## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/primer/brand/assets/131988618/874f712d-fe61-40b4-aafa-3de1d1888ace)

 </td>
<td valign="top">

<img width="896" alt="image" src="https://github.com/primer/brand/assets/131988618/25747475-cf22-4c8f-9425-bba2bd388353">

</td>
</tr>
</table>
