### PR TITLE
Fix documentation examples and note for Pricing options

### DIFF
--- a/apps/docs/content/components/PricingOptions.mdx
+++ b/apps/docs/content/components/PricingOptions.mdx
@@ -255,15 +255,17 @@ This is the two-item layout for the pricing options component.
 
 This is the three-option layout for the pricing options component.
 
-```jsx live
 <Note>
-  `PricingOptions` is designed to fill the width of the page's main container,
-  thus it cannot be accurately represented within the narrower container of this
-  documentation. 
-  
-  Please refer to our [Storybook examples](https://primer.style/brand/storybook/?path=/story/components-pricingoptions-features--three-options) to see the component in a full-width context as originally intended.
+
+`PricingOptions` is designed to fill the width of the page's main container,
+thus it cannot be accurately represented within the narrower container of this
+documentation.
+
+Please refer to our [Storybook
+examples](https://primer.style/brand/storybook/?path=/story/components-pricingoptions-features--three-options)
+to see the component in a full-width context as originally intended.
+
 </Note>
-```
 
 ### Feature list sets
 
@@ -357,53 +359,6 @@ Use `PricingOptions.FeatureListHeading` to group feature items together.
       </PricingOptions.FeatureListItem>
     </PricingOptions.FeatureList>
   </PricingOptions.Item>
-
-  <PricingOptions.Item>
-    <PricingOptions.Label>Available Feb 2024</PricingOptions.Label>
-    <PricingOptions.Heading>Copilot Enterprise</PricingOptions.Heading>
-    <PricingOptions.Description>
-      Copilot personalized to your organization throughout the software
-      development lifecycle. Requires GitHub Enterprise Cloud.
-    </PricingOptions.Description>
-    <PricingOptions.Price currencySymbol="$" trailingText="per user / month">
-      39
-    </PricingOptions.Price>
-    <PricingOptions.FeatureList>
-      <PricingOptions.FeatureListHeading>
-        Base features
-      </PricingOptions.FeatureListHeading>
-      <PricingOptions.FeatureListItem>
-        Everything in Copilot Business
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        Documentation search and summaries
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        Pull request summaries
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        Code review skills
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListHeading>
-        Security
-      </PricingOptions.FeatureListHeading>
-      <PricingOptions.FeatureListItem>
-        Security vulnerability filter
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        Public code filter
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        IP indemnity
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        Enterprise-grade security, safety, and privacy
-      </PricingOptions.FeatureListItem>
-    </PricingOptions.FeatureList>
-    <PricingOptions.PrimaryAction href="/waitlist">
-      Join waitlist
-    </PricingOptions.PrimaryAction>
-  </PricingOptions.Item>
 </PricingOptions>
 ```
 
@@ -465,55 +420,6 @@ Use `PricingOptions.FeatureListItem` with `variant="included"` and `variant="exc
     <PricingOptions.PrimaryAction href="/buy">
       Start a free trial
     </PricingOptions.PrimaryAction>
-  </PricingOptions.Item>
-
-  <PricingOptions.Item>
-    <PricingOptions.Label>Recommended</PricingOptions.Label>
-    <PricingOptions.Heading>Copilot Business</PricingOptions.Heading>
-    <PricingOptions.Description>
-      Copilot personalized to your organization.
-    </PricingOptions.Description>
-    <PricingOptions.Price currencySymbol="$" trailingText="per user / month">
-      19
-    </PricingOptions.Price>
-    <PricingOptions.PrimaryAction href="/buy">
-      Buy now
-    </PricingOptions.PrimaryAction>
-    <PricingOptions.SecondaryAction href="/contact">
-      Contact sales
-    </PricingOptions.SecondaryAction>
-    <PricingOptions.FeatureList>
-      <PricingOptions.FeatureListHeading>
-        Chat
-      </PricingOptions.FeatureListHeading>
-      <PricingOptions.FeatureListItem>
-        Unlimited messages, interactions, and history
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        Context-aware coding support and explanations
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        Debugging and security remediation assistance
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        Repository-based semantic search
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem variant="excluded">
-        Access your knowledge base
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListHeading>
-        Code completion
-      </PricingOptions.FeatureListHeading>
-      <PricingOptions.FeatureListItem>
-        Code suggestions as you type
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem>
-        Comments to code
-      </PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem variant="excluded">
-        Fine-tuned models (coming soon)
-      </PricingOptions.FeatureListItem>
-    </PricingOptions.FeatureList>
   </PricingOptions.Item>
 
   <PricingOptions.Item>


### PR DESCRIPTION
Fixes a note formatting issue in the pricing options documentation and changes three-item examples to two-item examples for a more accurate representation of the live component in the docs.

| Before | After |
|--------|--------|
| ![screenshot-nuaMo1aA-000948@2x](https://github.com/primer/brand/assets/175638/4cca76df-828e-41fe-8463-3c91fbd01d6a) | ![screenshot-EWemIrcK-000947@2x](https://github.com/primer/brand/assets/175638/7e5820e1-664b-461c-aeed-352835e095fb) |
| ![screenshot-djVhfqbD-000949@2x](https://github.com/primer/brand/assets/175638/9b8f15d3-5574-4016-b4cf-e0c0635b8d67) | ![screenshot-ExECHbky-000950@2x](https://github.com/primer/brand/assets/175638/be7525fd-177e-405e-aea2-ddd002177d1c) |
| ![screenshot-Y2Ykna73-000951@2x](https://github.com/primer/brand/assets/175638/e280d758-3c89-4ebb-a651-849c5778fc7c) | ![screenshot-reOhkvFB-000952@2x](https://github.com/primer/brand/assets/175638/aab030f0-bba8-4fb8-8f5e-e6ea3ae09c37) | 