### PR TITLE
Tiny docs bugs

### DIFF
--- a/apps/docs/src/components/content/ColorThemePicker.js
+++ b/apps/docs/src/components/content/ColorThemePicker.js
@@ -1,7 +1,6 @@
 import {Box as PRCBox} from '@primer/react'
 import React from 'react'
 import {useColorTheme, availableModes} from './ColorThemeContext'
-import baseColorScales from '@primer/brand-primitives/lib/design-tokens/js/module/tokens/base/colors/light'
 
 export function ColorThemePicker() {
   const [colorTheme, setColorTheme] = useColorTheme()
@@ -47,9 +46,10 @@ export function ColorThemePicker() {
   )
 }
 
-function ColorThemePreview() {
+function ColorThemePreview({colorTheme}) {
   return (
     <PRCBox
+      data-color-mode={colorTheme}
       sx={{
         color: 'var(--brand-color-text-default)',
         bg: 'var(--brand-color-canvas-default)',
@@ -67,7 +67,7 @@ function ColorThemePreview() {
             sx={{
               width: 20,
               height: 20,
-              bg: baseColorScales.base.color.scale[name][5].value,
+              bg: `var(--base-color-scale-${name}-5)`,
               borderRadius: 999,
             }}
           />

--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -1,4 +1,4 @@
-import {ThemeProvider} from '../../../packages/react/src'
+import { ThemeProvider } from '../../../packages/react/src'
 import styles from './preview.module.css'
 import '../../../packages/react/src/css/stylesheets'
 import '../../../packages/react/src/css/utilities.css'
@@ -30,7 +30,7 @@ export const globalTypes = {
           title: 'All',
         },
       ],
-      title: true,
+      title: 'Color mode',
     },
   },
 }


### PR DESCRIPTION
## Summary

- Fix colour mode label in Storybook
- Fix theme selector on Color primitives page

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] All developer debugging and non-functional logging has been removed

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="553" alt="Theme selector with light and dark visuals matching" src="https://github.com/user-attachments/assets/5bc3c0aa-ebe9-4a7c-9cbf-fa5063b92db0">
<img width="405" alt="true label in Storybook toolbar" src="https://github.com/user-attachments/assets/5f3b8576-e307-489b-bacb-e228b4662f1b">


 </td>
<td valign="top">

<img width="558" alt="Theme selector with correct dark mode visual" src="https://github.com/user-attachments/assets/4fdb1fe7-79b5-4bc7-acb6-ebb64372e914">
<img width="451" alt="Color mode in Storybook toolbar" src="https://github.com/user-attachments/assets/2d3a4914-7285-41f8-8c56-07f204b112bc">


</td>
</tr>
</table>
