### PR TITLE
Fix documentation for heading, box and timeline

### DIFF
--- a/apps/docs/content/components/Box/react.mdx
+++ b/apps/docs/content/components/Box/react.mdx
@@ -29,7 +29,7 @@ import {Box} from '@primer/react-brand'
 
 <Note>
 
-Box requires the `dir` attribute to be set on the `<html>` element to ensure the correct visual apperance and layout of the timeline items.
+Box requires the `dir` attribute to be set on the `<html>` element to ensure that directional padding and margin values are applied correctly.
 
 </Note>
 

--- a/apps/docs/content/components/Box/react.mdx
+++ b/apps/docs/content/components/Box/react.mdx
@@ -27,6 +27,12 @@ import {Box} from '@primer/react-brand'
 
 ## Examples
 
+<Note>
+
+Box requires the `dir` attribute to be set on the `<html>` element to ensure the correct visual apperance and layout of the timeline items.
+
+</Note>
+
 ### Default
 
 The `Box` component, by default, represents an empty `<div>` element with no predefined styles applied to it.

--- a/apps/docs/content/components/Heading/react.mdx
+++ b/apps/docs/content/components/Heading/react.mdx
@@ -36,30 +36,29 @@ import {Heading} from '@primer/react-brand'
 
 ### Scale
 
-Heading sizes range from 1-6 and map to positions 900-400 on the Brand type scale respectively.
-
 ```jsx live
 <>
-  <Heading as="h1">1: 72px</Heading>
-  <Heading as="h2">2: 64px</Heading>
-  <Heading as="h3">3: 48px</Heading>
-  <Heading as="h4">4: 32px</Heading>
-  <Heading as="h5">5: 24px</Heading>
-  <Heading as="h6">6: 20px</Heading>
+  <Heading size="display">Display: 96px</Heading>
+  <Heading size="1">1: 72px</Heading>
+  <Heading size="2">2: 64px</Heading>
+  <Heading size="3">3: 48px</Heading>
+  <Heading size="4">4: 40px</Heading>
+  <Heading size="5">5: 32px</Heading>
+  <Heading size="6">6: 24px</Heading>
+  <Heading size="subhead-large">subhead-large: 20px</Heading>
+  <Heading size="subhead-medium">subhead-medium: 16px</Heading>
 </>
 ```
 
-### Sizes
+### Levels
 
-The `Heading` size by default is determined by the type of HTML element specified. E.g. `h1`, `h2`, `h3`, `h4`, `h5` or `h6`.
+The `Heading` level can be assigned using the `as` prop, which accepts any valid HTML heading tag.
 
-```jsx live
-<Heading as="h6">This is my super sweet heading</Heading>
-```
-
-Occasionally, you may need to apply a different visual size to override the default appearance. This can be achieved using the `size` prop.
+Its visual appearance corresponds to the `1-6` scale values, but can be overridden using the `size` prop.
 
 ```jsx live
+<Heading as="h6">This is my super sweet heading as a h6</Heading>
+
 <Heading as="h2" size="4">
   This h2 will appear visually identical to a h4
 </Heading>

--- a/apps/docs/content/components/Timeline.mdx
+++ b/apps/docs/content/components/Timeline.mdx
@@ -17,7 +17,7 @@ import {Timeline} from '@primer/react-brand'
 
 <Note>
 
-Timeline requires the `dir` attribute to be set on the `<html>` element to ensure the correct visual apperance and layout of the timeline items.
+Timeline requires the `dir` attribute to be set on the `<html>` element to ensure the correct visual apperance of timeline items.
 
 </Note>
 

--- a/apps/docs/content/components/Timeline.mdx
+++ b/apps/docs/content/components/Timeline.mdx
@@ -7,7 +7,6 @@ description: Use the timeline component to display a list of connected items as 
 a11yReviewed: false
 ---
 
-
 import {PropTableValues} from '../../src/components'
 
 ```js
@@ -15,6 +14,12 @@ import {Timeline} from '@primer/react-brand'
 ```
 
 ## Examples
+
+<Note>
+
+Timeline requires the `dir` attribute to be set on the `<html>` element to ensure the correct visual apperance and layout of the timeline items.
+
+</Note>
 
 ### Default
 
@@ -67,7 +72,7 @@ Use an `<em>` element within the timeline items to apply a duotone style and emp
 
 ### Timeline.Item
 
-| Name        | Type                                   |  Default  | Description                              |
-| :---------- | :------------------------------------- | :-------: | :--------------------------------------- |
-| `className` | `string`                               |           | Sets a custom class on the root element  |
-| `children`  | `React.ReactNode`, `React.ReactNode[]` |  | Content to be displayed within the item. |
+| Name        | Type                                   | Default | Description                              |
+| :---------- | :------------------------------------- | :-----: | :--------------------------------------- |
+| `className` | `string`                               |         | Sets a custom class on the root element  |
+| `children`  | `React.ReactNode`, `React.ReactNode[]` |         | Content to be displayed within the item. |

--- a/apps/docs/scripts/components-with-animation.js
+++ b/apps/docs/scripts/components-with-animation.js
@@ -13,5 +13,6 @@ export const supportedComponents = [
   'Stack',
   'Testimonial',
   'Text',
+  'Timeline',
   'Animate',
 ]


### PR DESCRIPTION
## Summary

- Updates the documentation to reflect recent changes to heading scale.
- Adds a note to Box and Timeline pages to indicate that `dir` needs to be set for the component to display correctly. This is because we use logical properties, that are part of the selectors for those components.


## What should reviewers focus on?

- Check wording, grammar, etc


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">


![Screenshot 2023-08-15 at 12 23 02](https://github.com/primer/brand/assets/13340707/2b8a09ff-166c-44de-823f-b3fa6b5027b0)

 </td>
<td valign="top">

![Screenshot 2023-08-15 at 12 22 49](https://github.com/primer/brand/assets/13340707/c919193d-7fb8-41e9-ab48-44f37602109a)


</td>
</tr>
</table>
