### PR TITLE
Switch remix integration test template to default

### DIFF
--- a/.github/workflows/integration_test_remix.yml
+++ b/.github/workflows/integration_test_remix.yml
@@ -44,7 +44,7 @@ jobs:
         run: cd ./packages/react && npm pack
 
       - name: Configuring Remix.run
-        run: npx create-remix --template remix-run/indie-stack ${{env.TEST_FOLDER}} --yes
+        run: npx create-remix@latest ./${{env.TEST_FOLDER}} --yes
 
       - name: Retrieving package version
         id: package-version
@@ -56,7 +56,7 @@ jobs:
         run: |
           cd ${{env.TEST_FOLDER}} 
           cp ../packages/react/primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz ./
-          npm install primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz
+          npm install primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz vite-plugin-cjs-interop
 
       - name: Prefer ESM imports
         run: |
@@ -65,6 +65,7 @@ jobs:
 
       - name: Copying required files
         run: |
+          cp ./packages/e2e/integration-tests/remix.run/vite.config.ts ./${{env.TEST_FOLDER}}
           cp ./packages/e2e/integration-tests/remix.run/_index.tsx ./${{env.TEST_FOLDER}}/app/routes
           cp ./packages/e2e/integration-tests/remix.run/root.tsx ./${{env.TEST_FOLDER}}/app
           cp -r ./packages/e2e/integration-tests/fixtures ./${{env.TEST_FOLDER}}/app

--- a/packages/e2e/integration-tests/fixtures/KitchenSink.tsx
+++ b/packages/e2e/integration-tests/fixtures/KitchenSink.tsx
@@ -18,6 +18,7 @@ import {
   Stack,
   ButtonGroup,
 } from './'
+
 import '@primer/react-brand/lib/css/main.css'
 
 export default function KitchenSink() {
@@ -26,8 +27,8 @@ export default function KitchenSink() {
   const mockHandler = () => {}
 
   return (
-    <>
-      <SubdomainNavBar title="Subdomain">
+    <ThemeProvider>
+      <SubdomainNavBar title="Subdomain" fixed={false}>
         <SubdomainNavBar.Link href="#">Collections</SubdomainNavBar.Link>
         <SubdomainNavBar.Link href="#">Topics</SubdomainNavBar.Link>
         <SubdomainNavBar.Link href="#">Articles</SubdomainNavBar.Link>
@@ -377,6 +378,6 @@ export default function KitchenSink() {
           </form>
         </div>
       </ThemeProvider>
-    </>
+    </ThemeProvider>
   )
 }

--- a/packages/e2e/integration-tests/fixtures/index.esm.ts
+++ b/packages/e2e/integration-tests/fixtures/index.esm.ts
@@ -1,3 +1,23 @@
+import {
+  Hero,
+  River,
+  FAQ,
+  Heading,
+  Text,
+  InlineLink,
+  Link,
+  FormControl,
+  TextInput,
+  ThemeProvider,
+  Checkbox,
+  Select,
+  Button,
+  SubdomainNavBar,
+  ComparisonTable,
+  Stack,
+  ButtonGroup,
+} from '@primer/react-brand'
+
 export {
   Hero,
   River,
@@ -16,4 +36,4 @@ export {
   ComparisonTable,
   Stack,
   ButtonGroup,
-} from '@primer/react-brand'
+}

--- a/packages/e2e/integration-tests/remix.run/root.tsx
+++ b/packages/e2e/integration-tests/remix.run/root.tsx
@@ -1,9 +1,8 @@
-import {cssBundleHref} from '@remix-run/css-bundle'
-import type {LinksFunction, LoaderArgs} from '@remix-run/node'
-import {json} from '@remix-run/node'
-import {Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration} from '@remix-run/react'
-
-import {getUser} from '~/session.server'
+/**
+ * Created using npx create-remix
+ * Modified to add Primer Brand stylesheet
+ */
+import {Links, Meta, Outlet, Scripts, ScrollRestoration} from '@remix-run/react'
 import primerBrandStyles from '@primer/react-brand/lib/css/main.css'
 import stylesheet from '~/tailwind.css'
 
@@ -13,25 +12,24 @@ export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{rel: 'stylesheet', href: cssBundleHref}] : []),
 ]
 
-export const loader = async ({request}: LoaderArgs) => {
-  return json({user: await getUser(request)})
-}
-
-export default function App() {
+export function Layout({children}: {children: React.ReactNode}) {
   return (
-    <html lang="en" className="h-full">
+    <html lang="en">
       <head>
         <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
       </head>
-      <body className="h-full">
-        <Outlet />
+      <body>
+        {children}
         <ScrollRestoration />
         <Scripts />
-        <LiveReload />
       </body>
     </html>
   )
+}
+
+export default function App() {
+  return <Outlet />
 }

--- a/packages/e2e/integration-tests/remix.run/root.tsx
+++ b/packages/e2e/integration-tests/remix.run/root.tsx
@@ -3,18 +3,12 @@
  * Modified to add Primer Brand stylesheet
  */
 import {Links, Meta, Outlet, Scripts, ScrollRestoration} from '@remix-run/react'
-import primerBrandStyles from '@primer/react-brand/lib/css/main.css'
-import stylesheet from '~/tailwind.css'
-
-export const links: LinksFunction = () => [
-  {rel: 'stylesheet', href: stylesheet},
-  {rel: 'stylesheet', href: primerBrandStyles},
-  ...(cssBundleHref ? [{rel: 'stylesheet', href: cssBundleHref}] : []),
-]
+import '@primer/react-brand/lib/css/main.css'
+import './tailwind.css'
 
 export function Layout({children}: {children: React.ReactNode}) {
   return (
-    <html lang="en">
+    <html lang="en" dir="ltr">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/e2e/integration-tests/remix.run/vite.config.ts
+++ b/packages/e2e/integration-tests/remix.run/vite.config.ts
@@ -1,0 +1,26 @@
+/**
+ * Vite isn't optimized for CJS dependencies, so we need to use a plugin to
+ * enable interop. This is a temporary solution and documented on Remix website:
+ * https://remix.run/docs/en/main/guides/vite#esm--cjs
+ */
+import {vitePlugin as remix} from '@remix-run/dev'
+import {defineConfig} from 'vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
+import {cjsInterop} from 'vite-plugin-cjs-interop'
+
+export default defineConfig({
+  plugins: [
+    cjsInterop({
+      // List of CJS dependencies that require interop
+      dependencies: ['@primer/react-brand'],
+    }),
+    remix({
+      future: {
+        v3_fetcherPersist: true,
+        v3_relativeSplatPath: true,
+        v3_throwAbortReason: true,
+      },
+    }),
+    tsconfigPaths(),
+  ],
+})


### PR DESCRIPTION
## Summary

Fixes failing integration test for Remix

## List of notable changes:

<!--
E.g.

- **updated** the Remix template to the default. More representative of actual end-user usage, and better supported.


- **updated** the Remix template to the default. More representative of actual end-user usage, and better supported than the Indie Stack, which seems to be in maintenance mode.

## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile). 
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Is the workflow passing in the Checks?


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change


Fixed:

![Screenshot 2024-08-30 at 10 08 00](https://github.com/user-attachments/assets/e5addcd0-48a4-42a3-8679-5d02adc92a87)

