### PR TITLE
Add interface guidelines for section intro content length

### DIFF
--- a/apps/docs/content/components/SectionIntro/index.mdx
+++ b/apps/docs/content/components/SectionIntro/index.mdx
@@ -45,7 +45,7 @@ Ensure the description is concise, keeping it to one paragraph. Use a link to di
 <DoDontContainer>
   <Do>
     <img src="https://github.com/primer/design/assets/175638/f8bd5ed9-d716-40c2-aef6-33979a87784d" />
-    <Caption>Use a short description to introduce the Selection.</Caption>
+    <Caption>Use a short description to introduce the section.</Caption>
   </Do>
   <Dont>
     <img src="https://github.com/primer/design/assets/175638/c2985d40-94c0-436c-9947-6c98611a0c77" />

--- a/apps/docs/content/components/SectionIntro/index.mdx
+++ b/apps/docs/content/components/SectionIntro/index.mdx
@@ -24,6 +24,8 @@ We recommmend using the section intro as a header of an HTML `<section>` element
 
 Sections are designed to be self-contained, meaning they should make sense and be meaningful even when viewed independently from the rest of the page. They provide a way to divide the content into meaningful and structured blocks.
 
+Ensure the description is concise, keeping it to one paragraph. Use a link to direct users to a page with further details if needed.
+
 <DoDontContainer>
   <Do>
     <img src="https://github.com/primer/brand/assets/6951037/6cfa8d47-7fe6-4ead-8c3b-d1ccf5e2fc36" />
@@ -37,6 +39,17 @@ Sections are designed to be self-contained, meaning they should make sense and b
     <Caption>
       Don't use it as standalone element followed by other section intros.
     </Caption>
+  </Dont>
+</DoDontContainer>
+
+<DoDontContainer>
+  <Do>
+    <img src="https://github.com/primer/design/assets/175638/f8bd5ed9-d716-40c2-aef6-33979a87784d" />
+    <Caption>Use a short description to introduce the Selection.</Caption>
+  </Do>
+  <Dont>
+    <img src="https://github.com/primer/design/assets/175638/c2985d40-94c0-436c-9947-6c98611a0c77" />
+    <Caption>Don't use section intro for long form content.</Caption>
   </Dont>
 </DoDontContainer>
 


### PR DESCRIPTION
Adds content length guidance and do's and don'ts for section intro.

[Docs preview](https://primer-72c54b3967-26139705.drafts.github.io/components/SectionIntro)