### PR TITLE
Remove unused ActionMenu color tokens

### DIFF
--- a/packages/design-tokens/src/tokens/functional/components/action-menu/colors.js
+++ b/packages/design-tokens/src/tokens/functional/components/action-menu/colors.js
@@ -2,20 +2,6 @@ module.exports = {
   brand: {
     ActionMenu: {
       color: {
-        border: {
-          rest: {
-            value: 'var(--brand-color-border-default)',
-            dark: 'var(--brand-color-border-default)',
-          },
-          hover: {
-            value: 'var(--base-color-scale-black-0)',
-            dark: 'var(--base-color-scale-white-0)',
-          },
-          active: {
-            value: 'var(--base-color-scale-black-0)',
-            dark: 'var(--base-color-scale-white-0)',
-          },
-        },
         item: {
           hover: {
             value: 'var(--base-color-scale-gray-1)',

--- a/packages/react/src/ActionMenu/ActionMenu.module.css
+++ b/packages/react/src/ActionMenu/ActionMenu.module.css
@@ -76,7 +76,6 @@
   white-space: pre;
   list-style: none;
   border-radius: var(--brand-borderRadius-medium);
-  border-color: var(--brand-ActionMenu-color-border-rest);
 }
 
 .ActionMenu__item[aria-disabled='true'] {


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/2097

As I'm auditing all color tokens, I came across these values that are never used (and I don't see a purpose for them). I will be aligning ActionMenu colors with `control` colors separately. 