### PR TITLE
Visuals in TextInput props should also be components

### DIFF
--- a/packages/react/src/forms/TextInput/TextInput.stories.tsx
+++ b/packages/react/src/forms/TextInput/TextInput.stories.tsx
@@ -104,8 +104,8 @@ export const Playground: StoryFn<typeof TextInput> = args => (
   <TextInput
     aria-label="Standalone text input"
     {...args}
-    leadingVisual={args.leadingVisual ? CheckIcon : undefined}
-    trailingVisual={args.trailingVisual ? SearchIcon : undefined}
+    leadingVisual={args.leadingVisual ? <CheckIcon /> : undefined}
+    trailingVisual={args.trailingVisual ? <SearchIcon /> : undefined}
   />
 )
 


### PR DESCRIPTION
## Summary

Changing props from Objects to JSX in #489, TextInput visuals seem to have been missed in the stories.

## List of notable changes:

Fixes stories for TextInput

## What should reviewers focus on?

Do the icons now appear correctly in the TextInput stories

## Steps to test:

1. Go to the TextInput storybook
2. Enable the leading and trailing visuals.
3. See that they now work.

## Supporting resources (related issues, external links, etc):



## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->
![CleanShot 2023-11-13 at 09 37 07@2x](https://github.com/primer/brand/assets/12260694/cd1564c4-dd05-4a60-bdad-fe1e5c0663b2)

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->
![CleanShot 2023-11-13 at 09 35 34@2x](https://github.com/primer/brand/assets/12260694/ea78ec78-fd42-409a-a7eb-fc572a928e5d)

</td>
</tr>
</table>
