### PR TITLE
Add `originalPrice` property to pricing options component

### DIFF
--- a/apps/docs/content/components/PricingOptions.mdx
+++ b/apps/docs/content/components/PricingOptions.mdx
@@ -604,12 +604,13 @@ One item per pricing plan to be displayed. Maximum of 3 items.
 
 ### PricingOptions.Price
 
-| Name             | Type        |   Default   | required | Description           |
-| :--------------- | :---------- | :---------: | :------: | :-------------------- |
-| `children`       | `ReactNode` | `undefined` |  `true`  | The price of the item |
-| `currencyCode`   | `string`    |    `USD`    | `false`  | The currency code     |
-| `currencySymbol` | `string`    |     `$`     | `false`  | The currency symbol   |
-| `trailingText`   | `string`    |             | `false`  | The trailing text     |
+| Name             | Type        |   Default   | required | Description                                        |
+| :--------------- | :---------- | :---------: | :------: | :------------------------------------------------- |
+| `children`       | `ReactNode` | `undefined` |  `true`  | The price of the item                              |
+| `currencyCode`   | `string`    |    `USD`    | `false`  | The currency code                                  |
+| `currencySymbol` | `string`    |     `$`     | `false`  | The currency symbol                                |
+| `originalPrice`  | `string`    | `undefined` | `false`  | The initial price before any discounts are applied |
+| `trailingText`   | `string`    |             | `false`  | The trailing text                                  |
 
 ### PricingOptions.FeatureList
 

--- a/packages/react/src/PricingOptions/PricingOptions.features.stories.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.features.stories.tsx
@@ -1,28 +1,26 @@
 import React from 'react'
 import {StoryFn, Meta} from '@storybook/react'
 import {PricingOptions} from '.'
-import {Box, Grid, Stack, ThemeProvider} from '..'
+import {Box, Grid, Stack} from '..'
 import imageExample from '../fixtures/images/bento/3.png'
 import {CopilotIcon} from '@primer/octicons-react'
 
-const decorators = (Story, context) => (
-  <ThemeProvider colorMode={context.parameters.darkMode ? 'dark' : 'light'}>
-    <Box
-      backgroundColor="subtle"
-      paddingBlockStart="spacious"
-      paddingBlockEnd="spacious"
-      style={{
-        ['--brand-color-accent-primary' as string]: 'var(--base-color-scale-purple-5)',
-        minHeight: '100vh',
-      }}
-    >
-      <Grid>
-        <Grid.Column span={12}>
-          <Story />
-        </Grid.Column>
-      </Grid>
-    </Box>
-  </ThemeProvider>
+const decorators = Story => (
+  <Box
+    backgroundColor="subtle"
+    paddingBlockStart="spacious"
+    paddingBlockEnd="spacious"
+    style={{
+      ['--brand-color-accent-primary' as string]: 'var(--base-color-scale-purple-5)',
+      minHeight: '100vh',
+    }}
+  >
+    <Grid>
+      <Grid.Column span={12}>
+        <Story />
+      </Grid.Column>
+    </Grid>
+  </Box>
 )
 
 export default {
@@ -374,80 +372,6 @@ export const ThreeOptions: StoryFn<typeof PricingOptions> = () => {
       </PricingOptions.Item>
     </PricingOptions>
   )
-}
-
-export const DarkColorMode: StoryFn<typeof PricingOptions> = () => {
-  return (
-    <PricingOptions>
-      <PricingOptions.Item>
-        <PricingOptions.Heading>Copilot Individual</PricingOptions.Heading>
-        <PricingOptions.Description>
-          Code completions, Chat, and more for indie developers and freelancers.
-        </PricingOptions.Description>
-        <PricingOptions.Price trailingText="per month / $100 per year">10</PricingOptions.Price>
-        <PricingOptions.FeatureList>
-          <PricingOptions.FeatureListItem>Code completions</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>Chat in IDE and Mobile</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>CLI assistance</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>Security vulnerability filter</PricingOptions.FeatureListItem>
-        </PricingOptions.FeatureList>
-        <PricingOptions.Footnote>
-          Free for verified students, teachers, and maintainers of popular open source projects.
-        </PricingOptions.Footnote>
-        <PricingOptions.PrimaryAction as="a" href="#">
-          Start a free trial
-        </PricingOptions.PrimaryAction>
-      </PricingOptions.Item>
-
-      <PricingOptions.Item>
-        <PricingOptions.Label>Recommended</PricingOptions.Label>
-        <PricingOptions.Heading>Copilot Business</PricingOptions.Heading>
-        <PricingOptions.Description>Copilot personalized to your organization.</PricingOptions.Description>
-        <PricingOptions.Price trailingText="per user / month">19</PricingOptions.Price>
-        <PricingOptions.PrimaryAction as="a" href="#">
-          Buy now
-        </PricingOptions.PrimaryAction>
-        <PricingOptions.SecondaryAction as="a" href="#">
-          Contact sales
-        </PricingOptions.SecondaryAction>
-        <PricingOptions.FeatureList>
-          <PricingOptions.FeatureListItem>Everything in Copilot Individual plus:</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>Chat in IDE and Mobile</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>CLI assistance</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>Security vulnerability filter</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>Code referencing</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>Public code filter</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>IP indemnity</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>
-            Enterprise-grade security, safety, and privacy
-          </PricingOptions.FeatureListItem>
-        </PricingOptions.FeatureList>
-      </PricingOptions.Item>
-
-      <PricingOptions.Item>
-        <PricingOptions.Label>Available Feb 2024</PricingOptions.Label>
-        <PricingOptions.Heading>Copilot Enterprise</PricingOptions.Heading>
-        <PricingOptions.Description>
-          Copilot personalized to your organization throughout the software development lifecycle. Requires GitHub
-          Enterprise Cloud.
-        </PricingOptions.Description>
-        <PricingOptions.Price trailingText="per user / month">39</PricingOptions.Price>
-        <PricingOptions.FeatureList>
-          <PricingOptions.FeatureListItem>Everything in Copilot Business plus:</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>Chat in IDE and Mobile</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>CLI assistance</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem>Code completions</PricingOptions.FeatureListItem>
-        </PricingOptions.FeatureList>
-        <PricingOptions.PrimaryAction as="a" href="#">
-          Join waitlist
-        </PricingOptions.PrimaryAction>
-      </PricingOptions.Item>
-    </PricingOptions>
-  )
-}
-
-DarkColorMode.parameters = {
-  darkMode: true,
 }
 
 export const WithFeatureSets: StoryFn<typeof PricingOptions> = () => {

--- a/packages/react/src/PricingOptions/PricingOptions.module.css
+++ b/packages/react/src/PricingOptions/PricingOptions.module.css
@@ -230,6 +230,16 @@
   line-height: 1;
 }
 
+.PricingOptions__price-original-price {
+  display: inline-flex;
+  align-self: flex-end;
+  text-decoration: none;
+}
+
+.PricingOptions__price-original-price-value {
+  text-decoration: line-through;
+}
+
 .PricingOptions__price-trailing-text {
   flex: 1 0 100%;
   display: block;

--- a/packages/react/src/PricingOptions/PricingOptions.module.css.d.ts
+++ b/packages/react/src/PricingOptions/PricingOptions.module.css.d.ts
@@ -16,6 +16,8 @@ declare const styles: {
   readonly "PricingOptions__price-currency-symbol": string;
   readonly "PricingOptions__price-currency-code": string;
   readonly "PricingOptions__price-value": string;
+  readonly "PricingOptions__price-original-price": string;
+  readonly "PricingOptions__price-original-price-value": string;
   readonly "PricingOptions__price-trailing-text": string;
   readonly "PricingOptions__footnote": string;
   readonly "PricingOptions__feature-list": string;

--- a/packages/react/src/PricingOptions/PricingOptions.stories.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {Meta} from '@storybook/react'
 import {PricingOptions} from '.'
-import {Box, Grid, ThemeProvider} from '..'
+import {Box, Grid} from '..'
 
 export default {
   title: 'Components/PricingOptions',
@@ -9,127 +9,131 @@ export default {
 } as Meta<typeof PricingOptions>
 
 export const Default = () => (
-  <ThemeProvider colorMode="auto">
-    <Box
-      backgroundColor="subtle"
-      paddingBlockStart="spacious"
-      paddingBlockEnd="spacious"
-      style={{
-        ['--brand-color-accent-primary' as string]: 'var(--base-color-scale-purple-5)',
-        minHeight: '100vh',
-      }}
-    >
-      <Grid>
-        <Grid.Column span={12}>
-          <PricingOptions>
-            <PricingOptions.Item>
-              <PricingOptions.Heading>Copilot Individual</PricingOptions.Heading>
-              <PricingOptions.Description>
-                Code completions, Chat, and more for indie developers and freelancers.
-              </PricingOptions.Description>
-              <PricingOptions.Price trailingText="per month / $100 per year">10</PricingOptions.Price>
-              <PricingOptions.FeatureList>
-                <PricingOptions.FeatureListHeading>Chat</PricingOptions.FeatureListHeading>
-                <PricingOptions.FeatureListItem>
-                  Unlimited messages, interactions, and history
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>
-                  Context-aware coding support and explanations
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem variant="excluded">
-                  Debugging and security remediation assistance
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem variant="excluded">
-                  Repository-based semantic search
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem variant="excluded">
-                  Access your knowledge base
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListHeading>Code completion</PricingOptions.FeatureListHeading>
-                <PricingOptions.FeatureListItem>Code suggestions as you type</PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>Comments to code</PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem variant="excluded">
-                  Fine-tuned models (coming soon)
-                </PricingOptions.FeatureListItem>
-              </PricingOptions.FeatureList>
+  <Box
+    backgroundColor="subtle"
+    paddingBlockStart="spacious"
+    paddingBlockEnd="spacious"
+    style={{
+      ['--brand-color-accent-primary' as string]: 'var(--base-color-scale-purple-5)',
+      minHeight: '100vh',
+    }}
+  >
+    <Grid>
+      <Grid.Column span={12}>
+        <PricingOptions>
+          <PricingOptions.Item>
+            <PricingOptions.Heading>Copilot Individual</PricingOptions.Heading>
+            <PricingOptions.Description>
+              Code completions, Chat, and more for indie developers and freelancers.
+            </PricingOptions.Description>
+            <PricingOptions.Price trailingText="per month / $100 per year" originalPrice="15">
+              10
+            </PricingOptions.Price>
+            <PricingOptions.FeatureList>
+              <PricingOptions.FeatureListHeading>Chat</PricingOptions.FeatureListHeading>
+              <PricingOptions.FeatureListItem>
+                Unlimited messages, interactions, and history
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>
+                Context-aware coding support and explanations
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem variant="excluded">
+                Debugging and security remediation assistance
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem variant="excluded">
+                Repository-based semantic search
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem variant="excluded">
+                Access your knowledge base
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListHeading>Code completion</PricingOptions.FeatureListHeading>
+              <PricingOptions.FeatureListItem>Code suggestions as you type</PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>Comments to code</PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem variant="excluded">
+                Fine-tuned models (coming soon)
+              </PricingOptions.FeatureListItem>
+            </PricingOptions.FeatureList>
 
-              <PricingOptions.Footnote>
-                Free for verified students, teachers, and maintainers of popular open source projects.
-              </PricingOptions.Footnote>
+            <PricingOptions.Footnote>
+              Free for verified students, teachers, and maintainers of popular open source projects.
+            </PricingOptions.Footnote>
 
-              <PricingOptions.PrimaryAction as="a" href="#">
-                Start a free trial
-              </PricingOptions.PrimaryAction>
-            </PricingOptions.Item>
+            <PricingOptions.PrimaryAction as="a" href="#">
+              Start a free trial
+            </PricingOptions.PrimaryAction>
+          </PricingOptions.Item>
 
-            <PricingOptions.Item>
-              <PricingOptions.Label>Recommended</PricingOptions.Label>
-              <PricingOptions.Heading>Copilot Business</PricingOptions.Heading>
-              <PricingOptions.Description>Copilot personalized to your organization.</PricingOptions.Description>
-              <PricingOptions.Price trailingText="per user / month">19</PricingOptions.Price>
-              <PricingOptions.PrimaryAction as="a" href="#">
-                Buy now
-              </PricingOptions.PrimaryAction>
-              <PricingOptions.SecondaryAction as="a" href="#">
-                Contact sales
-              </PricingOptions.SecondaryAction>
-              <PricingOptions.FeatureList>
-                <PricingOptions.FeatureListHeading>Chat</PricingOptions.FeatureListHeading>
-                <PricingOptions.FeatureListItem>
-                  Unlimited messages, interactions, and history
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>
-                  Context-aware coding support and explanations
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>
-                  Debugging and security remediation assistance
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>Repository-based semantic search</PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem variant="excluded">
-                  Access your knowledge base
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListHeading>Code completion</PricingOptions.FeatureListHeading>
-                <PricingOptions.FeatureListItem>Code suggestions as you type</PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>Comments to code</PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem variant="excluded">
-                  Fine-tuned models (coming soon)
-                </PricingOptions.FeatureListItem>
-              </PricingOptions.FeatureList>
-            </PricingOptions.Item>
+          <PricingOptions.Item>
+            <PricingOptions.Label>Recommended</PricingOptions.Label>
+            <PricingOptions.Heading>Copilot Business</PricingOptions.Heading>
+            <PricingOptions.Description>Copilot personalized to your organization.</PricingOptions.Description>
+            <PricingOptions.Price trailingText="per user / month" originalPrice="29">
+              19
+            </PricingOptions.Price>
+            <PricingOptions.PrimaryAction as="a" href="#">
+              Buy now
+            </PricingOptions.PrimaryAction>
+            <PricingOptions.SecondaryAction as="a" href="#">
+              Contact sales
+            </PricingOptions.SecondaryAction>
+            <PricingOptions.FeatureList>
+              <PricingOptions.FeatureListHeading>Chat</PricingOptions.FeatureListHeading>
+              <PricingOptions.FeatureListItem>
+                Unlimited messages, interactions, and history
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>
+                Context-aware coding support and explanations
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>
+                Debugging and security remediation assistance
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>Repository-based semantic search</PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem variant="excluded">
+                Access your knowledge base
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListHeading>Code completion</PricingOptions.FeatureListHeading>
+              <PricingOptions.FeatureListItem>Code suggestions as you type</PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>Comments to code</PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem variant="excluded">
+                Fine-tuned models (coming soon)
+              </PricingOptions.FeatureListItem>
+            </PricingOptions.FeatureList>
+          </PricingOptions.Item>
 
-            <PricingOptions.Item>
-              <PricingOptions.Label>Available Feb 2024</PricingOptions.Label>
-              <PricingOptions.Heading>Copilot Enterprise</PricingOptions.Heading>
-              <PricingOptions.Description>
-                Copilot personalized to your organization throughout the software development lifecycle. Requires GitHub
-                Enterprise Cloud.
-              </PricingOptions.Description>
-              <PricingOptions.Price trailingText="per user / month">39</PricingOptions.Price>
-              <PricingOptions.FeatureList>
-                <PricingOptions.FeatureListHeading>Chat</PricingOptions.FeatureListHeading>
-                <PricingOptions.FeatureListItem>
-                  Unlimited messages, interactions, and history
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>
-                  Context-aware coding support and explanations
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>
-                  Debugging and security remediation assistance
-                </PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>Repository-based semantic search</PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>Access your knowledge base</PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListHeading>Code completion</PricingOptions.FeatureListHeading>
-                <PricingOptions.FeatureListItem>Code suggestions as you type</PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>Comments to code</PricingOptions.FeatureListItem>
-                <PricingOptions.FeatureListItem>Fine-tuned models (coming soon)</PricingOptions.FeatureListItem>
-              </PricingOptions.FeatureList>
-              <PricingOptions.PrimaryAction as="a" href="#">
-                Join waitlist
-              </PricingOptions.PrimaryAction>
-            </PricingOptions.Item>
-          </PricingOptions>
-        </Grid.Column>
-      </Grid>
-    </Box>
-  </ThemeProvider>
+          <PricingOptions.Item>
+            <PricingOptions.Label>Available Feb 2024</PricingOptions.Label>
+            <PricingOptions.Heading>Copilot Enterprise</PricingOptions.Heading>
+            <PricingOptions.Description>
+              Copilot personalized to your organization throughout the software development lifecycle. Requires GitHub
+              Enterprise Cloud.
+            </PricingOptions.Description>
+            <PricingOptions.Price trailingText="per user / month" originalPrice="49">
+              39
+            </PricingOptions.Price>
+            <PricingOptions.FeatureList>
+              <PricingOptions.FeatureListHeading>Chat</PricingOptions.FeatureListHeading>
+              <PricingOptions.FeatureListItem>
+                Unlimited messages, interactions, and history
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>
+                Context-aware coding support and explanations
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>
+                Debugging and security remediation assistance
+              </PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>Repository-based semantic search</PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>Access your knowledge base</PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListHeading>Code completion</PricingOptions.FeatureListHeading>
+              <PricingOptions.FeatureListItem>Code suggestions as you type</PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>Comments to code</PricingOptions.FeatureListItem>
+              <PricingOptions.FeatureListItem>Fine-tuned models (coming soon)</PricingOptions.FeatureListItem>
+            </PricingOptions.FeatureList>
+            <PricingOptions.PrimaryAction as="a" href="#">
+              Join waitlist
+            </PricingOptions.PrimaryAction>
+          </PricingOptions.Item>
+        </PricingOptions>
+      </Grid.Column>
+    </Grid>
+  </Box>
 )

--- a/packages/react/src/PricingOptions/PricingOptions.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.tsx
@@ -235,12 +235,22 @@ type PricingOptionsPriceProps = PropsWithChildren<BaseProps<HTMLParagraphElement
   currencyCode?: string
   currencySymbol?: string
   'data-testid'?: string
+  originalPrice?: string
   trailingText?: string
 }
 
 const PricingOptionsPrice = forwardRef<HTMLParagraphElement, PricingOptionsPriceProps>(
   (
-    {children, className, currencyCode = 'USD', currencySymbol = '$', 'data-testid': testId, trailingText, ...rest},
+    {
+      children,
+      className,
+      currencyCode = 'USD',
+      currencySymbol = '$',
+      'data-testid': testId,
+      originalPrice,
+      trailingText,
+      ...rest
+    },
     ref,
   ) => {
     return (
@@ -252,17 +262,46 @@ const PricingOptionsPrice = forwardRef<HTMLParagraphElement, PricingOptionsPrice
         weight="normal"
         {...rest}
       >
-        <Text as="span" className={styles['PricingOptions__price-currency-symbol']} size="500" weight="normal">
+        <Text
+          as="span"
+          className={styles['PricingOptions__price-currency-symbol']}
+          font="hubot-sans"
+          size="500"
+          weight="normal"
+        >
           {currencySymbol}
         </Text>
 
-        <Text as="span" className={styles['PricingOptions__price-value']} size="700" weight="normal">
+        <Text as="span" className={styles['PricingOptions__price-value']} font="hubot-sans" size="700" weight="normal">
           {children}
         </Text>
 
-        <Text as="span" className={styles['PricingOptions__price-currency-code']} size="500" weight="normal">
+        <Text
+          as="span"
+          className={styles['PricingOptions__price-currency-code']}
+          font="hubot-sans"
+          size="500"
+          weight="normal"
+        >
           {currencyCode}
         </Text>
+
+        {originalPrice && (
+          <del className={styles['PricingOptions__price-original-price']}>
+            <Text font="hubot-sans" size="400" variant="muted" weight="normal">
+              {currencySymbol}
+            </Text>
+            <Text
+              className={styles['PricingOptions__price-original-price-value']}
+              font="hubot-sans"
+              size="500"
+              variant="muted"
+              weight="normal"
+            >
+              {originalPrice}
+            </Text>
+          </del>
+        )}
 
         {trailingText && (
           <Text as="span" className={styles['PricingOptions__price-trailing-text']} size="200" variant="muted">


### PR DESCRIPTION
## Summary

Add an optional `originalPrice` property to PricingOptions to display a strike-through price (i.e, the initial price before any discounts are applied).

## List of notable changes:

- Added an `originalPrice` porperty to `PricingOptions.Price`. 
- Used Hubot Sans for `PricingOptions.Price` text.
- Removed `ThemeProvider`s from stories and the `Dark Mode` story.

## What should reviewers focus on?

- Check out storybook and docs



## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![Without original price](https://github.com/primer/brand/assets/175638/f2c7f33a-1fdd-4aec-aeca-a12631137475)

 </td>
<td valign="top">

![With original price](https://github.com/primer/brand/assets/175638/fb87d8ed-e8db-4fac-9e44-d7ea3be5cf58)


</td>
</tr>
</table>
