### PR TITLE
Fix Image component's `aspectRatio` prop

### DIFF
--- a/.changeset/strange-geckos-repair.md
+++ b/.changeset/strange-geckos-repair.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixes previously non-functional `aspectRatio` prop on `Image` component

--- a/packages/react/src/Image/Image.module.css
+++ b/packages/react/src/Image/Image.module.css
@@ -12,19 +12,19 @@
 }
 
 .Image--aspect-ratio-1-1 {
-  --brand-image-aspectRatio: 1 / 1;
+  aspect-ratio: 1 / 1;
 }
 
 .Image--aspect-ratio-16-9 {
-  --brand-image-aspectRatio: 16 / 9;
+  aspect-ratio: 16 / 9;
 }
 
 .Image--aspect-ratio-16-10 {
-  --brand-image-aspectRatio: 16 / 10;
+  aspect-ratio: 16 / 10;
 }
 
 .Image--aspect-ratio-4-3 {
-  --brand-image-aspectRatio: 4 / 3;
+  aspect-ratio: 4 / 3;
 }
 
 .Image--borderRadius-small {


### PR DESCRIPTION
## Summary

Fixes the previously non-functional `aspectRatio` prop on the `Image` component by updating the CSS classes in the `Image.module.css` file to use the `aspect-ratio` property instead of just setting the `--brand-image-aspectRatio` custom property. 

## What should reviewers focus on?

- Ensure that components which use this prop still appear as expected


## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/issues/635

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

