### PR TITLE
Add a space after the minus sign so that CSS can be built successfully

### DIFF
--- a/.changeset/long-lions-cough.md
+++ b/.changeset/long-lions-cough.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Adds a missing space around font-size calculation
+Adds a missing space around font-size calculation in the IDE component

--- a/.changeset/long-lions-cough.md
+++ b/.changeset/long-lions-cough.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Adds a missing space around font-size calculation

--- a/packages/react/src/IDE/IDE.module.css
+++ b/packages/react/src/IDE/IDE.module.css
@@ -278,7 +278,7 @@ img.IDE__Editor-tab-icon {
 
 .IDE__Editor--small .IDE__Editor-pane,
 .IDE__Editor--small .IDE__Editor-lineNumbers {
-  font-size: calc(var(--base-size-12) -1px) !important; /* workaround dotcom specificity */
+  font-size: calc(var(--base-size-12) - 1px) !important; /* workaround dotcom specificity */
   line-height: calc(var(--base-size-16) + 2px) !important; /* workaround dotcom specificity */
 }
 


### PR DESCRIPTION
## Summary

When we tried to update `@primer/react-brand` to 0.33.0, we got the following error in our CI output when trying to build CSS for the package:

```
Error: "+" and "-" must be surrounded by whitespace in calculations.
      
17134    font-size: calc(var(--base-size-12) -1px) !important;
                                             ^
      
  @primer/react-brand/lib/css/main.css 17134:39  @import
  app/assets/stylesheets/primer-brand.scss 9:9   root stylesheet
```

## List of notable changes:

Added a single space character after the minus sign

## What should reviewers focus on?



## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Build the CSS using `dartsass`

## Supporting resources (related issues, external links, etc):

-
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
