### PR TITLE
Rename `Image` token + refactor CSS

### DIFF
--- a/.changeset/perfect-boxes-fetch.md
+++ b/.changeset/perfect-boxes-fetch.md
@@ -1,6 +1,6 @@
 ---
-"@primer/brand-primitives": patch
-"@primer/react-brand": patch
+"@primer/brand-primitives": minor
+"@primer/react-brand": minor
 ---
 
 Renames --brand-Image-ratio-custom to --brand-image-aspectRatio

--- a/.changeset/perfect-boxes-fetch.md
+++ b/.changeset/perfect-boxes-fetch.md
@@ -1,0 +1,6 @@
+---
+"@primer/brand-primitives": patch
+"@primer/react-brand": patch
+---
+
+Renames --brand-Image-ratio-custom to --brand-image-aspectRatio

--- a/packages/design-tokens/src/tokens/functional/components/image/base.json
+++ b/packages/design-tokens/src/tokens/functional/components/image/base.json
@@ -1,10 +1,8 @@
 {
   "brand": {
-    "Image": {
-      "ratio": {
-        "custom": {
-          "value": "auto"
-        }
+    "image": {
+      "aspectRatio": {
+        "value": "auto"
       }
     }
   }

--- a/packages/react/src/Image/Image.module.css
+++ b/packages/react/src/Image/Image.module.css
@@ -8,21 +8,21 @@
 }
 
 .Image--aspect-ratio-custom {
-  aspect-ratio: var(--brand-Image-ratio-custom);
+  aspect-ratio: var(--brand-image-aspectRatio);
 }
 
 .Image--aspect-ratio-1-1 {
-  aspect-ratio: 1 / 1;
+  --brand-image-aspectRatio: 1 / 1;
 }
 
 .Image--aspect-ratio-16-9 {
-  aspect-ratio: 16 / 9;
+  --brand-image-aspectRatio: 16 / 9;
 }
 
 .Image--aspect-ratio-16-10 {
-  aspect-ratio: 16 / 10;
+  --brand-image-aspectRatio: 16 / 10;
 }
 
 .Image--aspect-ratio-4-3 {
-  aspect-ratio: 4 / 3;
+  --brand-image-aspectRatio: 4 / 3;
 }


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/2097

Tokens renamed:
--brand-Image-ratio-custom → --brand-image-aspectRatio

In order for this name to make sense/fit our convention, I modified the CSS to reference the token and then reset the value for each prop.
