### PR TITLE
Update label docs images 

### DIFF
--- a/apps/docs/content/components/Label/index.mdx
+++ b/apps/docs/content/components/Label/index.mdx
@@ -77,7 +77,7 @@ Use the `medium` size when paired with medium-sized headings or in components su
   </div>
   <div>
     <img
-      src="https://github.com/primer/brand/assets/912236/b45356de-dba6-4f83-86a2-00e8943e956a"
+      src="https://github.com/primer/brand/assets/6951037/c51e151c-d93a-42f8-bf73-6bd15b1c3781"
       alt=""
     />
     <Caption>

--- a/apps/docs/content/components/Label/index.mdx
+++ b/apps/docs/content/components/Label/index.mdx
@@ -7,7 +7,7 @@ import {Box as Container} from '@primer/react'
 import ComponentLayout from '../../../src/layouts/component-layout'
 export default ComponentLayout
 
-![An image showing a group of labels with different styles, colors, leading icons and content.](https://github.com/primer/brand/assets/912236/297f8cc9-326f-4250-adbf-c6ea37b64f7b)
+![An image showing a group of labels with different styles, colors, leading icons and content.](https://github.com/primer/brand/assets/6951037/1c9c6b81-0a2a-4a56-a9f5-a9608f89e220)
 
 ## Usage
 
@@ -15,11 +15,11 @@ Use labels to indicate the status of an item or to help oraganize and categorize
 
 <DoDontContainer>
   <Do>
-    <img src="https://github.com/primer/brand/assets/912236/fcaa89e3-19c4-4e2f-81ac-a3f7e673034a" />
+    <img src="https://github.com/primer/brand/assets/6951037/5da25ec0-a780-4add-972a-246bf9462e07" />
     <Caption>Use labels to categorize an item.</Caption>
   </Do>
   <Dont>
-    <img src="https://github.com/primer/brand/assets/912236/aecf5346-e054-4dc0-b9a8-e4546bec4795" />
+    <img src="https://github.com/primer/brand/assets/6951037/976d645c-17ba-45ff-97ea-03c81a4c3b53" />
     <Caption>
       Don't use labels as an interactive or navigational element. Use a button
       or a link component.
@@ -31,14 +31,14 @@ Position the labels to clearly identify the object they’re informing.
 
 <DoDontContainer>
   <Do>
-    <img src="https://github.com/primer/brand/assets/912236/e7a44547-975b-4538-a293-92dae75907df" />
+    <img src="https://github.com/primer/brand/assets/6951037/467449ad-013d-4b9c-9eec-a4655c4d13ec" />
     <Caption>
       Give labels enough space to be clearly identified. Use size or color to
       differentiate them if needed.
     </Caption>
   </Do>
   <Dont>
-    <img src="https://github.com/primer/brand/assets/912236/a6e606fc-cabd-4454-81d4-5e7e2befe0f1" />
+    <img src="https://github.com/primer/brand/assets/6951037/5a32b608-2bc7-417b-b064-42c2308075ea" />
     <Caption>
       When used along with other items, don't place the label too close to them.
     </Caption>
@@ -93,7 +93,7 @@ Use the `large` size when paired with large headings, such as in the `Hero` comp
 
 <div>
   <img
-    src="https://github.com/primer/brand/assets/912236/f6d3d6ad-2e54-4927-9563-0a610433ed2c"
+    src="https://github.com/primer/brand/assets/6951037/13f9debc-3b20-4f77-a509-b8291ca677ae"
     alt=""
   />
   <Caption>
@@ -106,13 +106,13 @@ Use the `large` size when paired with large headings, such as in the `Hero` comp
 
 The label offers color options from the [Primer Brand color palette](/primitives/color). These color choices are carefully curated to ensure optimal contrast with the background or surrounding elements. Colors options doesn't follow a strict functional meaning. We recommend using the colors that best fit the context of your application. For example, blue and purple gradient for `Copilot` examples.
 
-![An image showing multiple label options with different colors.](https://github.com/primer/brand/assets/912236/68c93e16-f4cc-4468-bd5a-34727119ad63)
+![An image showing multiple label options with different colors.](https://github.com/primer/brand/assets/6951037/41817520-87bb-41bc-9586-95155604b83d)
 
 ### Leading visual
 
 You can add a leading icon to enhance the visual context. It is recommended you use an [Octicon](https://primer.style/octicons). Use an icon that reinforces the meaning of the label. For example, a `StarIcon` for a "Starred" label.
 
-![An image showing multiple label options with different leading visuals.](https://github.com/primer/brand/assets/912236/f248e443-eebb-4c61-9a11-fa8a1670761d)
+![An image showing multiple label options with different leading visuals.](https://github.com/primer/brand/assets/6951037/d5fdf463-f5ce-4806-886d-1b8f44278308)
 
 ## Related components
 


### PR DESCRIPTION
### Changes
Updated the images containing gradient labels to match the latest [changes](https://github.com/github/primer/issues/3084#event-12130265516) to text color. 
<img width="960" alt="cover" src="https://github.com/primer/brand/assets/6951037/420125e9-6f3f-4a32-b5bf-8e3859629e76">
