### PR TITLE
Update bento docs for indicate a11y review passed, and promote to alpha

### DIFF
--- a/apps/docs/content/components/Bento.mdx
+++ b/apps/docs/content/components/Bento.mdx
@@ -1,6 +1,7 @@
 ---
 title: Bento
-status: Experimental
+status: Alpha
+a11yReviewed: true
 source: https://github.com/primer/brand/blob/main/packages/react/src/Bento/Bento.tsx
 storybook: '/brand/storybook/?path=/story/components-bento--default'
 description: Use the bento to present content in a responsive grid layout.
@@ -9,8 +10,6 @@ description: Use the bento to present content in a responsive grid layout.
 ```js
 import {Bento} from '@primer/react-brand'
 ```
-
-## Examples
 
 ### Default
 
@@ -28,6 +27,8 @@ import {Bento} from '@primer/react-brand'
 ```
 
 ### Example layout
+
+## Examples
 
 ```jsx live
 <Box
@@ -59,6 +60,12 @@ import {Bento} from '@primer/react-brand'
 Use `columnSpan`, `rowSpan`, `columnStart`, `rowStart`, `flow`, `verticalAlign`, `horizontalAlign` with an `Object` of breakpoint-specific keys and values corresponding to each type to enable responsive behavior for each of these properties.
 
 Breakpoints use `min-width`, where it will also apply your chosen `span` value to all larger breakpoints.
+
+<Note>
+  Bento items can render in a different source order to what is presented
+  visually. It's important to ensure that the content of each item is
+  self-contained and can be read independently of its adjacent items.
+</Note>
 
 ```jsx live
 <Box


### PR DESCRIPTION
## Summary

Part of https://github.com/github/primer/issues/2746#issuecomment-1792503715

Promotes Bento to alpha following successful a11y review

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Promotes Bento to `alpha`
- Adds note about source order, which applies when bento is used in responsive configurations
- Marked as a11y reviewed


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:


<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![Screenshot 2023-11-10 at 15 28 12](https://github.com/primer/brand/assets/13340707/ce1605c3-d54a-43d9-96bb-c2ff77ec69eb)


 </td>
<td valign="top">


![Screenshot 2023-11-10 at 15 26 11](https://github.com/primer/brand/assets/13340707/75ccfe66-490c-4096-8b4d-42c8beb3e09d)

</td>
</tr>
</table>

Message about source order:

![Screenshot 2023-11-10 at 15 26 25](https://github.com/primer/brand/assets/13340707/ce96626b-f2d0-4658-9139-dc45c5742648)

