### PR TITLE
Fix AnchorNav focus bug

### DIFF
--- a/.changeset/fast-rice-switch.md
+++ b/.changeset/fast-rice-switch.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Resolved an issue with the `AnchorNav` component where focus would become trapped on mobile

--- a/packages/react/src/AnchorNav/AnchorNav.test.tsx
+++ b/packages/react/src/AnchorNav/AnchorNav.test.tsx
@@ -60,7 +60,7 @@ describe('AnchorNav', () => {
     expect(getByTestId(AnchorNav.testIds.root).tagName).toBe('nav'.toUpperCase()) // expect root to be a <nav> element
   })
 
-  it('renders the correct number of links  into the document', () => {
+  it('renders the correct number of links into the document', () => {
     const {getByTestId} = render(<MockAnchorNavFixture />)
 
     expect(getByTestId(AnchorNav.testIds.menuLinks).children.length).toBe(mockData.length)
@@ -134,7 +134,7 @@ describe('AnchorNav', () => {
     expect(secondaryActionEl).toHaveClass('Button--secondary')
   })
 
-  it('renders applies correct behaviors when menu button is toggled', () => {
+  it('applies correct behaviors when menu button is toggled', () => {
     const {getByTestId} = render(<MockAnchorNavFixture />)
     const menuButton = getByTestId(AnchorNav.testIds.menuButton)
 

--- a/packages/react/src/AnchorNav/AnchorNav.tsx
+++ b/packages/react/src/AnchorNav/AnchorNav.tsx
@@ -240,6 +240,7 @@ function _AnchorNav({children, enableDefaultBgColor = false, hideUntilSticky = f
             {Links}
           </div>
           <span
+            data-forward-focus="true"
             className={clsx(
               styles['AnchorNav__actionsContainer'],
               hasTwoActions && styles['AnchorNav__actionsContainer--multiple'],

--- a/packages/react/src/AnchorNav/useExpandedMenu.ts
+++ b/packages/react/src/AnchorNav/useExpandedMenu.ts
@@ -40,7 +40,12 @@ export const useExpandedMenu = (
       // tab key
       if (event.key === 'Tab') {
         event.preventDefault()
-        nextNode?.focus()
+
+        if (nextNode?.getAttribute('data-forward-focus') === 'true' && nextNode.firstChild instanceof HTMLElement) {
+          nextNode.firstChild.focus()
+        } else {
+          nextNode?.focus()
+        }
       }
       // shift+tab
       if (event.shiftKey && event.key === 'Tab') {


### PR DESCRIPTION
## Summary

Resolves an issue where the focus was trapped on mobile when using the `AnchorNav` component. This PR adds a new attribute to the `span` element in the `AnchorNav` component to allow the focus to move forward when the tab key is pressed.

## List of notable changes:

- `data-forward-focus` attribute added to span which wraps `AnchorNav` actions. The name is arbitrary, but it is used to determine if the focus should instead be forwarded to the element's first child
- Fixes a few minor typos in the `AnchorNav` test file
- DOES NOT add any tests for the focus fix. I couldn't get tabbing and focus tracking to work correctly inside the unit tests unfortunately. 

## What should reviewers focus on?

- Are you happy with the `data-forward-focus` approach?

## Steps to test:

- Check that you're able to tab from any link in the `AnchorNav` to the first of the actions

## Supporting resources (related issues, external links, etc):

- #608 

## Contributor checklist:

- [x] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
