### PR TITLE
Fix Storybook links

### DIFF
--- a/apps/docs/content/components/ActionMenu.mdx
+++ b/apps/docs/content/components/ActionMenu.mdx
@@ -3,7 +3,7 @@ title: Action menu
 status: Experimental
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=4912%3A32799'
 source: https://github.com/primer/brand/tree/main/packages/react/src/ActionMenu/ActionMenu.tsx
-storybook: '/brand/storybook/?path=/story/components-actionmenu-features--default'
+storybook: '/brand/storybook/?path=/story/components-actionmenu--default'
 description: Use the action menu component to display a list of actions or selections that expand through a trigger button.
 ---
 

--- a/apps/docs/content/components/Breadcrumbs.mdx
+++ b/apps/docs/content/components/Breadcrumbs.mdx
@@ -2,7 +2,7 @@
 title: Breadcrumbs
 status: Experimental
 source: https://github.com/primer/brand/tree/main/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
-storybook: '/brand/storybook/?path=/story/components-breadcrumbs--default'
+storybook: '/brand/storybook/?path=/story/components-breadcrumbs--playground'
 description: Use breadcrumbs to enable wayfinding through navigational links
 ---
 

--- a/apps/docs/content/components/Card/react.mdx
+++ b/apps/docs/content/components/Card/react.mdx
@@ -2,7 +2,7 @@
 title: Card
 status: Experimental
 source: https://github.com/primer/brand/tree/main/packages/react/src/Card/Card.tsx
-storybook: '/brand/storybook/?path=/story/components-card--default'
+storybook: '/brand/storybook/?path=/story/components-card--playground'
 description: Use the card component to display information in a compact way and link to other internal pages.
 a11yReviewed: true
 ---

--- a/apps/docs/content/components/Checkbox/react.mdx
+++ b/apps/docs/content/components/Checkbox/react.mdx
@@ -3,7 +3,7 @@ title: Checkbox
 status: Experimental
 source: https://github.com/primer/brand/blob/main/packages/react/src/forms/Checkbox/Checkbox.tsx
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=1377%3A30754'
-storybook: '/brand/storybook/?path=/story/components-forms-textinput--playground'
+storybook: '/brand/storybook/?path=/story/components-forms-checkbox--playground'
 description: Use the checkbox component to select one or more options of a limited number of choices.
 ---
 

--- a/apps/docs/content/components/FormControl.mdx
+++ b/apps/docs/content/components/FormControl.mdx
@@ -3,7 +3,7 @@ title: Form control
 status: Experimental
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=1793%3A27781'
 source: https://github.com/primer/brand/blob/main/packages/react/src/forms/FormControl/FormControl.tsx
-storybook: '/brand/storybook/?path=/story/components-forms-formcontrol--playground'
+storybook: '/brand/storybook/?path=/story/components-forms-formcontrol--text-input-playground'
 description: Use the form control component to display form inputs alongside labels, validation and more.
 ---
 

--- a/apps/docs/content/components/Grid/react.mdx
+++ b/apps/docs/content/components/Grid/react.mdx
@@ -2,7 +2,7 @@
 title: Grid
 status: Experimental
 source: https://github.com/primer/brand/tree/main/packages/react/src/Grid/Grid.tsx
-storybook: '/brand/storybook/?path=/story/components-grid--default'
+storybook: '/brand/storybook/?path=/story/components-grid--playground'
 description: Use the grid component to create flexible and responsive grid-based layouts.
 ---
 

--- a/apps/docs/content/components/Heading/react.mdx
+++ b/apps/docs/content/components/Heading/react.mdx
@@ -4,7 +4,7 @@ status: Experimental
 a11yReviewed: true
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=354%3A8982'
 source: https://github.com/primer/brand/blob/main/packages/react/src/Heading/Heading.tsx
-storybook: '/brand/storybook/?path=/story/components-heading--default'
+storybook: '/brand/storybook/?path=/story/components-heading--playground'
 description: Use the heading component to render title or subtitle text.
 ---
 

--- a/apps/docs/content/components/IDE.mdx
+++ b/apps/docs/content/components/IDE.mdx
@@ -2,7 +2,7 @@
 title: IDE
 status: Experimental
 source: https://github.com/primer/brand/tree/main/packages/react/src/IDE/IDE.tsx
-storybook: '/brand/storybook/?path=/story/components-ide--default'
+storybook: '/brand/storybook/?path=/story/components-ide--playground'
 description: Use the IDE to showcase a simulated integrated developer environment, complete with a code editor and AI chat that's intended to enhancing code representation in marketing contexts.
 ---
 

--- a/apps/docs/content/components/Label/react.mdx
+++ b/apps/docs/content/components/Label/react.mdx
@@ -3,7 +3,7 @@ title: Label
 status: Experimental
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=6084-28401'
 source: https://github.com/primer/brand/blob/main/packages/react/src/Label/Label.tsx
-storybook: '/brand/storybook/?path=/story/components-label--default'
+storybook: '/brand/storybook/?path=/story/components-label--playground'
 a11yReviewed: true
 description: Use the label component to add metadata or indicate the status of items.
 ---

--- a/apps/docs/content/components/LogoSuite/react.mdx
+++ b/apps/docs/content/components/LogoSuite/react.mdx
@@ -3,7 +3,7 @@ title: Logo suite
 status: Experimental
 a11yReviewed: false
 source: https://github.com/primer/brand/blob/main/packages/react/src/LogoSuite/LogoSuite.tsx
-storybook: '/brand/storybook/?path=/story/components-logosuite--default'
+storybook: '/brand/storybook/?path=/story/components-logosuite--playground'
 description: Use a logo suite to present a list logos, such as sponsors or vendors.
 ---
 

--- a/apps/docs/content/components/MinimalFooter.mdx
+++ b/apps/docs/content/components/MinimalFooter.mdx
@@ -3,7 +3,7 @@ title: Minimal footer
 status: Experimental
 source: https://github.com/primer/brand/blob/main/packages/react/src/MinimalFooter/MinimalFooter.tsx
 figma: https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=4686%3A30927&t=QKh20cPDVIFtBCHj-0
-storybook: '/brand/storybook/?path=/story/components-minimalfooter--default'
+storybook: '/brand/storybook/?path=/story/components-minimalfooter--playground'
 description: Use the minimal footer component to provide a global footer featuring legal links, GitHub logomarks and footnotes.
 ---
 

--- a/apps/docs/content/components/OrderedList/react.mdx
+++ b/apps/docs/content/components/OrderedList/react.mdx
@@ -3,7 +3,7 @@ title: Ordered list
 status: Experimental
 figma: https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/branch/NzBMPIfPrFU9I87d3k7KVq/Primer-Brand?node-id=4045%3A17560&t=W8B9ArDngbzJCC2m-0
 source: https://github.com/primer/brand/blob/main/packages/react/src/list/OrderedList/OrderedList.tsx
-storybook: '/brand/storybook/?path=/story/components-orderedlist--default'
+storybook: '/brand/storybook/?path=/story/components-orderedlist--playground'
 description: Use the ordered list component to display a list of numbered items.
 ---
 

--- a/apps/docs/content/components/Pagination.mdx
+++ b/apps/docs/content/components/Pagination.mdx
@@ -2,7 +2,7 @@
 title: Pagination
 status: Experimental
 source: https://github.com/primer/brand/tree/main/packages/react/src/Pagination/Pagination.tsx
-storybook: '/brand/storybook/?path=/story/components-pagination--default'
+storybook: '/brand/storybook/?path=/story/components-pagination--playground'
 description: Use Pagination to display a sequence of links that allow navigation to discrete, related pages.
 ---
 

--- a/apps/docs/content/components/Pillar/react.mdx
+++ b/apps/docs/content/components/Pillar/react.mdx
@@ -2,7 +2,7 @@
 title: Pillar
 status: Experimental
 source: https://github.com/primer/brand/tree/main/packages/react/src/Pillar/Pillar.tsx
-storybook: '/brand/storybook/?path=/story/components-pillar--default'
+storybook: '/brand/storybook/?path=/story/components-pillar--playground'
 a11yReviewed: true
 description: Use the pillar component to group related content together.
 figma: https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=6849-31364&mode=design

--- a/apps/docs/content/components/Prose.mdx
+++ b/apps/docs/content/components/Prose.mdx
@@ -2,7 +2,7 @@
 title: Prose
 status: Experimental
 source: https://github.com/primer/brand/blob/main/packages/react/src/Prose/Prose.tsx
-storybook: '/brand/storybook/?path=/story/components-prose--default'
+storybook: '/brand/storybook/?path=/story/components-prose--playground'
 description: Use the prose component to apply Primer Brand styles to HTML markup.
 ---
 

--- a/apps/docs/content/components/Radio/react.mdx
+++ b/apps/docs/content/components/Radio/react.mdx
@@ -4,7 +4,7 @@ description: Use the radio component when a user needs to select one option from
 status: Experimental
 source: https://github.com/primer/brand/blob/main/packages/react/src/forms/Radio/Radio.tsx
 figma: https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=3063%3A30198&t=QKh20cPDVIFtBCHj-0
-storybook: '/react/storybook?path=/story/components-forms-radio--playground'
+storybook: '/react/storybook?path=/story/components-forms-radio--default'
 ---
 
 import ComponentLayout from '../../../src/layouts/component-layout'

--- a/apps/docs/content/components/Select.mdx
+++ b/apps/docs/content/components/Select.mdx
@@ -3,7 +3,7 @@ title: Select
 status: Experimental
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=1793%3A28117'
 source: https://github.com/primer/brand/blob/main/packages/react/src/forms/Select/Select.tsx
-storybook: '/brand/storybook/?path=/story/components-forms-formcontrol--playground'
+storybook: '/brand/storybook/?path=/story/components-forms-select--playground'
 description: Use the select component to enable selection of one option from a list.
 ---
 

--- a/apps/docs/content/components/Stack/react.mdx
+++ b/apps/docs/content/components/Stack/react.mdx
@@ -1,8 +1,8 @@
 ---
 title: Stack
 status: Experimental
-source: https://github.com/primer/brand/tree/main/src/Text/Text.tsx
-storybook: https://github.com/primer/brand/blob/main/packages/react/src/Stack/Stack.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Stack/Stack.tsx
+storybook: '/brand/storybook/?path=/story/components-stack--playground'
 description: Use the stack component to enable layout of its immediate children along the vertical or horizontal axis.
 ---
 

--- a/apps/docs/content/components/SubdomainNavBar.mdx
+++ b/apps/docs/content/components/SubdomainNavBar.mdx
@@ -3,7 +3,7 @@ title: Subdomain nav bar
 status: Experimental
 figma: https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=1024%3A32796
 source: https://github.com/primer/brand/blob/main/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
-storybook: '/brand/storybook/?path=/story/components-subdomainnavbar--default'
+storybook: '/brand/storybook/?path=/story/components-subdomainnavbar--playground'
 description: Use the subdomain nav bar component for top level navigation for subdomain sites.
 ---
 

--- a/apps/docs/content/components/Text/react.mdx
+++ b/apps/docs/content/components/Text/react.mdx
@@ -4,7 +4,7 @@ status: Experimental
 a11yReviewed: true
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=354%3A9513'
 source: https://github.com/primer/brand/blob/main/packages/react/src/Text/Text.tsx
-storybook: '/brand/storybook/?path=/story/components-text--scale'
+storybook: '/brand/storybook/?path=/story/components-text--playground'
 description: Use the text component create a range of body text
 ---
 

--- a/apps/docs/content/components/Textarea.mdx
+++ b/apps/docs/content/components/Textarea.mdx
@@ -3,7 +3,7 @@ title: Textarea
 description: Use the textarea component for multi-line text input form fields.
 status: Experimental
 source: https://github.com/primer/brand/blob/main/packages/react/src/forms/Textarea/Textarea.tsx
-storybook: '/react/storybook?path=/story/components-forms-textarea--playground'
+storybook: '/react/storybook?path=/story/components-forms-textarea--default'
 ---
 
 import {PropTableValues} from '../../src/components'

--- a/apps/docs/content/components/Tooltip.mdx
+++ b/apps/docs/content/components/Tooltip.mdx
@@ -2,7 +2,7 @@
 title: Tooltip
 status: Experimental
 source: https://github.com/primer/brand/tree/main/packages/react/src/Tooltip/Tooltip.tsx
-storybook: '/brand/storybook/?path=/story/components-tooltip--default'
+storybook: '/brand/storybook/?path=/story/components-tooltip--playground'
 description: Use the tooltip component to display a short message when a user hovers or focuses an interactive element.
 ---
 
@@ -19,7 +19,7 @@ import {Tooltip} from '@primer/react-brand'
 
 ```jsx
 <Tooltip text="Sample tooltip content">
-    <Button>Action</Button>
+  <Button>Action</Button>
 </Tooltip>
 ```
 
@@ -31,7 +31,7 @@ As long as there is enough room in the viewport, the tooltip will appear in the 
 
 ```jsx
 <Tooltip text="Sample tooltip content" direction="e">
-    <Button>Action</Button>
+  <Button>Action</Button>
 </Tooltip>
 ```
 
@@ -43,15 +43,16 @@ Use this with caution. It is generally better to use a visible label for better 
 
 ```jsx
 <Tooltip text="Go fullscreen" type="label">
-    <Button hasArrow={false}><ScreenFullIcon /></Button>
+  <Button hasArrow={false}>
+    <ScreenFullIcon />
+  </Button>
 </Tooltip>
 ```
 
 ## Component props
 
-| name         | type                                                              | default         | required | description                             |
-| ------------ | ----------------------------------------------------------------- | --------------- | -------- | --------------------------------------- |
-| `direction`  | <PropTableValues values={['n', 'e', 's', 'w']} />                 | `'s'`           | `false`  | The side the tooltip appears on |
-| `text`       | `string`                                                          | `undefined`     | `true`   |  The text to be displayed in the tooltip |
-| `type`       | <PropTableValues values={['description', 'label']} />             | `'description'` | `false`  | The type of tooltip. `label` is used for labelling the element that triggers tooltip. `description` is used for describing or adding a suplementary information to the element that triggers the tooltip. |
-
+| name        | type                                                  | default         | required | description                                                                                                                                                                                               |
+| ----------- | ----------------------------------------------------- | --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `direction` | <PropTableValues values={['n', 'e', 's', 'w']} />     | `'s'`           | `false`  | The side the tooltip appears on                                                                                                                                                                           |
+| `text`      | `string`                                              | `undefined`     | `true`   | The text to be displayed in the tooltip                                                                                                                                                                   |
+| `type`      | <PropTableValues values={['description', 'label']} /> | `'description'` | `false`  | The type of tooltip. `label` is used for labelling the element that triggers tooltip. `description` is used for describing or adding a suplementary information to the element that triggers the tooltip. |

--- a/apps/docs/content/components/UnorderedList/react.mdx
+++ b/apps/docs/content/components/UnorderedList/react.mdx
@@ -3,7 +3,7 @@ title: Unordered list
 status: Experimental
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/branch/NzBMPIfPrFU9I87d3k7KVq/Primer-Brand?node-id=4045%3A17093&t=XJ9W58VgtbVo74gb-0'
 source: https://github.com/primer/brand/tree/main/packages/react/src/list/UnorderedList/UnorderedList.tsx
-storybook: '/brand/storybook/?path=/story/components-unorderedlist--default'
+storybook: '/brand/storybook/?path=/story/components-unorderedlist--playground'
 description: Use the unordered list component to present a collection of items without specific ordering.
 ---
 


### PR DESCRIPTION
## Summary

Fixing any broken links, and updating pointing all Storybook links to the Playground story if available.

## Research

This issue has arisen because locally the links on the docs site do not point to the local Storybook instance, so it's a pain to manually check them (copy/pasting the story ID). I've created an issue to explore this #625

For this PR I hacked the component in doctocat that renders the storybook link to point towards my local Storybook server.

in `apps/docs/node_modules/@primer/gatsby-theme-doctocat/src/components/storybook-link.js`:
 ```js
  const storybookHref =
    process.env.NODE_ENV === 'development'
      ? `http://localhost:6006/${href.slice(href.indexOf('/brand/storybook/') + 17)}`
      : href
 ```

## What should reviewers focus on?

- It seemed there were about as many links to the default story as to the playground story. I went with playground because it seemed more recent components linked to that, but could flip to default if preferred

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
