### PR TITLE
Fix missing ButtonGroup import in docs

### DIFF
--- a/apps/docs/content/components/ButtonGroup/react.mdx
+++ b/apps/docs/content/components/ButtonGroup/react.mdx
@@ -13,7 +13,7 @@ import {ButtonSizes} from '@primer/react-brand'
 import {PropTableValues} from '../../../src/components'
 
 ```js
-import {Button} from '@primer/react-brand'
+import {ButtonGroup, Button} from '@primer/react-brand'
 ```
 
 ## Examples


### PR DESCRIPTION
## Summary

Adds missing React import in ButtonGroup documentation

Internal-user reported.

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![Screenshot 2023-12-11 at 12 33 13](https://github.com/primer/brand/assets/13340707/a347b307-806c-4e9b-a817-02ec31f1a99a)


 </td>
<td valign="top">

![Screenshot 2023-12-11 at 12 33 26](https://github.com/primer/brand/assets/13340707/e89fe421-4873-45a2-92bd-5944d822a8bf)


</td>
</tr>
</table>
