### PR TITLE
Add `tabAttributes` prop to `FAQGroup` component

### DIFF
--- a/.changeset/perfect-wasps-speak.md
+++ b/.changeset/perfect-wasps-speak.md
@@ -1,0 +1,30 @@
+---
+'@primer/react-brand': patch
+---
+
+Added `tabAttributes` prop to `FAQGroup` component. This prop is used to set arbitrary attributes on the tabs rendered by the `FAQGroup` component.
+
+For example, the below code will add `data-analytics="tab-0"` to the first tab and `data-analytics="tab-1"` to the second tab.
+
+```tsx
+<FAQGroup
+  tabAttributes={(children, index) => ({
+    'data-analytics': `tab-${index}`,
+  })}
+>
+  <FAQGroup.Heading>Frequently asked questions</FAQGroup.Heading>
+  <FAQ>
+    <FAQ.Heading>Using GitHub Enterprise</FAQ.Heading>
+    <FAQ.Item>...</FAQ.Item>
+    <FAQ.Item>...</FAQ.Item>
+    <FAQ.Item>...</FAQ.Item>
+  </FAQ>
+
+  <FAQ>
+    <FAQ.Heading>About GitHub Enterprise</FAQ.Heading>
+    <FAQ.Item>...</FAQ.Item>
+    <FAQ.Item>...</FAQ.Item>
+    <FAQ.Item>...</FAQ.Item>
+  </FAQ>
+</FAQGroup>
+```

--- a/apps/docs/content/components/FAQ/react.mdx
+++ b/apps/docs/content/components/FAQ/react.mdx
@@ -112,8 +112,14 @@ import {FAQ, FAQGroup} from '@primer/react-brand'
 
 Use `FAQGroup` to display multiple `FAQ` components together.
 
+Use `tabAttributes` to add arbitrary attributes to the tabs. This can be useful for tracking analytics or adding custom attributes.
+
 ```jsx live
-<FAQGroup>
+<FAQGroup
+  tabAttributes={(children, i) => ({
+    'data-analytics': `faq-tab-${i}`,
+  })}
+>
   <FAQGroup.Heading>
     Frequently asked <br /> questions
   </FAQGroup.Heading>

--- a/apps/docs/content/components/FAQ/react.mdx
+++ b/apps/docs/content/components/FAQ/react.mdx
@@ -8,13 +8,11 @@ description: Use the FAQ component to display content in a Q&A format.
 ---
 
 import ComponentLayout from '../../../src/layouts/component-layout'
-export default ComponentLayout
 
-import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
 import {HeadingTags} from '@primer/react-brand'
-import {Box as Container} from '@primer/react'
-import {PropTableValues} from '../../../src/components'
 import {Label} from '@primer/react'
+import {PropTableValues} from '../../../src/components'
+export default ComponentLayout
 
 ```js
 import {FAQ, FAQGroup} from '@primer/react-brand'

--- a/apps/docs/content/components/FAQ/react.mdx
+++ b/apps/docs/content/components/FAQ/react.mdx
@@ -433,12 +433,13 @@ render(<App />)
 
 ### FAQGroup
 
-| Name        | Type                                                                                                                           | Default | Description                              |
-| :---------- | :----------------------------------------------------------------------------------------------------------------------------- | :-----: | :--------------------------------------- |
-| `className` | `string`                                                                                                                       |         | Sets a custom class                      |
-| `id`        | `string`                                                                                                                       |         | Sets a custom id                         |
-| `ref`       | `React.RefObject`                                                                                                              |         | Forward a Ref to the underlying DOM node |
-| `children`  | <PropTableValues values={[<a href="#faq-required">FAQ</a>, <a href="#faqgroup-heading">FAQGroup.Heading</a>]} addLineBreaks /> |         | Root element for the FAQGroup component. |
+| Name            | Type                                                                                                                           | Default | Description                                                                   |
+| :-------------- | :----------------------------------------------------------------------------------------------------------------------------- | :-----: | :---------------------------------------------------------------------------- |
+| `className`     | `string`                                                                                                                       |         | Sets a custom class                                                           |
+| `id`            | `string`                                                                                                                       |         | Sets a custom id                                                              |
+| `ref`           | `React.RefObject`                                                                                                              |         | Forward a Ref to the underlying DOM node                                      |
+| `children`      | <PropTableValues values={[<a href="#faq-required">FAQ</a>, <a href="#faqgroup-heading">FAQGroup.Heading</a>]} addLineBreaks /> |         | Root element for the FAQGroup component.                                      |
+| `tabAttributes` | `(children: ReactElement, index: number) => Record<string, unknown>`                                                           |         | Spreads the returned attributes onto the tab that's rendered by the FAQGroup. |
 
 ### FAQGroup.Heading
 

--- a/packages/react/src/FAQ/FAQGroup.test.tsx
+++ b/packages/react/src/FAQ/FAQGroup.test.tsx
@@ -93,7 +93,7 @@ describe('FAQGroup', () => {
     expect(panelTwo).not.toBeVisible()
   })
 
-  it('selects the first tab by default', async () => {
+  it('selects the first tab by default', () => {
     const {getByTestId} = render(<Component />)
 
     const buttonOneEl = getByTestId('FAQGroup-tab-1')
@@ -101,7 +101,7 @@ describe('FAQGroup', () => {
     const panelOne = getByTestId('FAQGroup-tab-panel-1')
     const panelTwo = getByTestId('FAQGroup-tab-panel-2')
 
-    await userEvent.click(buttonTwoEl)
+    userEvent.click(buttonTwoEl)
 
     expect(buttonOneEl).toHaveAttribute('aria-selected', 'false')
     expect(buttonTwoEl).toHaveAttribute('aria-selected', 'true')
@@ -116,25 +116,25 @@ describe('FAQGroup', () => {
     expect(results).toHaveNoViolations()
   })
 
-  it('changes selected tab on ArrowUp and ArrowDown key presses', async () => {
+  it('changes selected tab on ArrowUp and ArrowDown key presses', () => {
     const {getByTestId} = render(<Component />)
     const firstTabButton = getByTestId('FAQGroup-tab-1')
     const secondTabButton = getByTestId('FAQGroup-tab-2')
     const lastTabButton = getByTestId(`FAQGroup-tab-2`)
 
-    await userEvent.type(firstTabButton, '{arrowdown}')
+    userEvent.type(firstTabButton, '{arrowdown}')
     expect(secondTabButton).toHaveAttribute('aria-selected', 'true')
     expect(getByTestId('FAQGroup-tab-panel-2')).not.toHaveAttribute('hidden')
 
-    await userEvent.type(secondTabButton, '{arrowup}')
+    userEvent.type(secondTabButton, '{arrowup}')
     expect(firstTabButton).toHaveAttribute('aria-selected', 'true')
     expect(firstTabButton).not.toHaveAttribute('hidden')
 
-    await userEvent.type(firstTabButton, '{arrowup}')
+    userEvent.type(firstTabButton, '{arrowup}')
     expect(lastTabButton).toHaveAttribute('aria-selected', 'true')
     expect(lastTabButton).not.toHaveAttribute('hidden')
 
-    await userEvent.type(lastTabButton, '{arrowdown}')
+    userEvent.type(lastTabButton, '{arrowdown}')
     expect(firstTabButton).toHaveAttribute('aria-selected', 'true')
     expect(firstTabButton).not.toHaveAttribute('hidden')
   })

--- a/packages/react/src/FAQ/FAQGroup.test.tsx
+++ b/packages/react/src/FAQ/FAQGroup.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 import {axe, toHaveNoViolations} from 'jest-axe'
 
-import {FAQ, FAQGroup} from './'
+import {FAQ, FAQGroup, type FAQGroupProps} from './'
 
 expect.extend(toHaveNoViolations)
 
@@ -45,8 +45,8 @@ describe('FAQGroup', () => {
     },
   ]
 
-  const Component = () => (
-    <FAQGroup data-testid="root">
+  const Component = (props: FAQGroupProps) => (
+    <FAQGroup data-testid="root" {...props}>
       <FAQGroup.Heading>Frequently asked questions</FAQGroup.Heading>
       {testData.map((group, index) => (
         <FAQ key={index}>
@@ -137,5 +137,29 @@ describe('FAQGroup', () => {
     await userEvent.type(lastTabButton, '{arrowdown}')
     expect(firstTabButton).toHaveAttribute('aria-selected', 'true')
     expect(firstTabButton).not.toHaveAttribute('hidden')
+  })
+
+  it('calls `tabAttributes` with the correct arguments', () => {
+    const mockTabAttributes = jest.fn((_, i) => ({
+      'data-tab-index': i,
+    }))
+
+    render(<Component tabAttributes={mockTabAttributes} />)
+    const mockCalls = mockTabAttributes.mock.calls
+
+    expect(mockTabAttributes).toHaveBeenCalledTimes(2)
+    expect(mockCalls[0]).toEqual(['mock heading 1', 0])
+    expect(mockCalls[1]).toEqual(['mock heading 2', 1])
+  })
+
+  it('adds props to the tabs when `tabAttributes` is provided', () => {
+    const mockTabAttributes = jest.fn(children => ({
+      'data-tab-heading': children,
+    }))
+
+    const {getByRole} = render(<Component tabAttributes={mockTabAttributes} />)
+
+    expect(getByRole('tab', {name: 'mock heading 1'})).toHaveAttribute('data-tab-heading', 'mock heading 1')
+    expect(getByRole('tab', {name: 'mock heading 2'})).toHaveAttribute('data-tab-heading', 'mock heading 2')
   })
 })

--- a/packages/react/src/FAQ/FAQGroup.tsx
+++ b/packages/react/src/FAQ/FAQGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {type ReactElement} from 'react'
 import {useId} from '@reach/auto-id'
 import clsx from 'clsx'
 
@@ -25,12 +25,13 @@ function _Heading({children, className, as = 'h3', ...rest}: FAQSubheadingProps)
   )
 }
 
-type FAQGroupProps = React.PropsWithChildren<{
+export type FAQGroupProps = React.PropsWithChildren<{
   id?: string
   defaultSelectedIndex?: number
+  tabAttributes?: (children: ReactElement, index: number) => Record<string, unknown>
 }>
 
-function _FAQGroup({children, id, defaultSelectedIndex = 0, ...rest}: FAQGroupProps) {
+function _FAQGroup({children, id, defaultSelectedIndex = 0, tabAttributes, ...rest}: FAQGroupProps) {
   const [selectedIndex, setSelectedIndex] = React.useState(defaultSelectedIndex)
   const [hasInteracted, setHasInteracted] = React.useState(false)
   const instanceId = useId(id)
@@ -73,8 +74,13 @@ function _FAQGroup({children, id, defaultSelectedIndex = 0, ...rest}: FAQGroupPr
         child => React.isValidElement(child) && child.type === FAQ.Heading,
       )
 
+      const tabContents = React.isValidElement(GroupHeadingChild) && GroupHeadingChild.props.children
+
+      const providedTabAttributes = tabAttributes?.(tabContents, index)
+
       return (
         <Button
+          {...providedTabAttributes}
           variant="subtle"
           hasArrow={false}
           as="button"
@@ -91,7 +97,7 @@ function _FAQGroup({children, id, defaultSelectedIndex = 0, ...rest}: FAQGroupPr
           tabIndex={selectedIndex !== index ? -1 : undefined}
           ref={selectedIndex === index ? selectedTabRef : undefined}
         >
-          {React.isValidElement(GroupHeadingChild) && GroupHeadingChild.props.children}
+          {tabContents}
         </Button>
       )
     }


### PR DESCRIPTION
## Summary

Adds `tabAttributes` prop to `FAQGroup` component. This prop is used to set arbitrary attributes on the tabs rendered by the `FAQGroup` component.

For example, the below code will add `data-analytics="tab-0"` to the first tab and `data-analytics="tab-1"` to the second tab.

```tsx
<FAQGroup
  tabAttributes={(children, index) => ({
    'data-analytics': `tab-${index}`,
  })}
>
  <FAQGroup.Heading>Frequently asked questions</FAQGroup.Heading>
  <FAQ>
    <FAQ.Heading>Using GitHub Enterprise</FAQ.Heading>
    <FAQ.Item>...</FAQ.Item>
    <FAQ.Item>...</FAQ.Item>
    <FAQ.Item>...</FAQ.Item>
  </FAQ>

  <FAQ>
    <FAQ.Heading>About GitHub Enterprise</FAQ.Heading>
    <FAQ.Item>...</FAQ.Item>
    <FAQ.Item>...</FAQ.Item>
    <FAQ.Item>...</FAQ.Item>
  </FAQ>
</FAQGroup>
```

## List of notable changes:

- Adds `tabAttributes` prop to FAQGroup
- Adds `tabAttributes` tests to FAQGroup test suite
- Removes some unnecessary `async/await` usage from FAQGroup test suite
- Updates FAQGroup documentation

## What should reviewers focus on?

Ensure you're happy with the API, updated docs, and updated tests

## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/issues/612
- [API exploration](https://www.figma.com/board/FJhHnM9BznUtZ9XHCNLh2T/Brand---FAQGroup-analytics-props?node-id=215-185&t=53hWTCQwoeWUHYIx-11)

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
