### PR TITLE
Enforce `RiverStoryScroll` children are Rivers using types

### DIFF
--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
@@ -102,13 +102,13 @@ export function RiverStoryScroll({children, disabled}: React.PropsWithChildren<R
                 key={index}
                 index={index}
               >
-                {media[index].type === 'video' && (
+                {item.type === 'video' && (
                   <video playsInline={true} muted={true} preload="auto" className={styles['RiverStoryScroll__image']}>
-                    <source src={media[index].src} type="video/mp4; codecs=avc1.4d002a" />
+                    <source src={item.src} type="video/mp4; codecs=avc1.4d002a" />
                   </video>
                 )}
-                {media[index].type === 'image' && (
-                  <img className={styles['RiverStoryScroll__image']} src={`${media[index].src}`} alt="" />
+                {item.type === 'image' && (
+                  <img className={styles['RiverStoryScroll__image']} src={`${item.src}`} alt="" />
                 )}
               </RiverStoryScrollResponder>
             ))}

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
@@ -59,33 +59,31 @@ export function RiverStoryScroll({children, disabled}: React.PropsWithChildren<R
   }, [])
 
   useEffect(() => {
-    if (disabled || prefersReducedMotion) return
+    if (disabled || prefersReducedMotion || !contentContainerRef.current) return
 
-    if (contentContainerRef.current) {
-      const mediaElements = Array.from(contentContainerRef.current.querySelectorAll('img, video')).filter(element => {
-        return element.tagName === 'IMG' || element.tagName === 'VIDEO'
-      })
+    const mediaElements = Array.from(contentContainerRef.current.querySelectorAll('img, video')).filter(element => {
+      return element.tagName === 'IMG' || element.tagName === 'VIDEO'
+    })
 
-      const newMedia = mediaElements
-        .map((element): {type: 'image' | 'video'; src: string} | undefined => {
-          if (element.tagName === 'IMG') {
-            return {
-              type: 'image',
-              src: (element as HTMLImageElement).src,
-            }
-          } else if (element.tagName === 'VIDEO') {
-            return {
-              type: 'video',
-              src: (element as HTMLVideoElement).querySelector('source')?.src || '',
-            }
+    const newMedia = mediaElements
+      .map((element): {type: 'image' | 'video'; src: string} | undefined => {
+        if (element.tagName === 'IMG') {
+          return {
+            type: 'image',
+            src: (element as HTMLImageElement).src,
           }
-          return undefined
-        })
-        .filter(Boolean) as Array<{type: 'image' | 'video'; src: string}>
+        } else if (element.tagName === 'VIDEO') {
+          return {
+            type: 'video',
+            src: (element as HTMLVideoElement).querySelector('source')?.src || '',
+          }
+        }
+        return undefined
+      })
+      .filter(Boolean) as Array<{type: 'image' | 'video'; src: string}>
 
-      // set new media
-      setMedia(newMedia)
-    }
+    // set new media
+    setMedia(newMedia)
   }, [disabled, prefersReducedMotion])
 
   if (disabled || prefersReducedMotion) {

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
@@ -33,7 +33,7 @@ export function RiverStoryScroll({children, disabled}: React.PropsWithChildren<R
   const [media, setMedia] = React.useState<Media[]>([])
 
   const Children = React.Children.map(children, child => {
-    if (React.isValidElement(child) && child.type === River) {
+    if (React.isValidElement(child)) {
       return React.cloneElement(child as React.ReactElement<RiverProps>, {
         className: clsx(styles['RiverStoryScroll__internal-river'], styles['RiverStoryScroll__content-stack']),
       })

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx'
 import React, {useEffect, useRef} from 'react'
-import {River, RiverProps} from '../../'
-import {BaseProps} from '../../component-helpers'
+import type {RiverProps} from '../../'
 import {RiverStoryScrollProvider} from './RiverStoryScrollProvider'
 import {RiverStoryScrollResponder} from './RiverStoryScrollResponder'
 import {RiverStoryScrollTracker} from './RiverStoryScrollTracker'
@@ -22,10 +21,15 @@ export type RiverStoryScrollProps = {
    * Disable the scroll effect.
    */
   disabled?: boolean
-} & BaseProps<HTMLDivElement>
+  /**
+   * Only River components are allowed as children.
+   */
+  children?: React.ReactElement<RiverProps>[]
+}
+
 type Media = {type: 'image' | 'video'; src: string}
 
-export function RiverStoryScroll({children, disabled}: React.PropsWithChildren<RiverStoryScrollProps>) {
+export function RiverStoryScroll({children, disabled}: RiverStoryScrollProps) {
   const visualContainerRef = useRef<HTMLDivElement | null>(null)
   const contentContainerRef = useRef<HTMLDivElement | null>(null)
 

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.tsx
@@ -64,8 +64,8 @@ export function RiverStoryScroll({children, disabled}: RiverStoryScrollProps) {
   useEffect(() => {
     if (disabled || prefersReducedMotion || !contentContainerRef.current) return
 
-    const mediaElements = Array.from(contentContainerRef.current.querySelectorAll('img, video')).filter(
-      element => element instanceof HTMLImageElement || element instanceof HTMLVideoElement,
+    const mediaElements = Array.from(
+      contentContainerRef.current.querySelectorAll<HTMLImageElement | HTMLVideoElement>('img, video'),
     )
 
     const newMedia: Media[] = mediaElements.map(element => {

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScrollResponder.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScrollResponder.tsx
@@ -2,6 +2,7 @@ import React, {useEffect, useRef, useState} from 'react'
 import {useStoryScrollContext} from './RiverStoryScrollProvider' // Adjust the import path as necessary
 
 import styles from './RiverStoryScroll.module.css'
+import clsx from 'clsx'
 
 type RiverStoryScrollResponderProps = {
   index: number
@@ -23,7 +24,6 @@ export function RiverStoryScrollResponder({
 
   const {visibilityStates} = useStoryScrollContext()
   const isVisible = visibilityStates[index]
-  const dynamicClassName = `${className || ''} ${isVisible ? visibleClassName : hiddenClassName}`
   const videoRef = useRef<HTMLVideoElement>(null)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [videoStatus, setVideoStatus] = useState<'playing' | 'paused' | 'ended'>('paused')
@@ -55,5 +55,5 @@ export function RiverStoryScrollResponder({
     return child
   })
 
-  return <div className={dynamicClassName}>{parsedChildren}</div>
+  return <div className={clsx(className, isVisible ? visibleClassName : hiddenClassName)}>{parsedChildren}</div>
 }

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScrollResponder.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScrollResponder.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react'
+import React, {useEffect, useRef} from 'react'
 import {useStoryScrollContext} from './RiverStoryScrollProvider' // Adjust the import path as necessary
 
 import styles from './RiverStoryScroll.module.css'
@@ -19,30 +19,21 @@ export function RiverStoryScrollResponder({
   visibleClassName = styles['tracker-in-viewport'],
   hiddenClassName = styles['tracker-outside-viewport'],
 }: RiverStoryScrollResponderProps) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const isVideo = React.Children.toArray(children).some(child => React.isValidElement(child) && child.type === 'video')
-
   const {visibilityStates} = useStoryScrollContext()
   const isVisible = visibilityStates[index]
   const videoRef = useRef<HTMLVideoElement>(null)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [videoStatus, setVideoStatus] = useState<'playing' | 'paused' | 'ended'>('paused')
 
   useEffect(() => {
     const videoElement = videoRef.current
     if (videoElement) {
-      videoElement.onended = () => setVideoStatus('ended')
       if (isVisible) {
-        setVideoStatus('playing')
         // eslint-disable-next-line github/no-then
         videoElement.play().catch(error => {
           // eslint-disable-next-line no-console
           console.error('Error playing the video:', error)
-          setVideoStatus('paused')
         })
       } else {
         videoElement.pause()
-        setVideoStatus('paused')
       }
     }
   }, [isVisible])

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScrollResponder.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScrollResponder.tsx
@@ -25,16 +25,17 @@ export function RiverStoryScrollResponder({
 
   useEffect(() => {
     const videoElement = videoRef.current
-    if (videoElement) {
-      if (isVisible) {
-        // eslint-disable-next-line github/no-then
-        videoElement.play().catch(error => {
-          // eslint-disable-next-line no-console
-          console.error('Error playing the video:', error)
-        })
-      } else {
-        videoElement.pause()
-      }
+
+    if (!videoElement) return
+
+    if (isVisible) {
+      // eslint-disable-next-line github/no-then
+      videoElement.play().catch(error => {
+        // eslint-disable-next-line no-console
+        console.error('Error playing the video:', error)
+      })
+    } else {
+      videoElement.pause()
     }
   }, [isVisible])
 

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScrollTracker.tsx
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScrollTracker.tsx
@@ -1,7 +1,8 @@
 import React, {useEffect, useRef, useState} from 'react'
-import {useStoryScrollContext} from './RiverStoryScrollProvider'
-import {useWindowSize} from '../../'
+import clsx from 'clsx'
 
+import {useWindowSize} from '../../'
+import {useStoryScrollContext} from './RiverStoryScrollProvider'
 import styles from './RiverStoryScroll.module.css'
 
 type RiverStoryScrollTrackerProps = {
@@ -67,10 +68,11 @@ export const RiverStoryScrollTracker = ({index, children, className = ''}: River
     }
   }, [index, isLarge, setVisibilityStates])
 
-  const dynamicClassName = `${className} ${isIntersecting ? styles['in-viewport'] : styles['outside-viewport']}`
-
   return (
-    <div ref={elementRef} className={dynamicClassName}>
+    <div
+      ref={elementRef}
+      className={clsx(className, isIntersecting ? styles['in-viewport'] : styles['outside-viewport'])}
+    >
       {children}
     </div>
   )


### PR DESCRIPTION
## Summary

Lightly refactors `RiverStoryScroll` and moves the check that children are `River` components to TypeScript.

If consumers want to pass a component that isn't a River — for example a custom component which wraps `River` — then they will need to suppress a TypeScript error (for example, using a `@ts-expect-error` comment).

## List of notable changes:

- Uses TypeScript to enforce that `RiverStoryScroll` children are `River` components
- Small refactoring of `RiverStoryScroll` to remove a few unused variables, remove some nesting, and remove some type assertions

## What should reviewers focus on?

- Check that all of the `RiverStoryScroll` stories still work as expected

## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/issues/745

## Contributor checklist:

- [x] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
