### PR TITLE
Improve Storybook UX

### DIFF
--- a/apps/storybook/.storybook/main.js
+++ b/apps/storybook/.storybook/main.js
@@ -3,12 +3,17 @@ import {dirname, join} from 'path'
 module.exports = {
   stories: ['../../../packages/react/src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
+    {
+      name: getAbsolutePath('@storybook/addon-essentials'),
+      options: {
+        actions: false,
+      },
+    },
+    getAbsolutePath('@storybook/addon-storysource'),
     getAbsolutePath('@storybook/addon-a11y'),
     getAbsolutePath('@storybook/addon-links'),
-    getAbsolutePath('@storybook/addon-essentials'),
     getAbsolutePath('@storybook/addon-interactions'),
     getAbsolutePath('storybook-css-modules-preset'),
-    getAbsolutePath('@storybook/addon-storysource'),
     getAbsolutePath('@storybook/addon-webpack5-compiler-swc'),
   ],
   framework: {

--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -1,4 +1,4 @@
-import { ThemeProvider } from '../../../packages/react/src'
+import {ThemeProvider} from '../../../packages/react/src'
 import styles from './preview.module.css'
 import '../../../packages/react/src/css/stylesheets'
 import '../../../packages/react/src/css/utilities.css'
@@ -77,6 +77,24 @@ export const parameters = {
     matchers: {
       color: /(background|color)$/i,
       date: /Date$/,
+    },
+  },
+  options: {
+    storySort: (a, b) => {
+      const titleCompare = a.title.localeCompare(b.title)
+
+      // Sort top level alphabetically, with nested folders below nested stories
+      if (titleCompare !== 0) {
+        return titleCompare
+      }
+
+      // Put default story above playground in the component folder
+      if (a.name === 'Default') {
+        return -1
+      }
+
+      // Sort features and examples in the order they're written
+      return 0
     },
   },
 }


### PR DESCRIPTION
## Summary

Some tweaks to make Storybook easier and more intuitive to navigate, based on the audit in https://github.com/github/primer/issues/3635

## List of notable changes:

- Components in the sidebar are sorted alphabetically - previously they were sorted by load order, so it was mostly alphabetical but some nested folders like forms and river were at the bottom
- Components always show Default, then Playground, then sub-folders (examples + feature stories)
- Examples and feature stories are ordered in the order they're written in the file
- Moved Controls to be the first panel in addon sidebar so it opens automatically (previously was a11y panel)
- Removed Links addon (unused and cluttering sidebar)

## Supporting resources (related issues, external links, etc):

[PRC has a more complex sorting algorithm](https://github.com/primer/react/blob/%40primer/react%4036.26.0/packages/react/.storybook/preview.js#L33) to handle top-level sorting, but our top level order of 'components, misc, recipes' is fine unless we add more granularity up there.

## Contributor checklist:

- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table width="400px">
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->
![old sidebar order](https://github.com/user-attachments/assets/01854f09-abdb-4192-acef-6c75aedd8f54)


 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->
![new sidebar order](https://github.com/user-attachments/assets/98ab0c0c-ff22-48ae-9bc1-176c8e9cbce2)



</td>
</tr>
</table>
