### PR TITLE
Fix incorrectly appearing click targets in accordion content

### DIFF
--- a/.changeset/bright-actors-agree.md
+++ b/.changeset/bright-actors-agree.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed incorrect click target area for Accordion answers

--- a/packages/react/src/Accordion/Accordion.module.css
+++ b/packages/react/src/Accordion/Accordion.module.css
@@ -143,6 +143,8 @@ details[open] > .Accordion__summary.Accordion__summary--default .Accordion__summ
 details[open] > .Accordion__content {
   padding-bottom: var(--base-size-24);
   animation: fade-in 0.5s;
+  position: relative;
+  z-index: 0;
 }
 
 .Accordion__summary--default + .Accordion__content {


### PR DESCRIPTION
## Summary

Closes #432 

Removes incorrect click target areas in accordion toggles from appearing above the subsequent content.

First line of the content will no longer open/close the accordion item.

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Review storybook examples


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">


https://github.com/primer/brand/assets/13340707/3e1d0a9a-8370-4c44-a95d-e18e7b80cf66



 </td>
<td valign="top">


https://github.com/primer/brand/assets/13340707/10ed90cd-5660-40dd-9b45-e21dbe2152f9



</td>
</tr>
</table>
