### PR TITLE
Fix Animation docs page

### DIFF
--- a/apps/docs/content/getting-started/animation.mdx
+++ b/apps/docs/content/getting-started/animation.mdx
@@ -198,7 +198,7 @@ Alternatively, use `delay` to stagger animations on adjacent elements if this fe
     >
       <Animate animate="scale-in-up">
         <Card href="https://github.com">
-          <Card.Icon icon={RocketIcon} hasBackground color="blue" />
+          <Card.Icon icon={<RocketIcon />} hasBackground color="blue" />
           <Card.Label>Limited</Card.Label>
           <Card.Heading>GitHub Actions cheat sheet and more</Card.Heading>
           <Card.Description>

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
     },
     "apps/storybook": {
       "name": "@primer/brand-storybook",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.22.0",
@@ -31323,7 +31323,7 @@
     },
     "packages/design-tokens": {
       "name": "@primer/brand-primitives",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "MIT",
       "devDependencies": {
         "@primer/primitives": "^7.15.0",
@@ -31474,7 +31474,7 @@
     },
     "packages/e2e": {
       "name": "@primer/brand-e2e",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "MIT",
       "devDependencies": {
         "@github/axe-github": "^0.5.0",
@@ -31488,7 +31488,7 @@
     },
     "packages/fonts": {
       "name": "@primer/brand-fonts",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -31497,7 +31497,7 @@
     },
     "packages/react": {
       "name": "@primer/react-brand",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "MIT",
       "dependencies": {
         "@oddbird/popover-polyfill": "0.4.3",
@@ -31546,7 +31546,7 @@
     },
     "packages/repo-configs": {
       "name": "@primer/brand-config",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "MIT"
     }
   },


### PR DESCRIPTION
## Summary

- Fix error on Animation page (in production) of docs caused by incorrect icon usage.
- Update `package-lock.json` with latest primer versions (`0.34.0`)

## Steps to test:

1. Open updated Animation page in docs ([here](https://primer-1a2af1221e-26139705.drafts.github.io/getting-started/animation))
1. Verify that the _Cards and staggering_ example doesn't show a red error message

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/primer/brand/assets/6840861/a18b6d1e-ea0b-4090-a51d-7020638d699f)

 </td>
<td valign="top">

![image](https://github.com/primer/brand/assets/6840861/75190fef-9d35-44ad-a37a-f5204e8e4c98)

</td>
</tr>
</table>
