### PR TITLE
Add locally scoped font-smoothing to heading

### DIFF
--- a/.changeset/spicy-kiwis-unite.md
+++ b/.changeset/spicy-kiwis-unite.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Replaced global font-smoothing options with more targetted, and locally scoped usage in dark mode Heading instances only.

--- a/packages/react/src/Heading/Heading.module.css
+++ b/packages/react/src/Heading/Heading.module.css
@@ -2,6 +2,11 @@
   color: var(--brand-color-text-default);
 }
 
+[data-color-mode='dark'] .Heading {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 .Heading-font--mona-sans {
   font-family: var(--brand-heading-fontFamily);
 }

--- a/packages/react/src/css/reset.css
+++ b/packages/react/src/css/reset.css
@@ -38,11 +38,6 @@ html:focus-within {
   scroll-behavior: smooth;
 }
 
-html {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 /* Set core body defaults */
 body {
   min-height: 100vh;


### PR DESCRIPTION
## Summary

Removes the global font-smoothing option previously introduced in #461.

Replaces it with a more targeted level of selector specificity. It now **only applies to Heading components in dark mode**, which is the original use-case that this setting was intending to solve for. Applying it globally has caused a regression to the dotcom global navigation, so we can't enable it globally.

Font smoothing settings also have [the most impact on dark backgrounds](https://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/).



## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile). 
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Review before/afters

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Use the inspector on this story to enable/disable the setting to see the difference.


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
Font smoothing enabled globally for all text, including dark mode headings


![Screenshot 2023-10-25 at 17 26 09](https://github.com/primer/brand/assets/13340707/ff53252d-8110-46ac-bd51-6a32861a3489)


 </td>
<td valign="top">

Font smoothing continues to be enabled for dark mode headings only

![Screenshot 2023-10-25 at 17 26 01](https://github.com/primer/brand/assets/13340707/91c2f8ab-1b74-42f0-9375-f7771efb9ec7)


</td>
</tr>
</table>

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
Font smoothing enabled globally for all text, including light mode headings

![Screenshot 2023-10-25 at 17 24 49](https://github.com/primer/brand/assets/13340707/2984a096-2ca9-4ba4-9589-f5da68655c7a)



 </td>
<td valign="top">
Font smoothing not applicable to headings in light mode anymore

![Screenshot 2023-10-25 at 17 24 44](https://github.com/primer/brand/assets/13340707/2f2e4aeb-c32b-4538-953a-84416f2963fd)


</td>
</tr>
</table>
