### PR TITLE
Add lib export for useWindowSize and add forwardRef to hero children

### DIFF
--- a/.changeset/export-windowsize-hook.md
+++ b/.changeset/export-windowsize-hook.md
@@ -1,0 +1,16 @@
+---
+'@primer/react-brand': patch
+---
+
+Added hook for `useWindowSize` to the library exports.
+
+Usage example:
+
+```js
+import {useWindowSize} from '@primer/react-brand'
+```
+
+```jsx
+const {width, height, isXSmall, isSmall, isMedium, isLarge, isXLarge, isXXLarge, currentBreakpointSize} =
+  useWindowSize()
+```

--- a/.changeset/fix-hero-refs.md
+++ b/.changeset/fix-hero-refs.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Enabled `forwardRef` on `Hero.Description`, `Hero.Label` and `Hero.Image`.

--- a/packages/react/src/Hero/Hero.tsx
+++ b/packages/react/src/Hero/Hero.tsx
@@ -104,32 +104,44 @@ type HeroDescriptionProps = {
   weight?: TextWeightVariants | ResponsiveWeightMap
 } & BaseProps<HTMLParagraphElement>
 
-function HeroDescription({size = '200', weight, children}: PropsWithChildren<HeroDescriptionProps>) {
-  return (
-    <Text className={styles['Hero-description']} as="p" size={size} weight={weight}>
-      {children}
-    </Text>
-  )
-}
+const HeroDescription = forwardRef<HTMLParagraphElement, PropsWithChildren<HeroDescriptionProps>>(
+  ({size = '200', weight, children}: PropsWithChildren<HeroDescriptionProps>, ref) => {
+    return (
+      <Text ref={ref} className={styles['Hero-description']} as="p" size={size} weight={weight}>
+        {children}
+      </Text>
+    )
+  },
+)
 
 type HeroImageProps = {
   position?: 'inline-end' | 'block-end'
 } & ImageProps &
   BaseProps<HTMLImageElement>
 
-function HeroImage({position = 'block-end', className, ...rest}: PropsWithChildren<HeroImageProps>) {
-  return <Image className={clsx(styles['Hero-image'], styles[`Hero-image--pos-${position}`], className)} {...rest} />
-}
+const HeroImage = forwardRef<HTMLImageElement, HeroImageProps>(
+  ({position = 'block-end', className, ...rest}: PropsWithChildren<HeroImageProps>, ref) => {
+    return (
+      <Image
+        ref={ref}
+        className={clsx(styles['Hero-image'], styles[`Hero-image--pos-${position}`], className)}
+        {...rest}
+      />
+    )
+  },
+)
 
 type HeroLabelProps = LabelProps & BaseProps<HTMLSpanElement>
 
-function HeroLabel({children, ...rest}: PropsWithChildren<HeroLabelProps>) {
-  return (
-    <Label className={styles['Hero-label']} {...rest}>
-      {children}
-    </Label>
-  )
-}
+const HeroLabel = forwardRef<HTMLSpanElement, HeroLabelProps>(
+  ({children, ...rest}: PropsWithChildren<HeroLabelProps>, ref) => {
+    return (
+      <Label ref={ref} className={styles['Hero-label']} {...rest}>
+        {children}
+      </Label>
+    )
+  },
+)
 
 type RestrictedPolymorphism =
   | (BaseProps<HTMLAnchorElement> & {as?: 'a'})

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -36,3 +36,6 @@ export * from './VideoPlayer'
 export * from './LogoSuite'
 export * from './Timeline'
 export * from './Bento'
+
+// hooks
+export * from './hooks/useWindowSize'


### PR DESCRIPTION
## Summary

Adding missing export for `useWindowSize`, which is required for side-by-side recipes. Also backfills missing `forwardRef` references in Hero. 



## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile). 
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Just a code review


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:


n/a