### PR TITLE
Fix failing Remix integration test

### DIFF
--- a/.github/workflows/integration_test_remix.yml
+++ b/.github/workflows/integration_test_remix.yml
@@ -44,7 +44,7 @@ jobs:
         run: cd ./packages/react && npm pack
 
       - name: Configuring Remix.run
-        run: npx create-remix --template remix-run/indie-stack ${{env.TEST_FOLDER}} --yes
+        run: npx create-remix --template joshfarrant/indie-stack ${{env.TEST_FOLDER}} --yes
 
       - name: Retrieving package version
         id: package-version
@@ -54,7 +54,7 @@ jobs:
 
       - name: Installing local build
         run: |
-          cd ${{env.TEST_FOLDER}} 
+          cd ${{env.TEST_FOLDER}}
           cp ../packages/react/primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz ./
           npm install primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz
 
@@ -68,7 +68,7 @@ jobs:
           cp ./packages/e2e/integration-tests/remix.run/_index.tsx ./${{env.TEST_FOLDER}}/app/routes
           cp ./packages/e2e/integration-tests/remix.run/root.tsx ./${{env.TEST_FOLDER}}/app
           cp -r ./packages/e2e/integration-tests/fixtures ./${{env.TEST_FOLDER}}/app
-          cp ./packages/e2e/cypress.config.js ./${{env.TEST_FOLDER}} 
+          cp ./packages/e2e/cypress.config.js ./${{env.TEST_FOLDER}}
           mkdir ${{env.TEST_FOLDER}}/integration-tests
           cp -r ./packages/e2e/integration-tests/fixtures ./${{env.TEST_FOLDER}}/integration-tests
           cp -r ./packages/e2e/integration-tests/tests ./${{env.TEST_FOLDER}}/integration-tests

--- a/.github/workflows/integration_test_remix.yml
+++ b/.github/workflows/integration_test_remix.yml
@@ -44,7 +44,7 @@ jobs:
         run: cd ./packages/react && npm pack
 
       - name: Configuring Remix.run
-        run: npx create-remix --template joshfarrant/indie-stack ${{env.TEST_FOLDER}} --yes
+        run: npx create-remix --template https://github.com/joshfarrant/indie-stack/tree/module-fix ${{env.TEST_FOLDER}} --yes
 
       - name: Retrieving package version
         id: package-version


### PR DESCRIPTION
## Summary

A temporary change to fix our failing Remix integration test.

I've opened [an issue on the remix-run/indie-stack repo](https://github.com/remix-run/indie-stack/issues/294) and created [a PR which includes a fix](https://github.com/remix-run/indie-stack/pull/295).

Until that's merged, however, I suggest we just point the job at my branch.

When it is merged I'll open another PR to revert this change.

## List of notable changes:

- Updates location of indie-stack template to [my personal fork](https://github.com/joshfarrant/indie-stack/tree/module-fix).

## What should reviewers focus on?

- Are you happy with it temporarily pointing at my own fork?
- Does the CI run successfully?

## Supporting resources (related issues, external links, etc):

- Fork: https://github.com/joshfarrant/indie-stack/tree/module-fix
- https://github.com/remix-run/indie-stack/issues/294
- https://github.com/remix-run/indie-stack/pull/295

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
