### PR TITLE
SubdomainNavbar Mobile view fixes 

### DIFF
--- a/packages/react/src/SubdomainNavBar/NavigationVisbilityObserver.tsx
+++ b/packages/react/src/SubdomainNavBar/NavigationVisbilityObserver.tsx
@@ -11,13 +11,15 @@ import styles from './SubdomainNavBar.module.css'
 import {useKeyboardEscape} from '../hooks/useKeyboardEscape'
 import {useWindowSize} from '../hooks/useWindowSize'
 
-export function NavigationVisbilityObserver({children, className, ...rest}) {
+export function NavigationVisbilityObserver({children, className, onlyNarrow = false, ...rest}) {
   const navRef = useRef<HTMLUListElement | null>(null)
   const [visibilityMap] = useVisibilityObserver(navRef, children)
   const {width} = useWindowSize()
 
   const showOverflow = Object.values(visibilityMap).includes(false)
+  const breakpoint = 768
 
+  if (width && width > breakpoint && onlyNarrow) return null
   return (
     <ul className={clsx(styles['SubdomainNavBar-primary-nav-list'], className)} ref={navRef} {...rest}>
       {React.Children.map(children, child => {
@@ -25,11 +27,11 @@ export function NavigationVisbilityObserver({children, className, ...rest}) {
           className: clsx(
             child.props.className,
             width &&
-              width >= 768 &&
+              width >= breakpoint &&
               !!visibilityMap[child.props['data-navitemid']] &&
               styles['SubdomainNavBar-primary-nav-list-item--visible'],
             width &&
-              width >= 768 &&
+              width >= breakpoint &&
               !visibilityMap[child.props['data-navitemid']] &&
               styles['SubdomainNavBar-primary-nav-list-item--invisible'],
           ),

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -7,6 +7,7 @@ import {NavigationVisbilityObserver} from './NavigationVisbilityObserver'
 import {useOnClickOutside} from '../hooks/useOnClickOutside'
 import {useFocusTrap} from '../hooks/useFocusTrap'
 import {useKeyboardEscape} from '../hooks/useKeyboardEscape'
+import {useWindowSize} from '../hooks/useWindowSize'
 
 /**
  * Design tokens
@@ -77,6 +78,7 @@ function Root({
   titleHref = '/',
   ...rest
 }: SubdomainNavBarProps) {
+  // const {width} = useWindowSize()
   const [menuHidden, setMenuHidden] = useState(true)
   const [searchVisible, setSearchVisible] = useState(false)
 
@@ -183,7 +185,6 @@ function Root({
                 }
               })
               .filter(Boolean)}
-
             {hasLinks && (
               <button
                 aria-expanded={!menuHidden}
@@ -205,7 +206,10 @@ function Root({
             )}
 
             {hasLinks && !menuHidden && (
-              <NavigationVisbilityObserver className={clsx(styles['SubdomainNavBar-primary-nav-list--visible'])}>
+              <NavigationVisbilityObserver
+                onlyNarrow={true}
+                className={clsx(styles['SubdomainNavBar-primary-nav-list--visible'])}
+              >
                 {menuItems}
               </NavigationVisbilityObserver>
             )}


### PR DESCRIPTION
## Summary

This PR fixes 2 issues:
1. If the sandwich menu was open on narrow screen sizes, and then the viewport was widened, nav items would be duplicated.
2. If there were too many nav items for the height of the viewport, they would overflow into the CTA actions. (#405)

## List of notable changes:



- **added** `showOnlyOnNarrow: boolean` to `NavigationVisbilityObserver`. This is an internal component, and this prop makes it so that that the `NavigationVisbilityObserver` will not render anything on wide viewports

## What should reviewers focus on?

Verify that the SubdomainNavBar is working as intended, and there were no unintended side-effect changes.


## Steps to test:



1. Go to `MobileMenuOpenManyItems` in Storybook and verify that it is working as intended.
1. Verify that it is working as intended.
1. Ensure all other stories are unchanged

## Supporting resources (related issues, external links, etc):

-
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->
![CleanShot 2023-10-05 at 12 50 22@2x](https://github.com/primer/brand/assets/12260694/aceccbee-c7dc-4f7a-8f9b-192453ad1a76)

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->
![CleanShot 2023-10-05 at 12 50 42@2x](https://github.com/primer/brand/assets/12260694/72e76ad4-faf5-4fdb-ad51-d921a0869366)

</td>
</tr>
</table>
