### PR TITLE
regenerate vrt spec files

### DIFF
--- a/packages/react/src/ActionMenu/ActionMenu.visual.spec.ts
+++ b/packages/react/src/ActionMenu/ActionMenu.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: ActionMenu', () => {
+  test('ActionMenu / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-actionmenu--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('ActionMenu / Single Selection', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-actionmenu-features--single-selection&viewMode=story',
@@ -119,13 +126,6 @@ test.describe('Visual Comparison: ActionMenu', () => {
     )
 
     await page.waitForTimeout(1000)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('ActionMenu / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-actionmenu--default&viewMode=story')
-
-    await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()
   })
 })

--- a/packages/react/src/AnchorNav/AnchorNav.visual.spec.ts
+++ b/packages/react/src/AnchorNav/AnchorNav.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: AnchorNav', () => {
+  test('AnchorNav / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-anchornav--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('AnchorNav / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-anchornav--playground&viewMode=story')
+
+    await page.waitForTimeout(1000)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('AnchorNav / Fewer anchor links', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-anchornav-features--fewer-anchor-links&viewMode=story',
@@ -100,20 +114,6 @@ test.describe('Visual Comparison: AnchorNav', () => {
     )
 
     await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('AnchorNav / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-anchornav--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('AnchorNav / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-anchornav--playground&viewMode=story')
-
-    await page.waitForTimeout(1000)
     expect(await page.screenshot()).toMatchSnapshot()
   })
 })

--- a/packages/react/src/Avatar/Avatar.visual.spec.ts
+++ b/packages/react/src/Avatar/Avatar.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Avatar', () => {
+  test('Avatar / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-avatar--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Avatar / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-avatar--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Avatar / Sizes', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-avatar-features--sizes&viewMode=story')
 
@@ -25,20 +39,6 @@ test.describe('Visual Comparison: Avatar', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-avatar-features--responsive-sizes&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Avatar / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-avatar--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Avatar / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-avatar--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Bento/Bento.visual.spec.ts
+++ b/packages/react/src/Bento/Bento.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Bento', () => {
+  test('Bento / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-bento--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Bento / Layout Example 1', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-bento-features--layout-example-1&viewMode=story',
@@ -50,13 +57,6 @@ test.describe('Visual Comparison: Bento', () => {
 
   test('Bento / Mixed 3', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-bento-features--mixed-3&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Bento / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-bento--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Box/Box.visual.spec.ts
+++ b/packages/react/src/Box/Box.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Box', () => {
+  test('Box / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-box--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Box / Padding', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-box-features--padding&viewMode=story')
 
@@ -136,13 +143,6 @@ test.describe('Visual Comparison: Box', () => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-box-features--animation&viewMode=story')
 
     await page.waitForTimeout(6000)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Box / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-box--default&viewMode=story')
-
-    await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()
   })
 })

--- a/packages/react/src/Breadcrumbs/Breadcrumbs.visual.spec.ts
+++ b/packages/react/src/Breadcrumbs/Breadcrumbs.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Breadcrumbs', () => {
+  test('Breadcrumbs / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-breadcrumbs--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Breadcrumbs / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-breadcrumbs--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Breadcrumbs / Accent variant', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-breadcrumbs-features--accent&viewMode=story')
 
@@ -34,18 +48,5 @@ test.describe('Visual Comparison: Breadcrumbs', () => {
       await page.waitForTimeout(500)
       expect(await page.screenshot()).toMatchSnapshot()
     })
-  })
-  test('Breadcrumbs / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-breadcrumbs--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Breadcrumbs / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-breadcrumbs--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
   })
 })

--- a/packages/react/src/Button/Button.visual.spec.ts
+++ b/packages/react/src/Button/Button.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Button', () => {
+  test('Button / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-button--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Button / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-button--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Button / Primary', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-button-features--primary&viewMode=story')
 
@@ -188,20 +202,6 @@ test.describe('Visual Comparison: Button', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-button-features--with-visuals-and-disabled&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Button / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-button--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Button / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-button--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/CTABanner/CTABanner.visual.spec.ts
+++ b/packages/react/src/CTABanner/CTABanner.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: CTABanner', () => {
+  test('CTABanner / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-ctabanner--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('CTABanner / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-ctabanner--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('CTABanner / With Border', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-ctabanner-features--with-border&viewMode=story',
@@ -47,20 +61,6 @@ test.describe('Visual Comparison: CTABanner', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-ctabanner-features--custom-shadow&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('CTABanner / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-ctabanner--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('CTABanner / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-ctabanner--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/CTAForm/CTAForm.visual.spec.ts
+++ b/packages/react/src/CTAForm/CTAForm.visual.spec.ts
@@ -7,10 +7,8 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: CTAForm', () => {
-  test('CTAForm / With No Confirm', async ({page}) => {
-    await page.goto(
-      'http://localhost:6006/iframe.html?args=&id=components-ctaform-features--with-no-confirm&viewMode=story',
-    )
+  test('CTAForm / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-ctaform--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()
@@ -23,8 +21,10 @@ test.describe('Visual Comparison: CTAForm', () => {
     expect(await page.screenshot()).toMatchSnapshot()
   })
 
-  test('CTAForm / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-ctaform--default&viewMode=story')
+  test('CTAForm / With No Confirm', async ({page}) => {
+    await page.goto(
+      'http://localhost:6006/iframe.html?args=&id=components-ctaform-features--with-no-confirm&viewMode=story',
+    )
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Card/Card.visual.spec.ts
+++ b/packages/react/src/Card/Card.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Card', () => {
+  test('Card / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-card--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Card / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-card--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Card / Minimal', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-card-features--minimal&viewMode=story')
 
@@ -115,20 +129,6 @@ test.describe('Visual Comparison: Card', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-card-features--dark-color-mode-effect&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Card / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-card--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Card / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-card--playground&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/EyebrowBanner/EyebrowBanner.visual.spec.ts
+++ b/packages/react/src/EyebrowBanner/EyebrowBanner.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: EyebrowBanner', () => {
+  test('EyebrowBanner / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-eyebrowbanner--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('EyebrowBanner / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-eyebrowbanner--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('EyebrowBanner / Variations', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-eyebrowbanner-features--variations&viewMode=story',
@@ -65,20 +79,6 @@ test.describe('Visual Comparison: EyebrowBanner', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-eyebrowbanner-features--icons-dark&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('EyebrowBanner / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-eyebrowbanner--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('EyebrowBanner / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-eyebrowbanner--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/FAQ/FAQ.visual.spec.ts
+++ b/packages/react/src/FAQ/FAQ.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: FAQ', () => {
+  test('FAQ / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-faq--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('FAQ / All Closed', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-faq-features--all-closed&viewMode=story')
 
@@ -78,13 +85,6 @@ test.describe('Visual Comparison: FAQ', () => {
 
   test('FAQ / With Prose', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-faq-features--with-prose&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('FAQ / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-faq--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Grid/Grid.visual.spec.ts
+++ b/packages/react/src/Grid/Grid.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Grid', () => {
+  test('Grid / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-grid--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Grid / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-grid--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Grid / Asymmetry', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-grid-features--asymmetry&viewMode=story')
 
@@ -60,20 +74,6 @@ test.describe('Visual Comparison: Grid', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-grid-features--responsive-min-width&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Grid / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-grid--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Grid / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-grid--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Hero/Hero.visual.spec.ts
+++ b/packages/react/src/Hero/Hero.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Hero', () => {
+  test('Hero / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-hero--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Hero / Centered', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-hero-features--centered&viewMode=story')
 
@@ -134,13 +141,6 @@ test.describe('Visual Comparison: Hero', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-hero-features--eyebrow-centered&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Hero / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-hero--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Image/Image.visual.spec.ts
+++ b/packages/react/src/Image/Image.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Image', () => {
+  test('Image / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-image--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Image / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-image--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Image / Custom Picture Aspect Ratio', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-image-features--custom-picture-aspect-ratio&viewMode=story',
@@ -81,20 +95,6 @@ test.describe('Visual Comparison: Image', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-image-features--border-radius-options&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Image / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-image--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Image / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-image--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Label/Label.visual.spec.ts
+++ b/packages/react/src/Label/Label.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Label', () => {
+  test('Label / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-label--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Label / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-label--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Label / Large', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-label-features--large&viewMode=story')
 
@@ -50,20 +64,6 @@ test.describe('Visual Comparison: Label', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-label-features--with-octicon-color&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Label / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-label--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Label / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-label--playground&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Link/Link.visual.spec.ts
+++ b/packages/react/src/Link/Link.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Link', () => {
+  test('Link / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-link--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Link / Large', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-link-features--large&viewMode=story')
 
@@ -23,13 +30,6 @@ test.describe('Visual Comparison: Link', () => {
 
   test('Link / Accent', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-link-features--accent&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Link / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-link--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/LogoSuite/LogoSuite.visual.spec.ts
+++ b/packages/react/src/LogoSuite/LogoSuite.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: LogoSuite', () => {
+  test('LogoSuite / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-logosuite--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('LogoSuite / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-logosuite--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('LogoSuite / Align Start', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-logosuite-features--align-start&viewMode=story',
@@ -65,20 +79,6 @@ test.describe('Visual Comparison: LogoSuite', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-logosuite-features--with-raster-logos&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('LogoSuite / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-logosuite--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('LogoSuite / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-logosuite--playground&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/MinimalFooter/MinimalFooter.visual.spec.ts
+++ b/packages/react/src/MinimalFooter/MinimalFooter.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: MinimalFooter', () => {
+  test('MinimalFooter / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-minimalfooter--default&viewMode=story')
+
+    await page.waitForTimeout(5000)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('MinimalFooter / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-minimalfooter--playground&viewMode=story')
+
+    await page.waitForTimeout(5000)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('MinimalFooter / Multiple Footnotes', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-minimalfooter-features--multiple-footnotes&viewMode=story',
@@ -68,20 +82,6 @@ test.describe('Visual Comparison: MinimalFooter', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-minimalfooter-features--dark-theme&viewMode=story',
     )
-
-    await page.waitForTimeout(5000)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('MinimalFooter / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-minimalfooter--playground&viewMode=story')
-
-    await page.waitForTimeout(5000)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('MinimalFooter / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-minimalfooter--default&viewMode=story')
 
     await page.waitForTimeout(5000)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Pagination/Pagination.visual.spec.ts
+++ b/packages/react/src/Pagination/Pagination.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Pagination', () => {
+  test('Pagination / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pagination--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Pagination / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pagination--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Pagination / Larger Page Count Margin', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-pagination-features--larger-page-count-margin&viewMode=story',
@@ -56,20 +70,6 @@ test.describe('Visual Comparison: Pagination', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-pagination-features--custom-attribute-forwarding&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Pagination / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pagination--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Pagination / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pagination--playground&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Pillar/Pillar.visual.spec.ts
+++ b/packages/react/src/Pillar/Pillar.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Pillar', () => {
+  test('Pillar / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pillar--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Pillar / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pillar--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Pillar / Icon', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-pillar-features--icon&viewMode=story')
 
@@ -57,20 +71,6 @@ test.describe('Visual Comparison: Pillar', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-pillar-features--stacked-with-link&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Pillar / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pillar--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Pillar / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pillar--playground&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/PricingOptions/PricingOptions.visual.spec.ts
+++ b/packages/react/src/PricingOptions/PricingOptions.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: PricingOptions', () => {
+  test('PricingOptions / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pricingoptions--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('PricingOptions / Default Variant', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-pricingoptions-features--default-variant&viewMode=story',
@@ -117,11 +124,5 @@ test.describe('Visual Comparison: PricingOptions', () => {
       await page.waitForTimeout(500)
       expect(await page.screenshot()).toMatchSnapshot()
     })
-  })
-  test('PricingOptions / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-pricingoptions--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
   })
 })

--- a/packages/react/src/Prose/Prose.visual.spec.ts
+++ b/packages/react/src/Prose/Prose.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Prose', () => {
+  test('Prose / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-prose--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Prose / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-prose--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Prose / Full Width', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-prose-features--full-width&viewMode=story')
 
@@ -43,20 +57,6 @@ test.describe('Visual Comparison: Prose', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-prose-features--unordered-list&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Prose / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-prose--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Prose / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-prose--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/SectionIntro/SectionIntro.visual.spec.ts
+++ b/packages/react/src/SectionIntro/SectionIntro.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: SectionIntro', () => {
+  test('SectionIntro / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-sectionintro--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('SectionIntro / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-sectionintro--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('SectionIntro / Heading Only', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-sectionintro-features--heading-only&viewMode=story',
@@ -74,20 +88,6 @@ test.describe('Visual Comparison: SectionIntro', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-sectionintro-features--full-width&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('SectionIntro / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-sectionintro--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('SectionIntro / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-sectionintro--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Statistic/Statistic.visual.spec.ts
+++ b/packages/react/src/Statistic/Statistic.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Statistic', () => {
+  test('Statistic / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-statistic--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Statistic / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-statistic--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Statistic / Boxed Variant', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-statistic-features--boxed-variant&viewMode=story',
@@ -70,20 +84,6 @@ test.describe('Visual Comparison: Statistic', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-statistic-features--custom-intro&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Statistic / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-statistic--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Statistic / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-statistic--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/SubNav/SubNav.visual.spec.ts
+++ b/packages/react/src/SubNav/SubNav.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: SubNav', () => {
+  test('SubNav / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-subnav--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('SubNav / Example Usage', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-subnav-features--example-usage&viewMode=story',
@@ -58,13 +65,6 @@ test.describe('Visual Comparison: SubNav', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-subnav-features--longer-heading&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('SubNav / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-subnav--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Timeline/Timeline.visual.spec.ts
+++ b/packages/react/src/Timeline/Timeline.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Timeline', () => {
+  test('Timeline / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-timeline--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Timeline / With Emphasis', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-timeline-features--with-emphasis&viewMode=story',
@@ -38,13 +45,6 @@ test.describe('Visual Comparison: Timeline', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-timeline-features--with-longer-text&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Timeline / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-timeline--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/Tooltip/Tooltip.visual.spec.ts
+++ b/packages/react/src/Tooltip/Tooltip.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Tooltip', () => {
+  test('Tooltip / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-tooltip--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Tooltip / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-tooltip--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Tooltip / Anchor Has Margin', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-tooltip-features--anchor-has-margin&viewMode=story',
@@ -45,20 +59,6 @@ test.describe('Visual Comparison: Tooltip', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-tooltip-features--calculated-direction&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Tooltip / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-tooltip--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Tooltip / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-tooltip--playground&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/VideoPlayer/VideoPlayer.visual.spec.ts
+++ b/packages/react/src/VideoPlayer/VideoPlayer.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: VideoPlayer', () => {
+  test('VideoPlayer / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-videoplayer--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('VideoPlayer / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-videoplayer--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('VideoPlayer / With Poster', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-videoplayer-features--with-poster&viewMode=story',
@@ -74,20 +88,6 @@ test.describe('Visual Comparison: VideoPlayer', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-videoplayer-features--custom-play-icon&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('VideoPlayer / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-videoplayer--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('VideoPlayer / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-videoplayer--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/forms/Radio/Radio.visual.spec.ts
+++ b/packages/react/src/forms/Radio/Radio.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Radio', () => {
+  test('Radio / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-forms-radio--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Radio / w/ labels', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-forms-radio-features--with-form-control&viewMode=story',
@@ -29,13 +36,6 @@ test.describe('Visual Comparison: Radio', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-forms-radio-features--on-custom-background-color&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Radio / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-forms-radio--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/forms/Select/Select.visual.spec.ts
+++ b/packages/react/src/forms/Select/Select.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Select', () => {
+  test('Select / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-forms-select--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('Select / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-forms-select--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Select / Full Width', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-forms-select-features--full-width&viewMode=story',
@@ -63,20 +77,6 @@ test.describe('Visual Comparison: Select', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-forms-select-features--validation-error&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Select / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-forms-select--playground&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Select / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-forms-select--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/forms/Textarea/Textarea.visual.spec.ts
+++ b/packages/react/src/forms/Textarea/Textarea.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: Textarea', () => {
+  test('Textarea / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-forms-textarea--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('Textarea / Validation', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-forms-textarea-features--validation&viewMode=story',
@@ -38,13 +45,6 @@ test.describe('Visual Comparison: Textarea', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-forms-textarea-features--full-width&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('Textarea / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-forms-textarea--default&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/list/UnorderedList/UnorderedList.visual.spec.ts
+++ b/packages/react/src/list/UnorderedList/UnorderedList.visual.spec.ts
@@ -7,6 +7,20 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: UnorderedList', () => {
+  test('UnorderedList / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-unorderedlist--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('UnorderedList / Playground', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-unorderedlist--playground&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('UnorderedList / Check List', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-unorderedlist-features--check-list&viewMode=story',
@@ -47,20 +61,6 @@ test.describe('Visual Comparison: UnorderedList', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-unorderedlist-features--text-variant&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('UnorderedList / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-unorderedlist--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('UnorderedList / Playground', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-unorderedlist--playground&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/river/River/River.visual.spec.ts
+++ b/packages/react/src/river/River/River.visual.spec.ts
@@ -7,6 +7,29 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: River', () => {
+  test('River / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-river--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('River / Larger Placeholder Image', async ({page}) => {
+    await page.goto(
+      'http://localhost:6006/iframe.html?args=&id=components-river--larger-placeholder-image&viewMode=story',
+    )
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
+  test('River / Copilot', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-river--copilot&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('River / Left', async ({page}) => {
     await page.goto('http://localhost:6006/iframe.html?args=&id=components-river-features--left&viewMode=story')
 
@@ -102,29 +125,6 @@ test.describe('Visual Comparison: River', () => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-river-features--alternating-layout&viewMode=story',
     )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('River / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-river--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('River / Larger Placeholder Image', async ({page}) => {
-    await page.goto(
-      'http://localhost:6006/iframe.html?args=&id=components-river--larger-placeholder-image&viewMode=story',
-    )
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
-  })
-
-  test('River / Copilot', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-river--copilot&viewMode=story')
 
     await page.waitForTimeout(500)
     expect(await page.screenshot()).toMatchSnapshot()

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.visual.spec.ts
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.visual.spec.ts
@@ -7,6 +7,13 @@ import {test, expect} from '@playwright/test'
 
 // eslint-disable-next-line i18n-text/no-en
 test.describe('Visual Comparison: RiverStoryScroll', () => {
+  test('RiverStoryScroll / Default', async ({page}) => {
+    await page.goto('http://localhost:6006/iframe.html?args=&id=components-riverstoryscroll--default&viewMode=story')
+
+    await page.waitForTimeout(500)
+    expect(await page.screenshot()).toMatchSnapshot()
+  })
+
   test('RiverStoryScroll / With Timeline', async ({page}) => {
     await page.goto(
       'http://localhost:6006/iframe.html?args=&id=components-riverstoryscroll-features--with-timeline&viewMode=story',
@@ -57,11 +64,5 @@ test.describe('Visual Comparison: RiverStoryScroll', () => {
       await page.waitForTimeout(3500)
       expect(await page.screenshot()).toMatchSnapshot()
     })
-  })
-  test('RiverStoryScroll / Default', async ({page}) => {
-    await page.goto('http://localhost:6006/iframe.html?args=&id=components-riverstoryscroll--default&viewMode=story')
-
-    await page.waitForTimeout(500)
-    expect(await page.screenshot()).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
## Summary

Ran `npm run test:visual:generate -w packages/e2e` to regenerate vrt spec files.

I think this command should have been run as part of https://github.com/primer/brand/pull/662/files as that changed the sorting of stories, but I'll update here so as to not clutter another PR with these changes

There are no changes to vrt snapshots after this change, so there shouldn't be any actual changes.