### PR TITLE
Reduced spacing between buttons in a button group to 0.25 rem

### DIFF
--- a/.changeset/tasty-shrimps-cross.md
+++ b/.changeset/tasty-shrimps-cross.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Reduced spacing between buttons in a button group to 0.25 rem

--- a/packages/react/src/ButtonGroup/ButtonGroup.module.css
+++ b/packages/react/src/ButtonGroup/ButtonGroup.module.css
@@ -1,6 +1,6 @@
 .ButtonGroup {
   display: inline-flex;
-  gap: var(--base-size-8);
+  gap: var(--base-size-4);
   flex-direction: row;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
## Summary

Potentially fixes #504 

Not sure if it should remain 0.5 rem for large buttons, happy to update this PR if so.

Also, I noticed that the `buttonSize` and `buttonAs` controls don't work in the storybook so I've created another pr for this [here](https://github.com/primer/brand/pull/512).

I couldn't get playwright to work reliably so I've not updated snapshots, but I think there's a pipeline workflow for this.

Not sure what I'm doing with changeset either so if it needs to look any different, please let me know 😄

## List of notable changes:

Reduced spacing between buttons in a button group to 0.25 rem to match the designs

## What should reviewers focus on?

Spacing between the buttons in a Button Group

## Steps to test:

1. Open storybook and go to story/components-buttongroup--playground
2. Inspect the spacing between buttons

Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/primer/brand/assets/7106600/6bd61050-9645-4902-8b79-1450b5e9919f)

 </td>
<td valign="top">

![image](https://github.com/primer/brand/assets/7106600/c562a79f-99f8-4f2b-b58f-944c78ca1714)

</td>
</tr>
</table>
