### PR TITLE
Fixes type scale on narrow viewports

### DIFF
--- a/.changeset/chilly-badgers-melt.md
+++ b/.changeset/chilly-badgers-melt.md
@@ -1,0 +1,5 @@
+---
+'@primer/brand-primitives': patch
+---
+
+Fixes duplicate typographic scale sizes on small viewports

--- a/packages/design-tokens/src/tokens/functional/typography/typography-responsive.json
+++ b/packages/design-tokens/src/tokens/functional/typography/typography-responsive.json
@@ -212,7 +212,7 @@
           }
         },
         "500": {
-          "value": "24px",
+          "value": "22px",
           "responsive": {
             "1012px": {
               "value": "32px"
@@ -220,7 +220,7 @@
           }
         },
         "600": {
-          "value": "28px",
+          "value": "24px",
           "responsive": {
             "768px": {
               "value": "32px"
@@ -231,7 +231,7 @@
           }
         },
         "700": {
-          "value": "32px",
+          "value": "28px",
           "responsive": {
             "768px": {
               "value": "36px"

--- a/packages/design-tokens/src/tokens/functional/typography/typography.json
+++ b/packages/design-tokens/src/tokens/functional/typography/typography.json
@@ -109,7 +109,7 @@
           }
         },
         "500": {
-          "value": "24px",
+          "value": "22px",
           "responsive": {
             "1012px": {
               "value": "32px"
@@ -117,7 +117,7 @@
           }
         },
         "600": {
-          "value": "28px",
+          "value": "24px",
           "responsive": {
             "768px": {
               "value": "32px"
@@ -128,7 +128,7 @@
           }
         },
         "700": {
-          "value": "32px",
+          "value": "28px",
           "responsive": {
             "768px": {
               "value": "36px"


### PR DESCRIPTION
Fixes duplicate type scale sizes on mobile viewports, as pointed out by @jesussandreas on the Figma implementation.