### PR TITLE
Exclude Subnav links with aria-current set to "false" from active link styling

### DIFF
--- a/.changeset/soft-chicken-march.md
+++ b/.changeset/soft-chicken-march.md
@@ -1,0 +1,5 @@
+---
+"@primer/react-brand": patch
+---
+
+Update SubNav stylesheet to exclude Subnav links with aria-current set to "false" from active link styling

--- a/packages/react/src/SubNav/SubNav.module.css
+++ b/packages/react/src/SubNav/SubNav.module.css
@@ -126,7 +126,7 @@
     text-decoration: none;
   }
 
-    .SubNav__links-overlay--open .SubNav__link[aria-current]:not([aria-current="false"]) * {
+  .SubNav__links-overlay--open .SubNav__link[aria-current]:not([aria-current="false"]) * {
     color: var(--brand-SubNav-color-link-active);
   }
 
@@ -220,7 +220,7 @@
   }
 
   .SubNav__link:hover *,
-    .SubNav__link[aria-current]:not([aria-current="false"]) * {
+  .SubNav__link[aria-current]:not([aria-current="false"]) * {
     color: var(--brand-SubNav-color-link-active);
     text-decoration: none !important; /* dotcom override */
   }
@@ -242,7 +242,7 @@
 
   .SubNav__link:hover .SubNav__link-label::after,
   .SubNav__link:focus .SubNav__link-label::after,
-    .SubNav__link[aria-current]:not([aria-current="false"]) .SubNav__link-label::after {
+  .SubNav__link[aria-current]:not([aria-current="false"]) .SubNav__link-label::after {
     opacity: 1;
     transform: translate3d(0, 0.2em, 0);
     transform: scale(0.8, 1);

--- a/packages/react/src/SubNav/SubNav.module.css
+++ b/packages/react/src/SubNav/SubNav.module.css
@@ -126,7 +126,7 @@
     text-decoration: none;
   }
 
-  .SubNav__links-overlay--open .SubNav__link[aria-current] * {
+    .SubNav__links-overlay--open .SubNav__link[aria-current]:not([aria-current="false"]) * {
     color: var(--brand-SubNav-color-link-active);
   }
 
@@ -220,7 +220,7 @@
   }
 
   .SubNav__link:hover *,
-  .SubNav__link[aria-current] * {
+    .SubNav__link[aria-current]:not([aria-current="false"]) * {
     color: var(--brand-SubNav-color-link-active);
     text-decoration: none !important; /* dotcom override */
   }
@@ -242,7 +242,7 @@
 
   .SubNav__link:hover .SubNav__link-label::after,
   .SubNav__link:focus .SubNav__link-label::after,
-  .SubNav__link[aria-current] .SubNav__link-label::after {
+    .SubNav__link[aria-current]:not([aria-current="false"]) .SubNav__link-label::after {
     opacity: 1;
     transform: translate3d(0, 0.2em, 0);
     transform: scale(0.8, 1);

--- a/packages/react/src/SubNav/SubNav.module.css
+++ b/packages/react/src/SubNav/SubNav.module.css
@@ -126,7 +126,7 @@
     text-decoration: none;
   }
 
-  .SubNav__links-overlay--open .SubNav__link[aria-current]:not([aria-current="false"]) * {
+  .SubNav__links-overlay--open .SubNav__link[aria-current]:not([aria-current='false']) * {
     color: var(--brand-SubNav-color-link-active);
   }
 
@@ -220,7 +220,7 @@
   }
 
   .SubNav__link:hover *,
-  .SubNav__link[aria-current]:not([aria-current="false"]) * {
+  .SubNav__link[aria-current]:not([aria-current='false']) * {
     color: var(--brand-SubNav-color-link-active);
     text-decoration: none !important; /* dotcom override */
   }
@@ -242,7 +242,7 @@
 
   .SubNav__link:hover .SubNav__link-label::after,
   .SubNav__link:focus .SubNav__link-label::after,
-  .SubNav__link[aria-current]:not([aria-current="false"]) .SubNav__link-label::after {
+  .SubNav__link[aria-current]:not([aria-current='false']) .SubNav__link-label::after {
     opacity: 1;
     transform: translate3d(0, 0.2em, 0);
     transform: scale(0.8, 1);

--- a/packages/react/src/SubNav/SubNav.stories.tsx
+++ b/packages/react/src/SubNav/SubNav.stories.tsx
@@ -28,7 +28,9 @@ const Template: StoryFn<typeof SubNav> = args => (
       <SubNav.Link href="#" aria-current="page">
         Link
       </SubNav.Link>
-      <SubNav.Link href="#">Link</SubNav.Link>
+      <SubNav.Link href="#" aria-current="false">
+        Link
+      </SubNav.Link>
       <SubNav.Link href="#">Link</SubNav.Link>
       <SubNav.Action href="#">Primary CTA</SubNav.Action>
     </SubNav>


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

## List of notable changes:


Changes to SubNav styling:

* [`packages/react/src/SubNav/SubNav.module.css`](diffhunk://#diff-1edfafbe6a934fda2b154695158be5930bbf9793d69717351c878dfccdd26f7aL129-R129): Updated the CSS selectors for `.SubNav__links-overlay--open .SubNav__link[aria-current]`, `.SubNav__link:hover *`, `.SubNav__link[aria-current]` and `.SubNav__link[aria-current] .SubNav__link-label::after` to exclude `SubNav` links with `aria-current` set to "false" from active link styling. [[1]](diffhunk://#diff-1edfafbe6a934fda2b154695158be5930bbf9793d69717351c878dfccdd26f7aL129-R129) [[2]](diffhunk://#diff-1edfafbe6a934fda2b154695158be5930bbf9793d69717351c878dfccdd26f7aL223-R223) [[3]](diffhunk://#diff-1edfafbe6a934fda2b154695158be5930bbf9793d69717351c878dfccdd26f7aL245-R245)

Changes to SubNav stories:

* [`packages/react/src/SubNav/SubNav.stories.tsx`](diffhunk://#diff-95d3245d138a74f8115c96bd98b6aa69355f7f9d1c8a0ef758f628d4712d3ae3L31-R33): Updated a `SubNav.Link` in the `SubNav` story to have `aria-current="false"`, to ensure changes in the CSS work as intended. 

Package version update:

* [`.changeset/soft-chicken-march.md`](diffhunk://#diff-9ab54f31d8f42a06fce2353c9f6615c4f083a5aa0a96b10421f16bec0e99b416R1-R5): Bumped the patch version of `@primer/react-brand` to reflect the changes made in this pull request.
## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile). 
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Is there anything else I missed?

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Go to the Subnav component in Storybook. 
1. Ensure the example with aria-current="false" no longer has active link styling applied. 

## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/issues/572

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:
****

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="566" alt="Screenshot 2024-05-03 at 10 20 42 AM" src="https://github.com/primer/brand/assets/64283754/f5e2dc5e-23a3-4761-ad8a-a1cbc90f45ae">


 </td>
<td valign="top">

<img width="566" alt="Screenshot 2024-05-03 at 10 19 30 AM" src="https://github.com/primer/brand/assets/64283754/3bfd68b4-52e2-468e-8d79-1bcd1c0bdf69">


</td>
</tr>
</table>
