### PR TITLE
Update aria-label on GitHub link

### DIFF
--- a/.changeset/perfect-mirrors-report.md
+++ b/.changeset/perfect-mirrors-report.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Changed the aria-label for the GitHub link in the footer

--- a/packages/react/src/MinimalFooter/MinimalFooter.tsx
+++ b/packages/react/src/MinimalFooter/MinimalFooter.tsx
@@ -260,7 +260,7 @@ function SocialLogomarks({socialLinks, logoHref}: SocialLogomarksProps) {
             <a
               href={logoHref}
               data-analytics-event='{"category":"Footer","action":"go to home","label":"text:home"}'
-              aria-label="Go to GitHub homepage"
+              aria-label="GitHub"
             >
               <LogoGithubIcon fill={colorMode === ColorModesEnum.DARK ? 'white' : 'black'} size="medium" />
             </a>


### PR DESCRIPTION
## Summary

Changes the `aria-label` on the GitHub link in the footer.

Solves #387 and https://github.com/github/accessibility-audits/issues/5252

## List of notable changes:

- Changes the `aria-label` on the GitHub link in the footer.


## What should reviewers focus on?

That the `aria-label` matches the visual text (`"GitHub"`)

## Steps to test:

1. Go to the [minimal footer story](https://primer-0a3609e6d8-26139705.drafts.github.io/storybook/?path=/story/components-minimalfooter--default)
2. Find the `GitHub` mark in the footer and right-click -> Inspect Source
3. Ensure that the `aria-label` is `GitHub`.

## Supporting resources (related issues, external links, etc):

- https://github.com/github/accessibility-audits/issues/5252
- #387

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

N/A. No visual changes.
