### PR TITLE
fix prop forwarding to Selects inside FormControl

### DIFF
--- a/.changeset/sixty-jobs-perfectly.md
+++ b/.changeset/sixty-jobs-perfectly.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed inability to forward `name` props to the `Select` component when used inside a `FormControl`.

--- a/packages/react/src/forms/FormControl/FormControl.test.tsx
+++ b/packages/react/src/forms/FormControl/FormControl.test.tsx
@@ -1,9 +1,9 @@
 import React, {render, cleanup} from '@testing-library/react'
 import '@testing-library/jest-dom'
+import {axe, toHaveNoViolations} from 'jest-axe'
 
 import {FormControl} from './FormControl'
 import {TextInput} from '../TextInput'
-import {axe, toHaveNoViolations} from 'jest-axe'
 import {Select} from '../Select'
 
 expect.extend(toHaveNoViolations)

--- a/packages/react/src/forms/FormControl/FormControl.test.tsx
+++ b/packages/react/src/forms/FormControl/FormControl.test.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom'
 import {FormControl} from './FormControl'
 import {TextInput} from '../TextInput'
 import {axe, toHaveNoViolations} from 'jest-axe'
+import {Select} from '../Select'
 
 expect.extend(toHaveNoViolations)
 
@@ -86,6 +87,42 @@ describe('FormControl', () => {
     expect(inputNameValue).toEqual(mockFormControlId)
 
     expect(rootEl.getAttribute('id')).toBe(`FormControl--${mockFormControlId}`)
+  })
+
+  it('can forward a name prop to text inputs', async () => {
+    const mockName = 'input-name'
+    const {getByRole} = render(
+      <FormControl>
+        <FormControl.Label>{mockFormControlLabel}</FormControl.Label>
+        <TextInput name={mockName} />
+      </FormControl>,
+    )
+
+    const inputEl = getByRole('textbox')
+
+    const inputNameValue = inputEl.getAttribute('name')
+
+    expect(inputNameValue).toEqual(mockName)
+  })
+
+  it('can forward a name prop to select inputs', async () => {
+    const mockName = 'select-name'
+    const {getByRole} = render(
+      <FormControl>
+        <FormControl.Label>{mockFormControlLabel}</FormControl.Label>
+        <Select name={mockName}>
+          <Select.Option value="">Select a handle</Select.Option>
+          <Select.Option value="mona">Monalisa</Select.Option>
+          <Select.Option value="hubot">Hubot</Select.Option>
+        </Select>
+      </FormControl>,
+    )
+
+    const selectEl = getByRole('combobox')
+
+    const selectNameValue = selectEl.getAttribute('name')
+
+    expect(selectNameValue).toEqual(mockName)
   })
 
   it('applies error state to the inputs and form validation', async () => {

--- a/packages/react/src/forms/FormControl/FormControl.tsx
+++ b/packages/react/src/forms/FormControl/FormControl.tsx
@@ -98,7 +98,7 @@ const Root = ({
             return React.cloneElement(child as React.ReactElement, {
               className: clsx(child.props.className),
               id: inputId,
-              name: inputId,
+              name: child.props.name || inputId,
               required: child.props.required || required,
               validationStatus: child.props.validationStatus || validationStatus,
               fullWidth,


### PR DESCRIPTION
## Summary

Resolves https://github.com/primer/brand/issues/666

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Forwards `name` props correctly to Select elements that are used inside a FormControl to match other input types
- Adds test coverage 

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Review live documentation, and add a name attribute to Select
1. Use inspector to verify the name attribute has been set on the Select correctly


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:
n/a