### PR TITLE
update eslint-plugin-github to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@typescript-eslint/parser": "^5.59.7",
         "eslint": "^8.41.0",
         "eslint-import-resolver-typescript": "^2.7.1",
-        "eslint-plugin-github": "^4.10.1",
+        "eslint-plugin-github": "^5.0.2",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "eslint-plugin-mdx": "^1.17.1",
@@ -46,7 +46,7 @@
     },
     "apps/storybook": {
       "name": "@primer/brand-storybook",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.22.0",
@@ -4946,18 +4946,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@pkgr/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
-      }
-    },
     "node_modules/@pkgr/utils": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
@@ -8513,7 +8501,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8530,7 +8517,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8547,7 +8533,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8564,7 +8549,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8581,7 +8565,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8598,7 +8581,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8615,7 +8597,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8632,7 +8613,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8649,7 +8629,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8666,7 +8645,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13426,14 +13404,14 @@
       }
     },
     "node_modules/eslint-plugin-github": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.10.1.tgz",
-      "integrity": "sha512-1AqQBockOM+m0ZUpwfjWtX0lWdX5cRi/hwJnSNvXoOmz/Hh+ULH6QFz6ENWueTWjoWpgPv0af3bj+snps6o4og==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.2.tgz",
+      "integrity": "sha512-nMdzWJQ5CimjQDY6SFeJ0KIXuNFf0dgDWEd4eP3UWfuTuP/dXcZJDg7MQRvAFt743T1zUi4+/HdOihfu8xJkLA==",
       "dev": true,
       "dependencies": {
         "@github/browserslist-config": "^1.0.0",
-        "@typescript-eslint/eslint-plugin": "^6.0.0",
-        "@typescript-eslint/parser": "^6.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
         "aria-query": "^5.3.0",
         "eslint-config-prettier": ">=8.0.0",
         "eslint-plugin-escompat": "^3.3.3",
@@ -13456,40 +13434,32 @@
         "eslint": "^8.0.1"
       }
     },
-    "node_modules/eslint-plugin-github/node_modules/@types/semver": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-      "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
-      "dev": true
-    },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.11.0.tgz",
-      "integrity": "sha512-uXnpZDc4VRjY4iuypDBKzW1rz9T5YBBK0snMn8MaTSNd2kMlj50LnLBABELjJiOL5YHk7ZD8hbSpI9ubzqYI0w==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+      "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.11.0",
-        "@typescript-eslint/type-utils": "6.11.0",
-        "@typescript-eslint/utils": "6.11.0",
-        "@typescript-eslint/visitor-keys": "6.11.0",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/type-utils": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -13498,26 +13468,26 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/parser": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.11.0.tgz",
-      "integrity": "sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+      "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.11.0",
-        "@typescript-eslint/types": "6.11.0",
-        "@typescript-eslint/typescript-estree": "6.11.0",
-        "@typescript-eslint/visitor-keys": "6.11.0",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -13526,16 +13496,16 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.11.0.tgz",
-      "integrity": "sha512-0A8KoVvIURG4uhxAdjSaxy8RdRE//HztaZdG8KiHLP8WOXSk0vlF7Pvogv+vlJA5Rnjj/wDcFENvDaHb+gKd1A==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+      "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.11.0",
-        "@typescript-eslint/visitor-keys": "6.11.0"
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -13543,25 +13513,22 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/type-utils": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.11.0.tgz",
-      "integrity": "sha512-nA4IOXwZtqBjIoYrJcYxLRO+F9ri+leVGoJcMW1uqr4r1Hq7vW5cyWrA43lFbpRvQ9XgNrnfLpIkO3i1emDBIA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+      "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.11.0",
-        "@typescript-eslint/utils": "6.11.0",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -13570,12 +13537,12 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/types": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.11.0.tgz",
-      "integrity": "sha512-ZbEzuD4DwEJxwPqhv3QULlRj8KYTAnNsXxmfuUXFCxZmO6CF2gM/y+ugBSAQhrqaJL3M+oe4owdWunaHM6beqA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+      "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
       "dev": true,
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -13583,21 +13550,22 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.11.0.tgz",
-      "integrity": "sha512-Aezzv1o2tWJwvZhedzvD5Yv7+Lpu1by/U1LZ5gLc4tCx8jUmuSCMioPFRjliN/6SJIvY6HpTtJIWubKuYYYesQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+      "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.11.0",
-        "@typescript-eslint/visitor-keys": "6.11.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -13610,45 +13578,51 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/utils": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.11.0.tgz",
-      "integrity": "sha512-p23ibf68fxoZy605dc0dQAEoUsoiNoP3MD9WQGiHLDuTSOuqoTsa4oAy+h3KDkTcxbbfOtUjb9h3Ta0gT4ug2g==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+      "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.11.0",
-        "@typescript-eslint/types": "6.11.0",
-        "@typescript-eslint/typescript-estree": "6.11.0",
-        "semver": "^7.5.4"
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-github/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.11.0.tgz",
-      "integrity": "sha512-+SUN/W7WjBr05uRxPggJPSzyB8zUpaYo2hByKasWbqr3PM8AXfZt8UHdNpBS1v9SA62qnSSMF3380SwDqqprgQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+      "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.11.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "8.7.0",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-github/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/eslint-plugin-github/node_modules/eslint-plugin-prettier": {
@@ -13680,16 +13654,19 @@
         }
       }
     },
-    "node_modules/eslint-plugin-github/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+    "node_modules/eslint-plugin-github/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
-        "yallist": "^4.0.0"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-github/node_modules/prettier": {
@@ -13708,13 +13685,10 @@
       }
     },
     "node_modules/eslint-plugin-github/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -13737,12 +13711,6 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
-    },
-    "node_modules/eslint-plugin-github/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/eslint-plugin-i18n-text": {
       "version": "1.0.1",
@@ -13924,319 +13892,6 @@
       },
       "peerDependencies": {
         "eslint": "^8.42.0"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
-      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/type-utils": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^7.0.0",
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/@typescript-eslint/parser": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
-      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
-      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/@typescript-eslint/type-utils": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
-      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.18.0",
-        "@typescript-eslint/utils": "7.18.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/@typescript-eslint/types": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
-      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
-      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/visitor-keys": "7.18.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/@typescript-eslint/utils": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
-      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.18.0",
-        "@typescript-eslint/types": "7.18.0",
-        "@typescript-eslint/typescript-estree": "7.18.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.56.0"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
-      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "7.18.0",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || >=20.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/eslint-plugin-github": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.1.tgz",
-      "integrity": "sha512-qbXG3wL5Uh2JB92EKeX2hPtO9c/t75qVxQjVLYuTFfhHifLZzv9CBvLCvoaBhLrAC/xTMVht7DK/NofYK8X4Dg==",
-      "dev": true,
-      "dependencies": {
-        "@github/browserslist-config": "^1.0.0",
-        "@typescript-eslint/eslint-plugin": "^7.0.1",
-        "@typescript-eslint/parser": "^7.0.1",
-        "aria-query": "^5.3.0",
-        "eslint-config-prettier": ">=8.0.0",
-        "eslint-plugin-escompat": "^3.3.3",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-filenames": "^1.3.2",
-        "eslint-plugin-i18n-text": "^1.0.1",
-        "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-no-only-tests": "^3.0.0",
-        "eslint-plugin-prettier": "^5.0.0",
-        "eslint-rule-documentation": ">=1.0.0",
-        "jsx-ast-utils": "^3.3.2",
-        "prettier": "^3.0.0",
-        "svg-element-attributes": "^1.3.1"
-      },
-      "bin": {
-        "eslint-ignore-errors": "bin/eslint-ignore-errors.js"
-      },
-      "peerDependencies": {
-        "eslint": "^8.0.1"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/eslint-plugin-prettier": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
-      "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
-      "dev": true,
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.9.1"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": "*",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-primer-react/node_modules/synckit": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
-      "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
-      "dev": true,
-      "dependencies": {
-        "@pkgr/core": "^0.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -20055,6 +19710,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -20616,6 +20272,7 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -21689,6 +21346,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23506,6 +23164,7 @@
     },
     "node_modules/react": {
       "version": "17.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -23572,6 +23231,7 @@
     },
     "node_modules/react-dom": {
       "version": "17.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -24487,6 +24147,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -28138,7 +27799,7 @@
     },
     "packages/design-tokens": {
       "name": "@primer/brand-primitives",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "license": "MIT",
       "devDependencies": {
         "@primer/primitives": "9.1.1",
@@ -28151,7 +27812,7 @@
     },
     "packages/e2e": {
       "name": "@primer/brand-e2e",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "license": "MIT",
       "devDependencies": {
         "@github/axe-github": "^0.5.0",
@@ -28165,7 +27826,7 @@
     },
     "packages/fonts": {
       "name": "@primer/brand-fonts",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -28174,7 +27835,7 @@
     },
     "packages/react": {
       "name": "@primer/react-brand",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "license": "MIT",
       "dependencies": {
         "@oddbird/popover-polyfill": "0.4.3",
@@ -28225,7 +27886,7 @@
     },
     "packages/repo-configs": {
       "name": "@primer/brand-config",
-      "version": "0.40.0",
+      "version": "0.40.1",
       "license": "MIT"
     }
   },
@@ -28639,8 +28300,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -29993,13 +29653,11 @@
     },
     "@csstools/postcss-unset-value": {
       "version": "1.0.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@csstools/selector-specificity": {
       "version": "2.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -31517,12 +31175,6 @@
       "dev": true,
       "optional": true
     },
-    "@pkgr/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
-      "dev": true
-    },
     "@pkgr/utils": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
@@ -31639,8 +31291,7 @@
       "version": "19.8.0",
       "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.8.0.tgz",
       "integrity": "sha512-2Z+D7xTloFTLQVRUEbg0pQpe6aTL9RR+8RqBhjkrF+BFuVdM1ENOyjywaGEO7DIkPU5Zxlv0gxSlD85LQxL+sw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@primer/primitives": {
       "version": "9.1.1",
@@ -31975,8 +31626,7 @@
       "version": "8.2.6",
       "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.2.6.tgz",
       "integrity": "sha512-0JmRirMpxHS6VZzBk0kY871xWTpkk3TN4S1sxoFf5fcnCfVTHDjEJ5Ws/QWru1RJlIZHuJKRdQIA6Vuq5X+KfQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@storybook/addon-viewport": {
       "version": "8.2.6",
@@ -32233,8 +31883,7 @@
       "version": "8.2.6",
       "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.2.6.tgz",
       "integrity": "sha512-H8ckH1AnLkHtMtvJ3J8LxnmDtHxkJ7NJacGctHMRrsBIvdKTVwlT4su5nAVVJlan/PrEou+jESfw+OjjBYE5PA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@storybook/core": {
       "version": "8.2.6",
@@ -32573,8 +32222,7 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.2.10.tgz",
       "integrity": "sha512-310apKdDcjbbX2VSLWPwhEwAgjxTzVagrwucVZIdGPErwiAppX8KvBuWZgPo+rQLVrtH8S+pw1dbUwjcE6d7og==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@storybook/instrumenter": {
       "version": "8.2.6",
@@ -32591,8 +32239,7 @@
       "version": "8.2.6",
       "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.2.6.tgz",
       "integrity": "sha512-uv36h/b5RhlajWtEg4cVPBYV8gZs6juux0nIE+6G9i7vt8Ild6gM9tW1KNabgZcaHFiyWJYCNWxJZoKjgUmXDg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@storybook/node-logger": {
       "version": "7.6.17",
@@ -32797,8 +32444,7 @@
           "version": "8.2.6",
           "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.2.6.tgz",
           "integrity": "sha512-5vTj2ndX5ng4nDntZYe+r8UwLjCIGFymhq5/r2adAvRKL+Bo4zQDWGO7bhvGJk16do2THb2JvPz49ComW9LLZw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@types/node": {
           "version": "18.19.31",
@@ -32848,8 +32494,7 @@
       "version": "8.2.6",
       "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.2.6.tgz",
       "integrity": "sha512-B+x8UAEQPDp1yhN3tMh09NvSL38QNfJB7PAyLgKrfE7xIAzvewq+RLW2DfGkoZCy+Zr7QSHm1p7NOgud8+sQCg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@storybook/react-webpack5": {
       "version": "8.2.6",
@@ -32988,8 +32633,7 @@
           "version": "14.5.2",
           "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
           "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -33925,8 +33569,7 @@
       "version": "8.2.6",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.2.6.tgz",
       "integrity": "sha512-ICnYuLIVsYifVCMQljdHgrp+5vAquNybHxDGWiPeOxBicotwHF8rLhTckD2CdVQbMp0jk6r6jetvjXbFJ2MbvQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@storybook/types": {
       "version": "7.6.17",
@@ -34061,80 +33704,70 @@
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.16.tgz",
       "integrity": "sha512-UOCcH1GvjRnnM/LWT6VCGpIk0OhHRq6v1U6QXuPt5wVsgXnXQwnf5k3sG5Cm56hQHDvhRPY6HCsHi/p0oek8oQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/core-darwin-x64": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.16.tgz",
       "integrity": "sha512-t3bgqFoYLWvyVtVL6KkFNCINEoOrIlyggT/kJRgi1y0aXSr0oVgcrQ4ezJpdeahZZ4N+Q6vT3ffM30yIunELNA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/core-linux-arm-gnueabihf": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.16.tgz",
       "integrity": "sha512-DvHuwvEF86YvSd0lwnzVcjOTZ0jcxewIbsN0vc/0fqm9qBdMMjr9ox6VCam1n3yYeRtj4VFgrjeNFksqbUejdQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/core-linux-arm64-gnu": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.16.tgz",
       "integrity": "sha512-9Uu5YlPbyCvbidjKtYEsPpyZlu16roOZ5c2tP1vHfnU9bgf5Tz5q5VovSduNxPHx+ed2iC1b1URODHvDzbbDuQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/core-linux-arm64-musl": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.16.tgz",
       "integrity": "sha512-/YZq/qB1CHpeoL0eMzyqK5/tYZn/rzKoCYDviFU4uduSUIJsDJQuQA/skdqUzqbheOXKAd4mnJ1hT04RbJ8FPQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/core-linux-x64-gnu": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.16.tgz",
       "integrity": "sha512-UUjaW5VTngZYDcA8yQlrFmqs1tLi1TxbKlnaJwoNhel9zRQ0yG1YEVGrzTvv4YApSuIiDK18t+Ip927bwucuVQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/core-linux-x64-musl": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.16.tgz",
       "integrity": "sha512-aFhxPifevDTwEDKPi4eRYWzC0p/WYJeiFkkpNU5Uc7a7M5iMWPAbPFUbHesdlb9Jfqs5c07oyz86u+/HySBNPQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.16.tgz",
       "integrity": "sha512-bTD43MbhIHL2s5QgCwyleaGwl96Gk/scF2TaVKdUe4QlJCDV/YK9h5oIBAp63ckHtE8GHlH4c8dZNBiAXn4Org==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/core-win32-ia32-msvc": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.16.tgz",
       "integrity": "sha512-/lmZeAN/qV5XbK2SEvi8e2RkIg8FQNYiSA8y2/Zb4gTUMKVO5JMLH0BSWMiIKMstKDPDSxMWgwJaQHF8UMyPmQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/core-win32-x64-msvc": {
       "version": "1.4.16",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.16.tgz",
       "integrity": "sha512-BPAfFfODWXtUu6SwaTTftDHvcbDyWBSI/oanUeRbQR5vVWkXoQ3cxLTsDluc3H74IqXS5z1Uyoe0vNo2hB1opA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@swc/counter": {
       "version": "0.1.3",
@@ -35041,8 +34674,7 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -35053,8 +34685,7 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -35145,13 +34776,11 @@
     },
     "acorn-import-assertions": {
       "version": "1.9.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -35209,8 +34838,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -35463,8 +35091,7 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-jest": {
       "version": "29.7.0",
@@ -36543,8 +36170,7 @@
     },
     "css-prefers-color-scheme": {
       "version": "6.0.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-select": {
       "version": "4.3.0",
@@ -37464,8 +37090,7 @@
     },
     "eslint-config-prettier": {
       "version": "8.8.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",
@@ -37550,14 +37175,14 @@
       }
     },
     "eslint-plugin-github": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.10.1.tgz",
-      "integrity": "sha512-1AqQBockOM+m0ZUpwfjWtX0lWdX5cRi/hwJnSNvXoOmz/Hh+ULH6QFz6ENWueTWjoWpgPv0af3bj+snps6o4og==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.2.tgz",
+      "integrity": "sha512-nMdzWJQ5CimjQDY6SFeJ0KIXuNFf0dgDWEd4eP3UWfuTuP/dXcZJDg7MQRvAFt743T1zUi4+/HdOihfu8xJkLA==",
       "dev": true,
       "requires": {
         "@github/browserslist-config": "^1.0.0",
-        "@typescript-eslint/eslint-plugin": "^6.0.0",
-        "@typescript-eslint/parser": "^6.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
         "aria-query": "^5.3.0",
         "eslint-config-prettier": ">=8.0.0",
         "eslint-plugin-escompat": "^3.3.3",
@@ -37574,110 +37199,109 @@
         "svg-element-attributes": "^1.3.1"
       },
       "dependencies": {
-        "@types/semver": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-          "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==",
-          "dev": true
-        },
         "@typescript-eslint/eslint-plugin": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.11.0.tgz",
-          "integrity": "sha512-uXnpZDc4VRjY4iuypDBKzW1rz9T5YBBK0snMn8MaTSNd2kMlj50LnLBABELjJiOL5YHk7ZD8hbSpI9ubzqYI0w==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+          "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
           "dev": true,
           "requires": {
-            "@eslint-community/regexpp": "^4.5.1",
-            "@typescript-eslint/scope-manager": "6.11.0",
-            "@typescript-eslint/type-utils": "6.11.0",
-            "@typescript-eslint/utils": "6.11.0",
-            "@typescript-eslint/visitor-keys": "6.11.0",
-            "debug": "^4.3.4",
+            "@eslint-community/regexpp": "^4.10.0",
+            "@typescript-eslint/scope-manager": "8.7.0",
+            "@typescript-eslint/type-utils": "8.7.0",
+            "@typescript-eslint/utils": "8.7.0",
+            "@typescript-eslint/visitor-keys": "8.7.0",
             "graphemer": "^1.4.0",
-            "ignore": "^5.2.4",
+            "ignore": "^5.3.1",
             "natural-compare": "^1.4.0",
-            "semver": "^7.5.4",
-            "ts-api-utils": "^1.0.1"
+            "ts-api-utils": "^1.3.0"
           }
         },
         "@typescript-eslint/parser": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.11.0.tgz",
-          "integrity": "sha512-+whEdjk+d5do5nxfxx73oanLL9ghKO3EwM9kBCkUtWMRwWuPaFv9ScuqlYfQ6pAD6ZiJhky7TZ2ZYhrMsfMxVQ==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+          "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/scope-manager": "6.11.0",
-            "@typescript-eslint/types": "6.11.0",
-            "@typescript-eslint/typescript-estree": "6.11.0",
-            "@typescript-eslint/visitor-keys": "6.11.0",
+            "@typescript-eslint/scope-manager": "8.7.0",
+            "@typescript-eslint/types": "8.7.0",
+            "@typescript-eslint/typescript-estree": "8.7.0",
+            "@typescript-eslint/visitor-keys": "8.7.0",
             "debug": "^4.3.4"
           }
         },
         "@typescript-eslint/scope-manager": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.11.0.tgz",
-          "integrity": "sha512-0A8KoVvIURG4uhxAdjSaxy8RdRE//HztaZdG8KiHLP8WOXSk0vlF7Pvogv+vlJA5Rnjj/wDcFENvDaHb+gKd1A==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+          "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "6.11.0",
-            "@typescript-eslint/visitor-keys": "6.11.0"
+            "@typescript-eslint/types": "8.7.0",
+            "@typescript-eslint/visitor-keys": "8.7.0"
           }
         },
         "@typescript-eslint/type-utils": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.11.0.tgz",
-          "integrity": "sha512-nA4IOXwZtqBjIoYrJcYxLRO+F9ri+leVGoJcMW1uqr4r1Hq7vW5cyWrA43lFbpRvQ9XgNrnfLpIkO3i1emDBIA==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+          "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/typescript-estree": "6.11.0",
-            "@typescript-eslint/utils": "6.11.0",
+            "@typescript-eslint/typescript-estree": "8.7.0",
+            "@typescript-eslint/utils": "8.7.0",
             "debug": "^4.3.4",
-            "ts-api-utils": "^1.0.1"
+            "ts-api-utils": "^1.3.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.11.0.tgz",
-          "integrity": "sha512-ZbEzuD4DwEJxwPqhv3QULlRj8KYTAnNsXxmfuUXFCxZmO6CF2gM/y+ugBSAQhrqaJL3M+oe4owdWunaHM6beqA==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+          "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.11.0.tgz",
-          "integrity": "sha512-Aezzv1o2tWJwvZhedzvD5Yv7+Lpu1by/U1LZ5gLc4tCx8jUmuSCMioPFRjliN/6SJIvY6HpTtJIWubKuYYYesQ==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+          "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "6.11.0",
-            "@typescript-eslint/visitor-keys": "6.11.0",
+            "@typescript-eslint/types": "8.7.0",
+            "@typescript-eslint/visitor-keys": "8.7.0",
             "debug": "^4.3.4",
-            "globby": "^11.1.0",
+            "fast-glob": "^3.3.2",
             "is-glob": "^4.0.3",
-            "semver": "^7.5.4",
-            "ts-api-utils": "^1.0.1"
+            "minimatch": "^9.0.4",
+            "semver": "^7.6.0",
+            "ts-api-utils": "^1.3.0"
           }
         },
         "@typescript-eslint/utils": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.11.0.tgz",
-          "integrity": "sha512-p23ibf68fxoZy605dc0dQAEoUsoiNoP3MD9WQGiHLDuTSOuqoTsa4oAy+h3KDkTcxbbfOtUjb9h3Ta0gT4ug2g==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+          "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
           "dev": true,
           "requires": {
             "@eslint-community/eslint-utils": "^4.4.0",
-            "@types/json-schema": "^7.0.12",
-            "@types/semver": "^7.5.0",
-            "@typescript-eslint/scope-manager": "6.11.0",
-            "@typescript-eslint/types": "6.11.0",
-            "@typescript-eslint/typescript-estree": "6.11.0",
-            "semver": "^7.5.4"
+            "@typescript-eslint/scope-manager": "8.7.0",
+            "@typescript-eslint/types": "8.7.0",
+            "@typescript-eslint/typescript-estree": "8.7.0"
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.11.0.tgz",
-          "integrity": "sha512-+SUN/W7WjBr05uRxPggJPSzyB8zUpaYo2hByKasWbqr3PM8AXfZt8UHdNpBS1v9SA62qnSSMF3380SwDqqprgQ==",
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+          "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "6.11.0",
-            "eslint-visitor-keys": "^3.4.1"
+            "@typescript-eslint/types": "8.7.0",
+            "eslint-visitor-keys": "^3.4.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
           }
         },
         "eslint-plugin-prettier": {
@@ -37690,13 +37314,13 @@
             "synckit": "^0.8.5"
           }
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
           "dev": true,
           "requires": {
-            "yallist": "^4.0.0"
+            "brace-expansion": "^2.0.1"
           }
         },
         "prettier": {
@@ -37706,13 +37330,10 @@
           "dev": true
         },
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+          "dev": true
         },
         "synckit": {
           "version": "0.8.5",
@@ -37723,19 +37344,12 @@
             "@pkgr/utils": "^2.3.1",
             "tslib": "^2.5.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
         }
       }
     },
     "eslint-plugin-i18n-text": {
       "version": "1.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-import": {
       "version": "2.27.5",
@@ -37849,179 +37463,6 @@
         "eslint-traverse": "^1.0.0",
         "lodash": "^4.17.21",
         "styled-system": "^5.1.5"
-      },
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
-          "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
-          "dev": true,
-          "requires": {
-            "@eslint-community/regexpp": "^4.10.0",
-            "@typescript-eslint/scope-manager": "7.18.0",
-            "@typescript-eslint/type-utils": "7.18.0",
-            "@typescript-eslint/utils": "7.18.0",
-            "@typescript-eslint/visitor-keys": "7.18.0",
-            "graphemer": "^1.4.0",
-            "ignore": "^5.3.1",
-            "natural-compare": "^1.4.0",
-            "ts-api-utils": "^1.3.0"
-          }
-        },
-        "@typescript-eslint/parser": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
-          "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/scope-manager": "7.18.0",
-            "@typescript-eslint/types": "7.18.0",
-            "@typescript-eslint/typescript-estree": "7.18.0",
-            "@typescript-eslint/visitor-keys": "7.18.0",
-            "debug": "^4.3.4"
-          }
-        },
-        "@typescript-eslint/scope-manager": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
-          "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "7.18.0",
-            "@typescript-eslint/visitor-keys": "7.18.0"
-          }
-        },
-        "@typescript-eslint/type-utils": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
-          "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/typescript-estree": "7.18.0",
-            "@typescript-eslint/utils": "7.18.0",
-            "debug": "^4.3.4",
-            "ts-api-utils": "^1.3.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
-          "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
-          "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "7.18.0",
-            "@typescript-eslint/visitor-keys": "7.18.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "minimatch": "^9.0.4",
-            "semver": "^7.6.0",
-            "ts-api-utils": "^1.3.0"
-          }
-        },
-        "@typescript-eslint/utils": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
-          "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
-          "dev": true,
-          "requires": {
-            "@eslint-community/eslint-utils": "^4.4.0",
-            "@typescript-eslint/scope-manager": "7.18.0",
-            "@typescript-eslint/types": "7.18.0",
-            "@typescript-eslint/typescript-estree": "7.18.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "7.18.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
-          "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "7.18.0",
-            "eslint-visitor-keys": "^3.4.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "eslint-plugin-github": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-5.0.1.tgz",
-          "integrity": "sha512-qbXG3wL5Uh2JB92EKeX2hPtO9c/t75qVxQjVLYuTFfhHifLZzv9CBvLCvoaBhLrAC/xTMVht7DK/NofYK8X4Dg==",
-          "dev": true,
-          "requires": {
-            "@github/browserslist-config": "^1.0.0",
-            "@typescript-eslint/eslint-plugin": "^7.0.1",
-            "@typescript-eslint/parser": "^7.0.1",
-            "aria-query": "^5.3.0",
-            "eslint-config-prettier": ">=8.0.0",
-            "eslint-plugin-escompat": "^3.3.3",
-            "eslint-plugin-eslint-comments": "^3.2.0",
-            "eslint-plugin-filenames": "^1.3.2",
-            "eslint-plugin-i18n-text": "^1.0.1",
-            "eslint-plugin-import": "^2.25.2",
-            "eslint-plugin-jsx-a11y": "^6.7.1",
-            "eslint-plugin-no-only-tests": "^3.0.0",
-            "eslint-plugin-prettier": "^5.0.0",
-            "eslint-rule-documentation": ">=1.0.0",
-            "jsx-ast-utils": "^3.3.2",
-            "prettier": "^3.0.0",
-            "svg-element-attributes": "^1.3.1"
-          }
-        },
-        "eslint-plugin-prettier": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
-          "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
-          "dev": true,
-          "requires": {
-            "prettier-linter-helpers": "^1.0.0",
-            "synckit": "^0.9.1"
-          }
-        },
-        "minimatch": {
-          "version": "9.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        },
-        "prettier": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-          "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-          "dev": true
-        },
-        "synckit": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
-          "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
-          "dev": true,
-          "requires": {
-            "@pkgr/core": "^0.1.0",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "eslint-plugin-react": {
@@ -38069,8 +37510,7 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-storybook": {
       "version": "0.8.0",
@@ -39548,8 +38988,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -40302,8 +39741,7 @@
           "version": "1.5.3",
           "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
           "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "diff-sequences": {
           "version": "29.6.3",
@@ -41016,8 +40454,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-process-manager": {
       "version": "0.3.1",
@@ -41862,7 +41299,8 @@
       "dev": true
     },
     "js-tokens": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -42260,6 +41698,7 @@
     },
     "loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -42353,8 +41792,7 @@
       "version": "7.4.7",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.7.tgz",
       "integrity": "sha512-0+ls1IQZdU6cwM1yu0ZjjiVWYtkbExSyUIFU2ZeDIFuZM1W42Mh4OlJ4nb4apX4H8smxDHRdFaoIVJGwfv5hkg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "mdast-util-compact": {
       "version": "2.0.1",
@@ -42975,7 +42413,8 @@
       }
     },
     "object-assign": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.12.3",
@@ -43541,13 +42980,11 @@
     },
     "postcss-font-variant": {
       "version": "5.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-gap-properties": {
       "version": "3.0.5",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-icss-keyframes": {
       "version": "0.2.1",
@@ -43618,8 +43055,7 @@
     },
     "postcss-initial": {
       "version": "4.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-lab-function": {
       "version": "4.2.1",
@@ -43668,18 +43104,15 @@
     },
     "postcss-logical": {
       "version": "5.0.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.3",
@@ -43714,8 +43147,7 @@
     },
     "postcss-opacity-percentage": {
       "version": "1.1.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-overflow-shorthand": {
       "version": "3.0.4",
@@ -43726,8 +43158,7 @@
     },
     "postcss-page-break": {
       "version": "3.0.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-place": {
       "version": "7.0.5",
@@ -43814,8 +43245,7 @@
     },
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-selector-not": {
       "version": "6.0.1",
@@ -44056,6 +43486,7 @@
     },
     "react": {
       "version": "17.0.2",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -44065,8 +43496,7 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
       "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-docgen": {
       "version": "7.0.3",
@@ -44101,11 +43531,11 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
       "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-dom": {
       "version": "17.0.2",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -44734,6 +44164,7 @@
     },
     "scheduler": {
       "version": "0.20.2",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -45619,8 +45050,7 @@
     },
     "style-loader": {
       "version": "3.3.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "styled-system": {
       "version": "5.1.5",
@@ -45986,8 +45416,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ts-dedent": {
       "version": "2.2.0",
@@ -47110,8 +46539,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml": {
       "version": "1.0.1",
@@ -47194,8 +46622,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.3.1.tgz",
       "integrity": "sha512-uFzCZz7FQis256dqw4AhPQgD6f3pzNca/Zh62RNELavlumQB3nDIUFbF5JQfFLcMbO1s02Q7Xg/gpcOBlEnYZA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@typescript-eslint/parser": "^5.59.7",
     "eslint": "^8.41.0",
     "eslint-import-resolver-typescript": "^2.7.1",
-    "eslint-plugin-github": "^4.10.1",
+    "eslint-plugin-github": "^5.0.2",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-mdx": "^1.17.1",


### PR DESCRIPTION
## Summary

As per our [Accessibility Automation Scorecard](https://catalog.githubapp.com/services/primer/scorecards/accessibility-automation), we need to update `eslint-plugin-github` to the latest version to ensure that our codebase is up-to-date with the latest accessibility standards.


## List of notable changes:

- Update `eslint-plugin-github` to the latest version

## What should reviewers focus on?

- Ensure that linting jobs in the CI pass 

## Supporting resources (related issues, external links, etc):

- [Accessibility automation scorecard](https://catalog.githubapp.com/services/primer/scorecards/accessibility-automation)

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change