### PR TITLE
Remove erroneous style in accordion

### DIFF
--- a/packages/react/src/Accordion/Accordion.module.css
+++ b/packages/react/src/Accordion/Accordion.module.css
@@ -1,7 +1,6 @@
 .Accordion {
   box-sizing: border-box;
   position: relative;
-  background: var(--color-scale-blue-0);
 }
 
 .Accordion--default {


### PR DESCRIPTION
## Summary

Part of fixing https://github.com/primer/brand/pull/486

Removes a stray line of CSS that shouldn't be there. Found during dotcom regression test. This is a product token, which is why it doesn't appear in our visual tests or Storybook, only in dotcom.



## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
