### PR TITLE
Fix static assets dir in preview/production Storybook and docs

### DIFF
--- a/apps/docs/content/components/VideoPlayer.mdx
+++ b/apps/docs/content/components/VideoPlayer.mdx
@@ -18,8 +18,8 @@ import {VideoPlayer} from '@primer/react-brand'
 
 ```jsx live
 <VideoPlayer title="GitHub media player">
-  <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" />
-  <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+  <VideoPlayer.Source src="/brand/assets/example.mp4" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" />
 </VideoPlayer>
 ```
 
@@ -27,11 +27,11 @@ import {VideoPlayer} from '@primer/react-brand'
 
 ```jsx live
 <VideoPlayer
-  poster="https://primer.github.io/brand/assets/example-poster.png"
+  poster="/brand/assets/example-poster.png"
   title="GitHub media player"
 >
-  <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" />
-  <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+  <VideoPlayer.Source src="/brand/assets/example.mp4" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" />
 </VideoPlayer>
 ```
 
@@ -39,8 +39,8 @@ import {VideoPlayer} from '@primer/react-brand'
 
 ```jsx live
 <VideoPlayer showBranding={false} title="GitHub media player">
-  <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" />
-  <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+  <VideoPlayer.Source src="/brand/assets/example.mp4" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" />
 </VideoPlayer>
 ```
 
@@ -48,8 +48,8 @@ import {VideoPlayer} from '@primer/react-brand'
 
 ```jsx live
 <VideoPlayer visuallyHiddenTitle title="GitHub media player">
-  <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" />
-  <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+  <VideoPlayer.Source src="/brand/assets/example.mp4" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" />
 </VideoPlayer>
 ```
 
@@ -65,11 +65,8 @@ import {VideoPlayer} from '@primer/react-brand'
   showVolumeControl={false}
   showFullScreenButton={false}
 >
-  <VideoPlayer.Source
-    src="https://primer.github.io/brand/assets/example.mp4"
-    type="video/mp4"
-  />
-  <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+  <VideoPlayer.Source src="/brand/assets/example.mp4" type="video/mp4" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" />
 </VideoPlayer>
 ```
 
@@ -77,11 +74,8 @@ import {VideoPlayer} from '@primer/react-brand'
 
 ```jsx live
 <VideoPlayer title="GitHub media player" showControlsWhenPaused={false}>
-  <VideoPlayer.Source
-    src="https://primer.github.io/brand/assets/example.mp4"
-    type="video/mp4"
-  />
-  <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+  <VideoPlayer.Source src="/brand/assets/example.mp4" type="video/mp4" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" />
 </VideoPlayer>
 ```
 
@@ -94,11 +88,8 @@ import {VideoPlayer} from '@primer/react-brand'
   showBranding={false}
   showControlsWhenPaused={false}
 >
-  <VideoPlayer.Source
-    src="https://primer.github.io/brand/assets/example.mp4"
-    type="video/mp4"
-  />
-  <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+  <VideoPlayer.Source src="/brand/assets/example.mp4" type="video/mp4" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" />
 </VideoPlayer>
 ```
 
@@ -109,11 +100,8 @@ import {VideoPlayer} from '@primer/react-brand'
   title="GitHub media player"
   playIcon={() => <PlayIcon size={96} />}
 >
-  <VideoPlayer.Source
-    src="https://primer.github.io/brand/assets/example.mp4"
-    type="video/mp4"
-  />
-  <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+  <VideoPlayer.Source src="/brand/assets/example.mp4" type="video/mp4" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" />
 </VideoPlayer>
 ```
 
@@ -140,10 +128,10 @@ Full documentation for the `useVideo` hook can be found [below](#usevideo-contex
           showFullScreenButton={false}
         >
           <VideoPlayer.Source
-            src="https://primer.github.io/brand/assets/example.mp4"
+            src="/brand/assets/example.mp4"
             type="video/mp4"
           />
-          <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+          <VideoPlayer.Track src="/brand/assets/example.vtt" />
         </VideoPlayer>
         <Stack direction="horizontal">
           <Button onClick={() => togglePlaying()}>
@@ -201,9 +189,7 @@ Below is a detailed description of each property and method available in the `us
 
 ## Component props
 
-
 ### VideoPlayer <Label>Required</Label>
-
 
 `VideoPlayer` provides a React alternative to the native HTML `<video />`.
 
@@ -229,7 +215,6 @@ The component API supports all standard HTML attribute props, while providing so
 
 `VideoPlayer.Source` provides a React alternative to the native HTML `<source />`. The component API supports all standard HTML attribute props.
 
-
 ### VideoPlayer.Track <Label>Required</Label>
 
 `VideoPlayer.Track` provides a React alternative to the native HTML `<track />`.
@@ -240,6 +225,6 @@ The component API supports all standard HTML attribute props, while providing so
 
 The component API supports all standard HTML attribute props, while providing some additional behavior as described above.
 
-###  VideoPlayer.Provider
+### VideoPlayer.Provider
 
 `VideoPlayer.Provider` can be used in conjunction with the `useVideo` hook to enable programmatic access to features such as video playback, volume, closed captioning, and fullscreen mode.

--- a/apps/docs/content/components/VideoPlayer.mdx
+++ b/apps/docs/content/components/VideoPlayer.mdx
@@ -19,7 +19,7 @@ import {VideoPlayer} from '@primer/react-brand'
 ```jsx live
 <VideoPlayer title="GitHub media player">
   <VideoPlayer.Source src="/brand/assets/example.mp4" />
-  <VideoPlayer.Track src="/brand/assets/example.vtt" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" default/>
 </VideoPlayer>
 ```
 
@@ -31,7 +31,7 @@ import {VideoPlayer} from '@primer/react-brand'
   title="GitHub media player"
 >
   <VideoPlayer.Source src="/brand/assets/example.mp4" />
-  <VideoPlayer.Track src="/brand/assets/example.vtt" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" default/>
 </VideoPlayer>
 ```
 
@@ -40,7 +40,7 @@ import {VideoPlayer} from '@primer/react-brand'
 ```jsx live
 <VideoPlayer showBranding={false} title="GitHub media player">
   <VideoPlayer.Source src="/brand/assets/example.mp4" />
-  <VideoPlayer.Track src="/brand/assets/example.vtt" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" default/>
 </VideoPlayer>
 ```
 
@@ -49,7 +49,7 @@ import {VideoPlayer} from '@primer/react-brand'
 ```jsx live
 <VideoPlayer visuallyHiddenTitle title="GitHub media player">
   <VideoPlayer.Source src="/brand/assets/example.mp4" />
-  <VideoPlayer.Track src="/brand/assets/example.vtt" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" default/>
 </VideoPlayer>
 ```
 
@@ -66,7 +66,7 @@ import {VideoPlayer} from '@primer/react-brand'
   showFullScreenButton={false}
 >
   <VideoPlayer.Source src="/brand/assets/example.mp4" type="video/mp4" />
-  <VideoPlayer.Track src="/brand/assets/example.vtt" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" default/>
 </VideoPlayer>
 ```
 
@@ -75,7 +75,7 @@ import {VideoPlayer} from '@primer/react-brand'
 ```jsx live
 <VideoPlayer title="GitHub media player" showControlsWhenPaused={false}>
   <VideoPlayer.Source src="/brand/assets/example.mp4" type="video/mp4" />
-  <VideoPlayer.Track src="/brand/assets/example.vtt" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" default/>
 </VideoPlayer>
 ```
 
@@ -89,7 +89,7 @@ import {VideoPlayer} from '@primer/react-brand'
   showControlsWhenPaused={false}
 >
   <VideoPlayer.Source src="/brand/assets/example.mp4" type="video/mp4" />
-  <VideoPlayer.Track src="/brand/assets/example.vtt" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" default/>
 </VideoPlayer>
 ```
 
@@ -101,7 +101,7 @@ import {VideoPlayer} from '@primer/react-brand'
   playIcon={() => <PlayIcon size={96} />}
 >
   <VideoPlayer.Source src="/brand/assets/example.mp4" type="video/mp4" />
-  <VideoPlayer.Track src="/brand/assets/example.vtt" />
+  <VideoPlayer.Track src="/brand/assets/example.vtt" default/>
 </VideoPlayer>
 ```
 
@@ -131,7 +131,7 @@ Full documentation for the `useVideo` hook can be found [below](#usevideo-contex
             src="/brand/assets/example.mp4"
             type="video/mp4"
           />
-          <VideoPlayer.Track src="/brand/assets/example.vtt" />
+          <VideoPlayer.Track src="/brand/assets/example.vtt" default/>
         </VideoPlayer>
         <Stack direction="horizontal">
           <Button onClick={() => togglePlaying()}>

--- a/apps/docs/gatsby-node.js
+++ b/apps/docs/gatsby-node.js
@@ -41,15 +41,15 @@ exports.onPostBootstrap = async ({reporter}) => {
     return
   }
 
-  const staticDir = path.resolve(__dirname, 'static', 'assets')
-  const staticOutDir = path.resolve(__dirname, 'public', 'brand', 'assets')
+  const srcDir = path.resolve(__dirname, 'static', 'assets')
+  const outDir = path.resolve(__dirname, 'public', 'brand', 'assets')
 
   try {
     // eslint-disable-next-line i18n-text/no-en
-    reporter.info(`Copying static assets from ${staticDir} to ${staticOutDir}`)
-    await fs.mkdir(staticOutDir, {recursive: true})
+    reporter.info(`Copying static assets from ${srcDir} to ${outDir}`)
+    await fs.mkdir(outDir, {recursive: true})
 
-    fs.cp(staticDir, staticOutDir, {recursive: true, overwrite: true})
+    fs.cp(srcDir, outDir, {recursive: true, overwrite: true})
   } catch (err) {
     reporter.error('onPostBootstrap error:', err)
   }

--- a/apps/docs/gatsby-node.js
+++ b/apps/docs/gatsby-node.js
@@ -1,4 +1,6 @@
 const defines = require('./babel-defines')
+const path = require('path')
+const fs = require('fs').promises
 
 exports.onCreateWebpackConfig = ({actions, loaders, plugins, getConfig}) => {
   const config = getConfig()
@@ -27,4 +29,28 @@ exports.onCreateWebpackConfig = ({actions, loaders, plugins, getConfig}) => {
   })
 
   actions.replaceWebpackConfig(config)
+}
+
+exports.onPostBootstrap = async ({reporter}) => {
+  // eslint-disable-next-line i18n-text/no-en
+  reporter.info('Running post-bootstrap tasks...')
+
+  if (process.env.NODE_ENV === 'production') {
+    // eslint-disable-next-line i18n-text/no-en
+    reporter.info('No post-bootstrap tasks to run in production environment.')
+    return
+  }
+
+  const staticDir = path.resolve(__dirname, 'static', 'assets')
+  const staticOutDir = path.resolve(__dirname, 'public', 'brand', 'assets')
+
+  try {
+    // eslint-disable-next-line i18n-text/no-en
+    reporter.info(`Copying static assets from ${staticDir} to ${staticOutDir}`)
+    await fs.mkdir(staticOutDir, {recursive: true})
+
+    fs.cp(staticDir, staticOutDir, {recursive: true, overwrite: true})
+  } catch (err) {
+    reporter.error('onPostBootstrap error:', err)
+  }
 }

--- a/packages/react/src/VideoPlayer/VideoPlayer.features.stories.tsx
+++ b/packages/react/src/VideoPlayer/VideoPlayer.features.stories.tsx
@@ -15,22 +15,22 @@ export default {
 
 export const WithPoster = () => (
   <VideoPlayer poster={posterImage} title="GitHub media player">
-    <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+    <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+    <VideoPlayer.Track src="./example.vtt" />
   </VideoPlayer>
 )
 
 export const WithoutBranding = () => (
   <VideoPlayer showBranding={false} title="GitHub media player">
-    <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+    <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+    <VideoPlayer.Track src="./example.vtt" />
   </VideoPlayer>
 )
 
 export const WithVisuallyHiddenTitle = () => (
   <VideoPlayer visuallyHiddenTitle title="GitHub media player">
-    <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+    <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+    <VideoPlayer.Track src="./example.vtt" />
   </VideoPlayer>
 )
 
@@ -44,22 +44,22 @@ export const WithSomeHiddenControls = () => (
     showVolumeControl={false}
     showFullScreenButton={false}
   >
-    <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+    <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+    <VideoPlayer.Track src="./example.vtt" />
   </VideoPlayer>
 )
 
 export const HideControlsWhenPaused = () => (
   <VideoPlayer title="GitHub media player" showControlsWhenPaused={false}>
-    <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+    <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+    <VideoPlayer.Track src="./example.vtt" />
   </VideoPlayer>
 )
 
 export const Minimal = () => (
   <VideoPlayer title="GitHub media player" visuallyHiddenTitle showBranding={false} showControlsWhenPaused={false}>
-    <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+    <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+    <VideoPlayer.Track src="./example.vtt" />
   </VideoPlayer>
 )
 
@@ -77,8 +77,8 @@ const MyVideoPlayer = () => {
         showVolumeControl={false}
         showFullScreenButton={false}
       >
-        <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" type="video/mp4" />
-        <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+        <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+        <VideoPlayer.Track src="./example.vtt" />
       </VideoPlayer>
       <Stack direction="horizontal">
         <Button onClick={() => togglePlaying()}>{isPlaying ? 'Pause' : 'Play'}</Button>
@@ -99,7 +99,7 @@ export const ControlledProgrammatically = () => {
 
 export const CustomPlayIcon = () => (
   <VideoPlayer title="GitHub media player" playIcon={() => <PlayIcon size={96} />}>
-    <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+    <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+    <VideoPlayer.Track src="./example.vtt" />
   </VideoPlayer>
 )

--- a/packages/react/src/VideoPlayer/VideoPlayer.features.stories.tsx
+++ b/packages/react/src/VideoPlayer/VideoPlayer.features.stories.tsx
@@ -16,21 +16,21 @@ export default {
 export const WithPoster = () => (
   <VideoPlayer poster={posterImage} title="GitHub media player">
     <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="./example.vtt" />
+    <VideoPlayer.Track src="./example.vtt" default />
   </VideoPlayer>
 )
 
 export const WithoutBranding = () => (
   <VideoPlayer showBranding={false} title="GitHub media player">
     <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="./example.vtt" />
+    <VideoPlayer.Track src="./example.vtt" default />
   </VideoPlayer>
 )
 
 export const WithVisuallyHiddenTitle = () => (
   <VideoPlayer visuallyHiddenTitle title="GitHub media player">
     <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="./example.vtt" />
+    <VideoPlayer.Track src="./example.vtt" default />
   </VideoPlayer>
 )
 
@@ -45,21 +45,21 @@ export const WithSomeHiddenControls = () => (
     showFullScreenButton={false}
   >
     <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="./example.vtt" />
+    <VideoPlayer.Track src="./example.vtt" default />
   </VideoPlayer>
 )
 
 export const HideControlsWhenPaused = () => (
   <VideoPlayer title="GitHub media player" showControlsWhenPaused={false}>
     <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="./example.vtt" />
+    <VideoPlayer.Track src="./example.vtt" default />
   </VideoPlayer>
 )
 
 export const Minimal = () => (
   <VideoPlayer title="GitHub media player" visuallyHiddenTitle showBranding={false} showControlsWhenPaused={false}>
     <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="./example.vtt" />
+    <VideoPlayer.Track src="./example.vtt" default />
   </VideoPlayer>
 )
 
@@ -78,7 +78,7 @@ const MyVideoPlayer = () => {
         showFullScreenButton={false}
       >
         <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
-        <VideoPlayer.Track src="./example.vtt" />
+        <VideoPlayer.Track src="./example.vtt" default />
       </VideoPlayer>
       <Stack direction="horizontal">
         <Button onClick={() => togglePlaying()}>{isPlaying ? 'Pause' : 'Play'}</Button>
@@ -100,6 +100,6 @@ export const ControlledProgrammatically = () => {
 export const CustomPlayIcon = () => (
   <VideoPlayer title="GitHub media player" playIcon={() => <PlayIcon size={96} />}>
     <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="./example.vtt" />
+    <VideoPlayer.Track src="./example.vtt" default />
   </VideoPlayer>
 )

--- a/packages/react/src/VideoPlayer/VideoPlayer.stories.tsx
+++ b/packages/react/src/VideoPlayer/VideoPlayer.stories.tsx
@@ -62,8 +62,8 @@ export default meta
 
 export const Playground: StoryFn<typeof VideoPlayer> = args => (
   <VideoPlayer {...args}>
-    <VideoPlayer.Source src="/brand/storybook/example.mp4" type="video/mp4" />
-    <VideoPlayer.Track src="/brand/storybook/example.vtt" default />
+    <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+    <VideoPlayer.Track src="./example.vtt" default />
   </VideoPlayer>
 )
 

--- a/packages/react/src/recipes/SolutionTemplates/SolutionPage/SolutionPage.tsx
+++ b/packages/react/src/recipes/SolutionTemplates/SolutionPage/SolutionPage.tsx
@@ -921,7 +921,7 @@ function HeroVideo() {
       <Box marginBlockStart={32} animate="scale-in-up">
         <VideoPlayer visuallyHiddenTitle title="GitHub media player">
           <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
-          <VideoPlayer.Track src="./example.vtt" />
+          <VideoPlayer.Track src="./example.vtt" default />
         </VideoPlayer>
       </Box>
     </AnimationProvider>

--- a/packages/react/src/recipes/SolutionTemplates/SolutionPage/SolutionPage.tsx
+++ b/packages/react/src/recipes/SolutionTemplates/SolutionPage/SolutionPage.tsx
@@ -920,8 +920,8 @@ function HeroVideo() {
     <AnimationProvider staggerDelayIncrement={1000} runOnce visibilityOptions={0.2}>
       <Box marginBlockStart={32} animate="scale-in-up">
         <VideoPlayer visuallyHiddenTitle title="GitHub media player">
-          <VideoPlayer.Source src="https://primer.github.io/brand/assets/example.mp4" type="video/mp4" />
-          <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" />
+          <VideoPlayer.Source src="./example.mp4" type="video/mp4" />
+          <VideoPlayer.Track src="./example.vtt" />
         </VideoPlayer>
       </Box>
     </AnimationProvider>

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.features.stories.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.features.stories.tsx
@@ -213,7 +213,7 @@ export const Video = args => (
             src="https://githubnext.com/assets/projects/copilot-workspace/features-river-1.mp4"
             type="video/mp4; codecs=avc1.4d002a"
           />
-          <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" default />
+          <VideoPlayer.Track src="./example.vtt" default />
         </VideoPlayer>
       </River.Visual>
       <River.Content trailingComponent={args.withTrailingComponent ? TimelineExample : undefined}>
@@ -232,7 +232,7 @@ export const Video = args => (
             src="https://githubnext.com/assets/projects/copilot-workspace/features-river-2.mp4"
             type="video/mp4; codecs=avc1.4d002a"
           />
-          <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" default />
+          <VideoPlayer.Track src="./example.vtt" default />
         </VideoPlayer>
       </River.Visual>
       <River.Content trailingComponent={args.withTrailingComponent ? TimelineExample : undefined}>
@@ -251,7 +251,7 @@ export const Video = args => (
             src="https://githubnext.com/assets/projects/copilot-workspace/features-river-3.mp4"
             type="video/mp4; codecs=avc1.4d002a"
           />
-          <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" default />
+          <VideoPlayer.Track src="./example.vtt" default />
         </VideoPlayer>
       </River.Visual>
       <River.Content trailingComponent={args.withTrailingComponent ? TimelineExample : undefined}>
@@ -270,7 +270,7 @@ export const Video = args => (
             src="https://githubnext.com/assets/projects/copilot-workspace/features-river-4.mp4"
             type="video/mp4; codecs=avc1.4d002a"
           />
-          <VideoPlayer.Track src="https://primer.github.io/brand/assets/example.vtt" default />
+          <VideoPlayer.Track src="./example.vtt" default />
         </VideoPlayer>
       </River.Visual>
       <River.Content trailingComponent={args.withTrailingComponent ? TimelineExample : undefined}>


### PR DESCRIPTION
## Summary

There are currently some issues with the static directories in both the preview/production Storybook and the docs which result in assets not loading correctly in certain environments. The only component which consumes these assets is `VideoPlayer`, so the issue hasn't been particularly noticeable up to now.

This PR resolves those issues and allows us to pull static assets from the asset directory of the current application, without having to pull all assets from the production site, as we were doing before.

> ⚠️ NB This PR uses the `cp` method on Node's `fs` API — in development only — to move the docs assets into the expected directory.  The `cp` method was added in Node 20, so this PR won't work on older versions of Node. If that's an issue, we can use a different method to move the assets, but it will be slightly more complex.
> 
> Node 20 is now LTS however, so I think it's reasonable for us to require this version for development. If you disagree, let me know and I can look into other options.


## List of notable changes:

- Added an `onPostBootstrap` hook to our Gatsby config to move assets into the expected directory (`/brand/assets`) in development. This means that, in both dev and prod environments, the assets are in the same relative location. This means we don't need to add any special logic to the codebase which determines asset location based on environment.

## What should reviewers focus on?

- Check stories and documentation which use the `VideoPlayer` component to ensure that the video loads as expected

## Supporting resources (related issues, external links, etc):

- https://github.com/github/primer/issues/3772

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
