### PR TITLE
SectionIntro – Image updates and minor changes

### DIFF
--- a/apps/docs/content/components/SectionIntro/index.mdx
+++ b/apps/docs/content/components/SectionIntro/index.mdx
@@ -9,7 +9,7 @@ export default ComponentLayout
 
 ## Anatomy
 
-![An image displaying a section intro with a title, description and a link.](https://github.com/primer/brand/assets/13340707/aeb3216e-a22c-4a98-b268-31d9ab7990cc)
+![An image displaying a section intro with a title, description and a link.](https://github.com/primer/brand/assets/6951037/8b973760-6ddc-441a-a36a-8c4c282bfdcf)
 
 - Label: An optional label to provide leading context to the section intro.
 - Heading: The title of the section.
@@ -26,14 +26,14 @@ Sections are designed to be self-contained, meaning they should make sense and b
 
 <DoDontContainer>
   <Do>
-    <img src="https://github.com/primer/brand/assets/912236/eb8c5797-1704-4a92-8f9f-69c0b895f2b7" />
+    <img src="https://github.com/primer/brand/assets/6951037/c6266e92-ea5a-4d75-a48e-0f427288331c7" />
     <Caption>
       Use section intros to introduce a new topic in a section and combine it
       with other components and content.
     </Caption>
   </Do>
   <Dont>
-    <img src="https://github.com/primer/brand/assets/912236/7890cbc2-e588-4399-b903-78f2e581d05b" />
+    <img src="https://github.com/primer/brand/assets/6951037/f9ee0d4f-5ad5-4b31-9a8c-6533cd199096" />
     <Caption>
       Don't use it as standalone element followed by other section intros.
     </Caption>
@@ -48,14 +48,14 @@ Section intro can be aligned to the start or center of the page. By default, the
 
 <DoDontContainer stacked>
   <Do>
-    <img src="https://github.com/primer/brand/assets/912236/1d2b0be3-e696-4d4d-9b65-e8bced96fe04" />
+    <img src="https://github.com/primer/brand/assets/6951037/06f00622-baf4-45b8-b044-b90642d837e9" />
     <Caption>
       Use center alignment if the section intro is paired with a centered image
       or visual asset.
     </Caption>
   </Do>
   <Dont>
-    <img src="https://github.com/primer/brand/assets/912236/fa2f7c30-dd11-4b56-82ed-dbcb76245c6e" />
+    <img src="https://github.com/primer/brand/assets/6951037/67da7e5d-4535-4f80-bbce-b6e0a7708dee" />
     <Caption>
       Don't use center alignment if the section intro is paired with an image or
       visual asset aligned to the left.

--- a/apps/docs/content/components/SectionIntro/index.mdx
+++ b/apps/docs/content/components/SectionIntro/index.mdx
@@ -26,7 +26,7 @@ Sections are designed to be self-contained, meaning they should make sense and b
 
 <DoDontContainer>
   <Do>
-    <img src="https://github.com/primer/brand/assets/6951037/c6266e92-ea5a-4d75-a48e-0f427288331c7" />
+    <img src="https://github.com/primer/brand/assets/6951037/6cfa8d47-7fe6-4ead-8c3b-d1ccf5e2fc36" />
     <Caption>
       Use section intros to introduce a new topic in a section and combine it
       with other components and content.

--- a/apps/docs/content/components/SectionIntro/index.mdx
+++ b/apps/docs/content/components/SectionIntro/index.mdx
@@ -63,6 +63,12 @@ Section intro can be aligned to the start or center of the page. By default, the
   </Dont>
 </DoDontContainer>
 
+### Emphasized text
+
+Section intro allows for only one portion of the heading to be highlighted. Use strategically to highlight key ideas and guide effectively through a story.
+
+![An image displaying a section intro with emphasized text.](https://github.com/primer/brand/assets/6951037/d583e4f4-7ce6-426d-be08-5afc704ac611)
+
 ## Related components
 
 - [Hero](/components/Hero): Use the hero component to render a full-width banner on a webpage.


### PR DESCRIPTION
## Summary

- Changes images for the SectionIntro guidelines page.
- Added emphasized text option with image and brief guidelines.

🔗 https://primer-176d4c1f8e-26139705.drafts.github.io/components/SectionIntro

@nsolerieu I took the liberty to add what I think is a good basic description of how the emphasized text variation should be used and an image with content from the Enterprise landing page. 

Adding here for visibility: 

Section intro allows for only one portion of the heading to be highlighted. Use strategically to highlight key ideas and guide effectively through a story.

<img width="1174" alt="emphasis" src="https://github.com/primer/brand/assets/6951037/72509fbf-2517-45bd-9892-fb46d462b050">


