### PR TITLE
[Card] Add default height 100%

### DIFF
--- a/.changeset/giant-wasps-check.md
+++ b/.changeset/giant-wasps-check.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Adds default height to `Card` to align vertical size when using `Grid` or `Stack` components as a wrappers.

--- a/packages/react/src/Card/Card.features.stories.tsx
+++ b/packages/react/src/Card/Card.features.stories.tsx
@@ -189,7 +189,7 @@ export const Stacked: StoryFn<typeof Card> = () => {
       {fixtureData.map(({heading, description, href, icon, iconColor}, id) => {
         return (
           <Grid.Column key={id} span={{small: 6, medium: 6, large: 3, xlarge: 3}}>
-            <Card key={id} href={href} style={{height: '100%'}}>
+            <Card key={id} href={href}>
               <Card.Icon icon={icon} hasBackground color={iconColor} />
               <Card.Heading>{heading}</Card.Heading>
               <Card.Description>{description}</Card.Description>

--- a/packages/react/src/Card/Card.module.css
+++ b/packages/react/src/Card/Card.module.css
@@ -18,6 +18,7 @@
   flex: auto;
   grid-template-rows: auto auto auto auto 1fr;
   position: relative;
+  height: 100%;
 }
 
 .Card:focus-within {


### PR DESCRIPTION
## Summary

Adds default height to Card to align vertical size when using Grid or Stack components as a wrappers.

## List of notable changes:

- **added** default height 100% to Card

## What should reviewers focus on?

- Cards in the [storybook Stacked example](https://primer-81790c4190-26139705.drafts.github.io/storybook/?path=/story/components-card-features--stacked) are always aligned in different viewports:


## Supporting resources (related issues, external links, etc):

- https://github.slack.com/archives/C04E44ZPNEA/p1695744098808819

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
