### PR TITLE
Add hover states to social icon links in MinimalFooter

### DIFF
--- a/.changeset/gentle-wolves-vanish.md
+++ b/.changeset/gentle-wolves-vanish.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Adds hover states to the social icon links in MinimalFooter

--- a/packages/design-tokens/src/tokens/functional/components/footer/colors.json
+++ b/packages/design-tokens/src/tokens/functional/components/footer/colors.json
@@ -6,6 +6,12 @@
           "value": "var(--base-color-scale-white)",
           "dark": "var(--base-color-scale-gray-9)"
         }
+      },
+      "socialIcon": {
+        "hoverFilter": {
+          "value": "brightness(0)",
+          "dark": "brightness(2)"
+        }
       }
     }
   }

--- a/packages/react/src/MinimalFooter/MinimalFooter.module.css
+++ b/packages/react/src/MinimalFooter/MinimalFooter.module.css
@@ -59,7 +59,8 @@
   padding-bottom: var(--base-size-48);
 }
 
-.Footer__social-link:hover .Footer__social-icon {
+.Footer__social-link:hover .Footer__social-icon,
+.Footer__social-link:focus-visible .Footer__social-icon {
   filter: var(--brand-footer-socialIcon-hoverFilter);
 }
 

--- a/packages/react/src/MinimalFooter/MinimalFooter.module.css
+++ b/packages/react/src/MinimalFooter/MinimalFooter.module.css
@@ -59,6 +59,10 @@
   padding-bottom: var(--base-size-48);
 }
 
+.Footer__social-link:hover .Footer__social-icon {
+  filter: var(--brand-footer-socialIcon-hoverFilter);
+}
+
 .Footer__social-icon {
   width: 24px;
   height: auto;

--- a/packages/react/src/MinimalFooter/MinimalFooter.module.css.d.ts
+++ b/packages/react/src/MinimalFooter/MinimalFooter.module.css.d.ts
@@ -6,6 +6,7 @@ declare const styles: {
   readonly "Footer__social-links": string;
   readonly "Footer__logomarks": string;
   readonly "Footer__legal-and-links": string;
+  readonly "Footer__social-link": string;
   readonly "Footer__social-icon": string;
   readonly "Footer__copyright": string;
   readonly "Footer__links": string;

--- a/packages/react/src/MinimalFooter/MinimalFooter.tsx
+++ b/packages/react/src/MinimalFooter/MinimalFooter.tsx
@@ -229,6 +229,7 @@ function SocialLogomarks({socialLinks, logoHref}: SocialLogomarksProps) {
       <li key={link.name}>
         <a
           href={link.url}
+          className={styles['Footer__social-link']}
           data-analytics-event={`{"category":"Footer","action":"go to ${link.fullName}","label":"text:${link.name}"}`}
         >
           <img


### PR DESCRIPTION
Solves https://github.com/github/primer/issues/3063

[Storybook examples](https://primer-3ecc927f1b-26139705.drafts.github.io/storybook/?path=/story/components-minimalfooter-features--dark-theme)

_Please note: this temporary solution uses CSS filters to work around a limitation in the current implementation of MinimalFooter. The social icons are loaded in an `img` tag, preventing direct fill color changes in CSS. In a future PR, we will inline SVG icons to set the `hover` state color directly._

