### PR TITLE
use default tab order for AnchorNav

### DIFF
--- a/.changeset/soft-mugs-live.md
+++ b/.changeset/soft-mugs-live.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Improved keyboard navigation in mobile `AnchorNav` component. Arrow key navigation has been replaced with tab navigation.

--- a/packages/react/src/AnchorNav/AnchorNav.tsx
+++ b/packages/react/src/AnchorNav/AnchorNav.tsx
@@ -59,7 +59,6 @@ function _AnchorNav({children, enableDefaultBgColor = false, hideUntilSticky = f
 
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const rootRef = useRef<HTMLElement | null>(null)
-  const menuToggleButtonRef = useRef<HTMLButtonElement | null>(null)
   const linkContainerRef = useRef<HTMLDivElement | null>(null)
 
   const {isLarge} = useWindowSize()
@@ -87,7 +86,7 @@ function _AnchorNav({children, enableDefaultBgColor = false, hideUntilSticky = f
   }
 
   useKeyboardEscape(closeMenuCallback)
-  useExpandedMenu(menuOpen, linkContainerRef, menuToggleButtonRef, !isLarge)
+  useExpandedMenu(menuOpen, linkContainerRef, !isLarge)
 
   useEffect(() => {
     const queryResult = window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -213,7 +212,6 @@ function _AnchorNav({children, enableDefaultBgColor = false, hideUntilSticky = f
           )}
         >
           <button
-            ref={menuToggleButtonRef}
             onClick={handleMenuToggle}
             className={clsx(styles['AnchorNav-menu-button'])}
             aria-expanded={menuOpen ? 'true' : 'false'}

--- a/packages/react/src/AnchorNav/useExpandedMenu.ts
+++ b/packages/react/src/AnchorNav/useExpandedMenu.ts
@@ -1,11 +1,6 @@
 import React, {useEffect} from 'react'
 
-export const useExpandedMenu = (
-  open: boolean,
-  containerRef: React.RefObject<HTMLElement>,
-  anchorRef: React.RefObject<HTMLElement>,
-  isNarrow: boolean,
-) => {
+export const useExpandedMenu = (open: boolean, containerRef: React.RefObject<HTMLElement>, isNarrow: boolean) => {
   // Prevent background scroll when menu is open
   useEffect(() => {
     if (open && isNarrow) {
@@ -22,62 +17,4 @@ export const useExpandedMenu = (
       firstChildOfMenu.focus()
     }
   }, [open, containerRef])
-
-  // Manage the keyboard focus on the menu items
-  useEffect(() => {
-    const anchor = anchorRef.current
-    const container = containerRef.current
-    const nextNode = container?.nextSibling as HTMLElement | null
-    const childNodes = container?.children as unknown as HTMLElement[] | null // convert from HTMLCollecion to HTMLElement[]
-
-    let activeNodeIndex = 0
-
-    const handler = (event: KeyboardEvent) => {
-      if (!open || !container || !childNodes || childNodes.length <= 1) return
-
-      const lastChild = childNodes[childNodes.length - 1]
-      const lastChildIndexPos = childNodes.length - 1
-      // tab key
-      if (event.key === 'Tab') {
-        event.preventDefault()
-
-        if (nextNode?.getAttribute('data-forward-focus') === 'true' && nextNode.firstChild instanceof HTMLElement) {
-          nextNode.firstChild.focus()
-        } else {
-          nextNode?.focus()
-        }
-      }
-      // shift+tab
-      if (event.shiftKey && event.key === 'Tab') {
-        event.preventDefault()
-        anchor?.focus()
-      }
-      if (event.key === 'ArrowDown') {
-        event.preventDefault()
-        if (activeNodeIndex === lastChildIndexPos) {
-          childNodes[0].focus()
-          activeNodeIndex = 0
-          return
-        } else if (activeNodeIndex < lastChildIndexPos) {
-          childNodes[activeNodeIndex + 1].focus()
-          activeNodeIndex += 1
-          return
-        }
-      } else if (event.key === 'ArrowUp') {
-        event.preventDefault() // prevent scroll event
-        if (activeNodeIndex === 0) {
-          lastChild.focus()
-          activeNodeIndex = lastChildIndexPos
-          return
-        } else {
-          childNodes[activeNodeIndex - 1].focus()
-          activeNodeIndex--
-          return
-        }
-      }
-    }
-
-    container?.addEventListener('keydown', handler)
-    return () => container?.addEventListener('keydown', handler)
-  }, [open, containerRef, anchorRef])
 }


### PR DESCRIPTION
## Summary

Replace arrow key navigation with standard tab order navigation for the AnchorNav component.

## What should reviewers focus on?

- Ensure you can navigate through an AnchorNav using <kbd>Tab</kbd> and <kbd>Shift</kbd> + <kbd>Tab</kbd> keys

## Steps to test:

1. Open the AnchorNav component in Storybook
2. Resize your viewport to see the mobile AnchorNav
3. Use the <kbd>Tab</kbd> key to navigate through the links
4. Use the <kbd>Shift</kbd> + <kbd>Tab</kbd> to navigate backwards

## Supporting resources (related issues, external links, etc):

- [Link to updated AnchorNav Storybook](https://primer-02373c4008-26139705.drafts.github.io/storybook/?path=/story/components-anchornav-features--narrow-view)
- https://github.com/github/accessibility-audits/issues/7852

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:


https://github.com/user-attachments/assets/1b4aa8b8-9614-4396-8fda-be9e66335ded


