### PR TITLE
Fixed radio controls for stories

### DIFF
--- a/.changeset/fresh-apes-marry.md
+++ b/.changeset/fresh-apes-marry.md
@@ -1,0 +1,5 @@
+---
+'@primer/brand-storybook': patch
+---
+
+Fixed radio controls for stories

--- a/.changeset/fresh-apes-marry.md
+++ b/.changeset/fresh-apes-marry.md
@@ -1,5 +1,0 @@
----
-'@primer/brand-storybook': patch
----
-
-Fixed radio controls for stories

--- a/packages/react/src/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/Avatar/Avatar.stories.tsx
@@ -17,16 +17,16 @@ export default {
     size: {
       description: 'The size of the Avatar',
       control: {
-        type: 'radio',
-        options: AvatarSizes,
+        type: 'inline-radio',
       },
+      options: AvatarSizes,
     },
     shape: {
       description: 'The shape of the Avatar',
       control: {
-        type: 'radio',
-        options: AvatarShapes,
+        type: 'inline-radio',
       },
+      options: AvatarShapes,
     },
     src: {
       description: 'The url of the image to display',

--- a/packages/react/src/Button/Button.stories.tsx
+++ b/packages/react/src/Button/Button.stories.tsx
@@ -33,7 +33,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
-      options: [...ButtonVariants],
+      options: ButtonVariants,
     },
     href: {
       name: 'href',
@@ -48,7 +48,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
-      options: [...ButtonSizes],
+      options: ButtonSizes,
     },
     children: {
       name: 'children',

--- a/packages/react/src/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/react/src/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,30 +1,30 @@
 import React from 'react'
 import {Meta, StoryFn} from '@storybook/react'
 import {ButtonGroup} from '.'
-import {Button} from '../Button'
+import {Button, ButtonSizes, defaultButtonSize} from '../Button'
 
 export default {
   title: 'Components/ButtonGroup',
   component: ButtonGroup,
   subcomponents: {Button},
   args: {
-    buttonSize: 'medium',
+    buttonSize: defaultButtonSize,
     buttonsAs: 'button',
   },
   argTypes: {
     buttonSize: {
       description: 'The size of the button elements',
       control: {
-        type: 'radio',
-        options: ['medium', 'large'],
+        type: 'inline-radio',
       },
+      options: ButtonSizes,
     },
     buttonsAs: {
       description: 'The HTML element the button is rendered as',
       control: {
-        type: 'radio',
-        options: ['button', 'a'],
+        type: 'inline-radio',
       },
+      options: ['button', 'a'],
     },
     children: {
       table: {

--- a/packages/react/src/CTABanner/CTABanner.stories.tsx
+++ b/packages/react/src/CTABanner/CTABanner.stories.tsx
@@ -16,9 +16,9 @@ export default {
     align: {
       description: 'The alignment of the content',
       control: {
-        type: 'radio',
-        options: ['start', 'center'],
+        type: 'inline-radio',
       },
+      options: ['start', 'center'],
     },
     hasBorder: {
       description: 'Toggle to show or hide the border',

--- a/packages/react/src/Card/Card.stories.tsx
+++ b/packages/react/src/Card/Card.stories.tsx
@@ -20,7 +20,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
-      options: [...CardIconColors],
+      options: CardIconColors,
     },
     iconHasBackground: {
       name: 'iconHasBackground',
@@ -41,7 +41,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
-      options: [...LabelColors],
+      options: LabelColors,
     },
     heading: {
       name: 'heading',

--- a/packages/react/src/ComparisonTable/ComparisonTable.stories.tsx
+++ b/packages/react/src/ComparisonTable/ComparisonTable.stories.tsx
@@ -20,8 +20,8 @@ export default {
       description: 'The HTML element used to render the root component.',
       control: {
         type: 'inline-radio',
-        options: ['section', 'large'],
       },
+      options: ['section', 'large'],
       table: {
         category: 'ComparisonTable',
       },
@@ -29,8 +29,8 @@ export default {
     variant: {
       control: {
         type: 'inline-radio',
-        options: ['undefined', 'default', 'minimal'],
       },
+      options: ['undefined', 'default', 'minimal'],
       table: {
         category: 'ComparisonTable',
       },

--- a/packages/react/src/EyebrowBanner/EyebrowBanner.stories.tsx
+++ b/packages/react/src/EyebrowBanner/EyebrowBanner.stories.tsx
@@ -69,7 +69,7 @@ export default {
       control: {
         type: 'inline-radio',
       },
-      options: [...EyebrowBannerIconColors],
+      options: EyebrowBannerIconColors,
       table: {
         category: 'EyebrowBanner.Visual',
       },

--- a/packages/react/src/Heading/Heading.stories.tsx
+++ b/packages/react/src/Heading/Heading.stories.tsx
@@ -47,31 +47,31 @@ Playground.argTypes = {
   },
   size: {
     control: {
-      type: 'radio',
+      type: 'inline-radio',
     },
     options: HeadingSizes,
   },
   weight: {
     control: {
-      type: 'radio',
+      type: 'inline-radio',
     },
     options: HeadingWeights,
   },
   stretch: {
     control: {
-      type: 'radio',
+      type: 'inline-radio',
     },
     options: HeadingStretch,
   },
   letterSpacing: {
     control: {
-      type: 'radio',
+      type: 'inline-radio',
     },
     options: HeadingLetterSpacing,
   },
   font: {
     control: {
-      type: 'radio',
+      type: 'inline-radio',
     },
     options: HeadingFontVariants,
   },

--- a/packages/react/src/Image/Image.stories.tsx
+++ b/packages/react/src/Image/Image.stories.tsx
@@ -29,16 +29,16 @@ export default {
     as: {
       description: 'Sets the underlying HTML element',
       control: {
-        type: 'radio',
-        options: ['img', 'picture'],
+        type: 'inline-radio',
       },
+      options: ['img', 'picture'],
     },
     aspectRatio: {
       description: 'Sets the image aspect ratio. A custom ratio can be provided in the design tokens.',
       control: {
-        type: 'radio',
-        options: ['1:1', '16:9', '16:10', '4:3', 'custom'],
+        type: 'inline-radio',
       },
+      options: ['1:1', '16:9', '16:10', '4:3', 'custom'],
     },
     width: {
       description: 'The width of the image',
@@ -56,17 +56,17 @@ export default {
       description:
         'The loading attribute specifies whether a browser should load an image immediately or to defer loading of off-screen images until for example the user scrolls near them.',
       control: {
-        type: 'radio',
-        options: ['eager', 'lazy'],
+        type: 'inline-radio',
       },
+      options: ['eager', 'lazy'],
     },
     decoding: {
       description:
         'Sets the image decoding strategy. Representing a hint given to the browser on how it should decode the image.',
       control: {
-        type: 'radio',
-        options: ['auto', 'sync', 'async'],
+        type: 'inline-radio',
       },
+      options: ['auto', 'sync', 'async'],
     },
   },
 } as Meta<typeof Image>

--- a/packages/react/src/Label/Label.stories.tsx
+++ b/packages/react/src/Label/Label.stories.tsx
@@ -16,15 +16,15 @@ export default {
       description: 'Color of Label',
       control: {
         type: 'inline-radio',
-        options: [...LabelColors],
       },
+      options: LabelColors,
     },
     size: {
       description: 'Size of Label',
       control: {
         type: 'inline-radio',
-        options: [...LabelSizes],
       },
+      options: LabelSizes,
     },
     children: {
       name: 'children',

--- a/packages/react/src/Pillar/Pillar.stories.tsx
+++ b/packages/react/src/Pillar/Pillar.stories.tsx
@@ -15,8 +15,8 @@ export default {
       description: 'Color of Icon',
       control: {
         type: 'inline-radio',
-        options: [...PillarIconColors],
       },
+      options: PillarIconColors,
     },
     heading: {
       name: 'heading',

--- a/packages/react/src/SectionIntro/SectionIntro.stories.tsx
+++ b/packages/react/src/SectionIntro/SectionIntro.stories.tsx
@@ -12,9 +12,9 @@ export default {
     align: {
       description: 'The alignment of the SectionIntro',
       control: {
-        type: 'radio',
-        options: ['start', 'center'],
+        type: 'inline-radio',
       },
+      options: ['start', 'center'],
     },
     children: {
       table: {

--- a/packages/react/src/Testimonial/Testimonial.stories.tsx
+++ b/packages/react/src/Testimonial/Testimonial.stories.tsx
@@ -20,9 +20,9 @@ export default {
   argTypes: {
     quoteMarkColor: {
       control: {
-        type: 'radio',
-        options: TestimonialQuoteMarkColors,
+        type: 'inline-radio',
       },
+      options: TestimonialQuoteMarkColors,
     },
     name: {
       control: {type: 'text'},
@@ -38,7 +38,7 @@ export default {
     },
     type: {
       options: ['avatar', 'logo'],
-      control: {type: 'radio'},
+      control: {type: 'inline-radio'},
     },
     width: {
       control: {

--- a/packages/react/src/Text/Text.stories.tsx
+++ b/packages/react/src/Text/Text.stories.tsx
@@ -27,13 +27,13 @@ Playground.argTypes = {
   },
   size: {
     control: {
-      type: 'radio',
+      type: 'inline-radio',
     },
     options: TextSizes,
   },
   weight: {
     control: {
-      type: 'radio',
+      type: 'inline-radio',
     },
     options: TextWeights,
   },

--- a/packages/react/src/animation/Animation.stories.tsx
+++ b/packages/react/src/animation/Animation.stories.tsx
@@ -35,7 +35,7 @@ Playground.argTypes = {
   variant: {
     control: {
       type: 'inline-radio',
-      options: AnimationVariants,
     },
+    options: AnimationVariants,
   },
 }

--- a/packages/react/src/list/UnorderedList/UnorderedList.stories.tsx
+++ b/packages/react/src/list/UnorderedList/UnorderedList.stories.tsx
@@ -19,9 +19,9 @@ export default {
     variant: {
       description: 'Specify alternative leading visuals for list items',
       control: {
-        type: 'radio',
-        options: ['default', 'checked'],
+        type: 'inline-radio',
       },
+      options: ['default', 'checked'],
     },
     data: {
       name: 'Data',

--- a/packages/react/src/recipes/FeaturePreviewLPs/FeaturePreviewLevelOne/FeaturePreviewLevelOne.stories.tsx
+++ b/packages/react/src/recipes/FeaturePreviewLPs/FeaturePreviewLevelOne/FeaturePreviewLevelOne.stories.tsx
@@ -38,7 +38,7 @@ export default {
     accentColor: {
       name: 'theme',
       control: 'radio',
-      options: [...Object.keys(themeDetailsMap)],
+      options: Object.keys(themeDetailsMap),
       table: {
         category: 'Theming',
       },


### PR DESCRIPTION
## Summary

I was playing around with storybook and I noticed that in a lot of playgrounds the controls didn't work.
I moved the `options` property so that they work again and I've made them all `inline-radio` for consistency, most other working examples use inline.

Not sure what I'm doing with changeset so if it needs to look any different, please let me know 😄

## List of notable changes:

* moved `options` property so that controls work
* made all radios inline
* removed some spread operators

## What should reviewers focus on?

Controls in storybook

## Steps to test:

Open storybook for one of the following components and use the controls:

* Avatar
* Button
* ButtonGroup
* CTABanner
* ComparisonTable
* Image
* Label
* Pillar
* SectionIntro
* Testimonial
* Animation
* UnorderedList

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/primer/brand/assets/7106600/1215ac16-ed94-4ab5-86fd-ea2e7a8d9857)

 </td>
<td valign="top">

![image](https://github.com/primer/brand/assets/7106600/0851845f-68c9-4939-8e52-d614f76efa7f)

</td>
</tr>
</table>
