### PR TITLE
Add interface guidelines for river breakout content length

### DIFF
--- a/apps/docs/content/components/River/index.mdx
+++ b/apps/docs/content/components/River/index.mdx
@@ -168,7 +168,7 @@ Limit supplemental content to a maximum of 500 characters or two timeline items 
   <Do>
     <img
       alt=""
-      src="https://github.com/primer/design/assets/175638/e79ac03c-35d3-4d9d-868c-4eb16b65e39f"
+      src="https://github.com/primer/brand/assets/175638/c5879e94-09c3-4494-aa42-87543570dfb4"
     />
     <Caption>Limit supplemental timeline content to two items.</Caption>
   </Do>

--- a/apps/docs/content/components/River/index.mdx
+++ b/apps/docs/content/components/River/index.mdx
@@ -51,7 +51,8 @@ It is possible to use 2 or more following left or right river to create a simple
       src="https://github.com/primer/brand/assets/6951037/169d5c19-67f4-4f15-8e3b-80c877b34af1"
     />
     <Caption>
-      Don't break the flow in a stack of rivers that would otherwise stay aligned.
+      Don't break the flow in a stack of rivers that would otherwise stay
+      aligned.
     </Caption>
   </Dont>
 </DoDontContainer>
@@ -108,7 +109,7 @@ A single river component acts as a section and it should not include any child s
 
 A river breakout component has an image that fills the width of the container while providing more space for content such as text and lists.
 
-This is useful when you want to create a highlight which can be used to create more emphasis or simply break a monotonous vertical flow of left/right rivers. It can also be helpful on smaller viewports to avoid stacking two images or two chunks of text from adjacent river components. 
+This is useful when you want to create a highlight which can be used to create more emphasis or simply break a monotonous vertical flow of left/right rivers. It can also be helpful on smaller viewports to avoid stacking two images or two chunks of text from adjacent river components.
 
 As its name suggest, a river breakout should not be the first in the stack, it should be positioned in-between two standard rivers.
 
@@ -158,6 +159,25 @@ The headline in the river component must always be present, but the supplemental
       src="https://github.com/primer/brand/assets/2313998/62cf1c98-6b7d-46e9-a2d4-6d211a9103ad"
     />
     <Caption>Don't exclude the headline.</Caption>
+  </Dont>
+</DoDontContainer>
+
+Limit supplemental content to a maximum of 500 characters or two timeline items to avoid overwhelming the user and disrupting the layout's balance.
+
+<DoDontContainer>
+  <Do>
+    <img
+      alt=""
+      src="https://github.com/primer/design/assets/175638/e79ac03c-35d3-4d9d-868c-4eb16b65e39f"
+    />
+    <Caption>Limit supplemental timeline content to two items.</Caption>
+  </Do>
+  <Dont>
+    <img
+      alt=""
+      src="https://github.com/primer/design/assets/175638/8a083960-e12a-4f11-b282-45d663be2e28"
+    />
+    <Caption>Avoid unbalanced river breakout content.</Caption>
   </Dont>
 </DoDontContainer>
 


### PR DESCRIPTION
Adds content length guidance and do's and don'ts for river breakout.

[Docs preview](https://primer-e985c93047-26139705.drafts.github.io/components/River#river-breakout)