### PR TITLE
Fix FAQGroup autofocus with Alloy issue

### DIFF
--- a/.changeset/long-ties-burn.md
+++ b/.changeset/long-ties-burn.md
@@ -1,0 +1,5 @@
+---
+"@primer/react-brand": patch
+---
+
+FAQGroup use interaction gating instead of initialization gating due the Alloy prerender issue

--- a/.changeset/long-ties-burn.md
+++ b/.changeset/long-ties-burn.md
@@ -2,4 +2,4 @@
 "@primer/react-brand": patch
 ---
 
-FAQGroup use interaction gating instead of initialization gating due the Alloy prerender issue
+Updated `FAQGroup` autofocusing conditions

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
     },
     "apps/storybook": {
       "name": "@primer/brand-storybook",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.22.0",
@@ -31323,7 +31323,7 @@
     },
     "packages/design-tokens": {
       "name": "@primer/brand-primitives",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "MIT",
       "devDependencies": {
         "@primer/primitives": "^7.15.0",
@@ -31474,7 +31474,7 @@
     },
     "packages/e2e": {
       "name": "@primer/brand-e2e",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "MIT",
       "devDependencies": {
         "@github/axe-github": "^0.5.0",
@@ -31488,7 +31488,7 @@
     },
     "packages/fonts": {
       "name": "@primer/brand-fonts",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -31497,7 +31497,7 @@
     },
     "packages/react": {
       "name": "@primer/react-brand",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "MIT",
       "dependencies": {
         "@oddbird/popover-polyfill": "0.4.3",
@@ -31546,7 +31546,7 @@
     },
     "packages/repo-configs": {
       "name": "@primer/brand-config",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "MIT"
     }
   },

--- a/packages/react/src/FAQ/FAQGroup.tsx
+++ b/packages/react/src/FAQ/FAQGroup.tsx
@@ -32,12 +32,13 @@ type FAQGroupProps = React.PropsWithChildren<{
 
 function _FAQGroup({children, id, defaultSelectedIndex = 0, ...rest}: FAQGroupProps) {
   const [selectedIndex, setSelectedIndex] = React.useState(defaultSelectedIndex)
+  const [hasInteracted, setHasInteracted] = React.useState(false)
   const instanceId = useId(id)
-  const initialRender = React.useRef(true)
   const selectedTabRef = React.useRef<HTMLButtonElement>(null)
 
   const handleTabClick = (index: number) => (_event: React.MouseEvent<HTMLButtonElement>) => {
     setSelectedIndex(index)
+    if (!hasInteracted) setHasInteracted(true)
   }
 
   const handleKeyDown = (index: number) => (_event: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -45,6 +46,7 @@ function _FAQGroup({children, id, defaultSelectedIndex = 0, ...rest}: FAQGroupPr
       _event.preventDefault()
       const prevIndex = (index - 1 + faqChildren.length) % faqChildren.length
       setSelectedIndex(prevIndex)
+      if (!hasInteracted) setHasInteracted(true)
       return
     }
 
@@ -52,14 +54,14 @@ function _FAQGroup({children, id, defaultSelectedIndex = 0, ...rest}: FAQGroupPr
       _event.preventDefault()
       const nextIndex = (index + 1) % faqChildren.length
       setSelectedIndex(nextIndex)
+      if (!hasInteracted) setHasInteracted(true)
       return
     }
   }
 
   React.useEffect(() => {
-    if (!initialRender.current && selectedTabRef.current) selectedTabRef.current.focus()
-    if (initialRender.current) initialRender.current = false
-  }, [selectedIndex])
+    if (hasInteracted) selectedTabRef.current?.focus()
+  }, [hasInteracted, selectedIndex])
 
   const faqChildren = React.Children.toArray(children).filter(
     child => React.isValidElement<FAQRootProps>(child) && child.type === FAQ,


### PR DESCRIPTION
## Summary
I gated the focus logic via the initialRender ref to move focus on arrow navigation. However, the Alloy actually triggers the render of the FAQGroup component, which causes the initialRender ref to be set to false. This causes the autofocus to the first FAQGroup element and the page is scrolled to it.

This PR changes the logic to gate the focus logic via the hasInteracted state instead of the initialRender ref. This way, the focus logic is only triggered after the user has interacted with the FAQGroup component.

**This issue is only present in development environment** probably due the Alloy dev setup...

## List of notable changes:

- **updated** `FAQGroupProps` type to include `hasInteracted` state because the focus logic is gated via the `hasInteracted` state instead of the `initialRender` ref.

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

## What should reviewers focus on?

This can only be tested on the dotcom pages where the FAQGroup component is used, for instace `/features/copilot`. Arrow navigation should move the focus correctly and the page should not scroll to the first FAQGroup element on initial render.

## Supporting resources (related issues, external links, etc):

- https://github.com/github/marketing-platform-services/issues/3167#issuecomment-2191895803

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
