### PR TITLE
Fix timeline stroke width when browser is zoomed

### DIFF
--- a/packages/react/src/Timeline/Timeline.module.css
+++ b/packages/react/src/Timeline/Timeline.module.css
@@ -29,9 +29,7 @@
   height: var(--brand-Timeline-bullet-size);
   top: var(--bulletY);
   left: 0;
-  border-style: solid;
-  border-width: var(--brand-Timeline-strokeWidth);
-  border-color: var(--brand-Timeline-line-color);
+  box-shadow: inset 0 0 0 var(--brand-Timeline-strokeWidth) var(--brand-Timeline-line-color);
   border-radius: var(--brand-borderRadius-full);
 }
 


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

Fixes an issue where the browser would render the stroke of the timeline component's circle thinner than expected when zoomed out. Using a `box-shadow` instead of a `border` to render the circle prevents this rounding issue.

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
