### PR TITLE
Only use CSS filter for raster logos, not SVGs

### DIFF
--- a/.changeset/happy-ducks-jump.md
+++ b/.changeset/happy-ducks-jump.md
@@ -1,0 +1,6 @@
+---
+'@primer/brand-primitives': patch
+'@primer/react-brand': patch
+---
+
+Style `LogoSuite` logos differently depending on their format. Images using the `<img>` tag will be styled with a CSS filter, whereas inline SVGs will be styled with CSS fill.

--- a/.changeset/happy-ducks-jump.md
+++ b/.changeset/happy-ducks-jump.md
@@ -3,4 +3,6 @@
 '@primer/react-brand': patch
 ---
 
-Style `LogoSuite` logos differently depending on their format. Images using the `<img>` tag will be styled with a CSS filter, whereas inline SVGs will be styled with CSS fill.
+Partial revert of changes to the `LogoSuite` logobar elements.
+
+To allow optimal treatment of logos based on their respective file formats, `<img>` tag will continue be styled with a CSS filter, whereas inline `<svg>` elements will be styled with CSS fill.

--- a/packages/design-tokens/src/tokens/functional/components/logosuite/colors.json
+++ b/packages/design-tokens/src/tokens/functional/components/logosuite/colors.json
@@ -4,12 +4,22 @@
       "color": {
         "logo": {
           "muted": {
-            "value": "brightness(0) saturate(100%) invert(37%) sepia(7%) saturate(778%) hue-rotate(171deg) brightness(96%) contrast(91%)",
-            "dark": "brightness(0) saturate(100%) invert(61%) sepia(8%) saturate(430%) hue-rotate(171deg) brightness(94%) contrast(92%)"
+            "value": "var(--brand-color-text-muted)",
+            "dark": "var(--brand-color-text-muted)"
           },
           "emphasis": {
-            "value": "brightness(0) saturate(100%) invert(12%) sepia(20%) saturate(450%) hue-rotate(172deg) brightness(100%) contrast(91%)",
-            "dark": "brightness(0) saturate(100%) invert(91%) sepia(2%) saturate(2455%) hue-rotate(193deg) brightness(107%) contrast(98%)"
+            "value": "var(--brand-color-text-default)",
+            "dark": "var(--brand-color-text-default)"
+          },
+          "filter": {
+            "muted": {
+              "value": "brightness(0) saturate(100%) invert(37%) sepia(7%) saturate(778%) hue-rotate(171deg) brightness(96%) contrast(91%)",
+              "dark": "brightness(0) saturate(100%) invert(61%) sepia(8%) saturate(430%) hue-rotate(171deg) brightness(94%) contrast(92%)"
+            },
+            "emphasis": {
+              "value": "brightness(0) saturate(100%) invert(12%) sepia(20%) saturate(450%) hue-rotate(172deg) brightness(100%) contrast(91%)",
+              "dark": "brightness(0) saturate(100%) invert(91%) sepia(2%) saturate(2455%) hue-rotate(193deg) brightness(107%) contrast(98%)"
+            }
           }
         }
       }

--- a/packages/react/src/LogoSuite/LogoSuite.module.css
+++ b/packages/react/src/LogoSuite/LogoSuite.module.css
@@ -54,15 +54,21 @@
 }
 
 .LogoSuite__logobar--variant-muted svg,
-.LogoSuite__logobar--variant-muted path,
+.LogoSuite__logobar--variant-muted path {
+  fill: var(--brand-LogoSuite-color-logo-muted);
+}
+
 .LogoSuite__logobar--variant-muted img {
-  filter: var(--brand-LogoSuite-color-logo-muted);
+  filter: var(--brand-LogoSuite-color-logo-filter-muted);
 }
 
 .LogoSuite__logobar--variant-emphasis svg,
-.LogoSuite__logobar--variant-emphasis path,
+.LogoSuite__logobar--variant-emphasis path {
+  fill: var(--brand-LogoSuite-color-logo-emphasis);
+}
+
 .LogoSuite__logobar--variant-emphasis img {
-  filter: var(--brand-LogoSuite-color-logo-emphasis);
+  filter: var(--brand-LogoSuite-color-logo-filter-emphasis);
 }
 
 .LogoSuite--start .LogoSuite__logobar {


### PR DESCRIPTION
## Summary

Style `LogoSuite` logos differently depending on their format. Images using the `<img>` tag will be styled with a CSS filter, whereas inline SVGs will be styled with CSS fill.

Reverts commit 9724866560efa2f85dd8dde0966f0a5d12503ade 

## List of notable changes:

- Added filters to `LogoSuite` colors.json
- Modified `LogoSuite.module.css` to use CSS fill for SVGs and CSS filter for raster logos 

## What should reviewers focus on?

- Ensure there are no visual regressions, and that the colours of the monochrome raster logos are consistent with their SVG counterparts.

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
