### PR TITLE
SubdomainNavbarMenu Focus Trapping

### DIFF
--- a/.changeset/light-kings-clap.md
+++ b/.changeset/light-kings-clap.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Improved SubdomainNavBar keyboard navigation

--- a/.changeset/light-kings-clap.md
+++ b/.changeset/light-kings-clap.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Improved SubdomainNavBar keyboard navigation
+Improved keyboard navigation in the `SubdomainNavBar` mobile menu using focus trapping.

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -84,6 +84,9 @@ function Root({
 
   const handleMobileMenuClick = () => setMenuHidden(!menuHidden)
   const handleSearchVisibility = () => setSearchVisible(!searchVisible)
+  const focusTrapRef = useRef<HTMLDivElement | null>(null)
+
+  useFocusTrap({containerRef: focusTrapRef, restoreFocusOnCleanUp: true, disabled: menuHidden})
 
   useEffect(() => {
     if (isMedium) {
@@ -137,6 +140,7 @@ function Root({
     >
       <header className={clsx(styles['SubdomainNavBar'], className)} data-testid={testIds.root} {...rest}>
         <div
+          ref={focusTrapRef}
           className={clsx(
             styles['SubdomainNavBar-inner-container'],
             searchVisible && styles['SubdomainNavBar-inner-container--search-open'],

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -87,6 +87,9 @@ function Root({
   const focusTrapRef = useRef<HTMLDivElement | null>(null)
 
   useFocusTrap({containerRef: focusTrapRef, restoreFocusOnCleanUp: true, disabled: menuHidden})
+  useKeyboardEscape(() => {
+    setMenuHidden(true)
+  })
 
   useEffect(() => {
     if (isMedium) {


### PR DESCRIPTION
## Summary

Keyboard nav around the Subdomain Navbar now correctly loops after you get to the end of the menu

Fixes #369 and https://github.com/github/accessibility-audits/issues/5232

## List of notable changes:

**Updated** SubdomainNavbar

## What should reviewers focus on?


- That keyboard navigation around the SubdomainNavBar works correctly

## Steps to test:


1. Go to the SubdomainNavbar story (one of the mobile ones)
1. Open the sandwich menu
1. Use the tab key to navigate the menu items

## Supporting resources (related issues, external links, etc):

- https://github.com/github/accessibility-audits/issues/5232
- #369 

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

https://github.com/primer/brand/assets/12260694/a5158796-cbe8-40b0-b959-0803d74e0cf3


<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">



https://github.com/primer/brand/assets/12260694/08fa7260-488c-4261-aa06-797bcf530a1d



<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
