### PR TITLE
Resolves #528 - spread props on HeroDescription

### DIFF
--- a/.changeset/dry-news-dress.md
+++ b/.changeset/dry-news-dress.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Add className to HeroDescription

--- a/.changeset/dry-news-dress.md
+++ b/.changeset/dry-news-dress.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Add className to HeroDescription
+Added `className` forwarding to `Hero.Description`

--- a/.changeset/lucky-pugs-agree.md
+++ b/.changeset/lucky-pugs-agree.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Spread remaining props on HeroDescription component to allow for custom classNames

--- a/.changeset/lucky-pugs-agree.md
+++ b/.changeset/lucky-pugs-agree.md
@@ -1,5 +1,0 @@
----
-'@primer/react-brand': patch
----
-
-Spread remaining props on HeroDescription component to allow for custom classNames

--- a/packages/react/src/Hero/Hero.tsx
+++ b/packages/react/src/Hero/Hero.tsx
@@ -105,9 +105,9 @@ type HeroDescriptionProps = {
 } & BaseProps<HTMLParagraphElement>
 
 const HeroDescription = forwardRef<HTMLParagraphElement, PropsWithChildren<HeroDescriptionProps>>(
-  ({size = '200', weight, children, ...rest}: PropsWithChildren<HeroDescriptionProps>, ref) => {
+  ({size = '200', weight, children, className}: PropsWithChildren<HeroDescriptionProps>, ref) => {
     return (
-      <Text ref={ref} className={styles['Hero-description']} as="p" size={size} weight={weight} {...rest}>
+      <Text ref={ref} className={clsx(styles['Hero-description'], className)} as="p" size={size} weight={weight}>
         {children}
       </Text>
     )

--- a/packages/react/src/Hero/Hero.tsx
+++ b/packages/react/src/Hero/Hero.tsx
@@ -105,9 +105,9 @@ type HeroDescriptionProps = {
 } & BaseProps<HTMLParagraphElement>
 
 const HeroDescription = forwardRef<HTMLParagraphElement, PropsWithChildren<HeroDescriptionProps>>(
-  ({size = '200', weight, children}: PropsWithChildren<HeroDescriptionProps>, ref) => {
+  ({size = '200', weight, children, ...rest}: PropsWithChildren<HeroDescriptionProps>, ref) => {
     return (
-      <Text ref={ref} className={styles['Hero-description']} as="p" size={size} weight={weight}>
+      <Text ref={ref} className={styles['Hero-description']} as="p" size={size} weight={weight} {...rest}>
         {children}
       </Text>
     )


### PR DESCRIPTION
## Summary

Minor change that resolves #528 - allowing users to add custom class names to the `HeroDescription` component

## List of notable changes:


- **added** `{...rest}` to `HeroDescription` to allow for custom class names to be used, this pattern is being used in `HeroHeading`, `HeroImage` etc.

## What should reviewers focus on?

One thing to consider is that when a custom class name is being used it will remove the `Hero-description` styles, this is existing behaviour on the `HeroHeading` therefore isn't a regression. 

## Steps to test:

1. Run Storybook
1. Modify the default `Hero.stories.tsx` file and include a `className` on the `HeroDescription` component.
1. Open the Hero story on storybook, inspect element and see class added to the hero description.


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

