### PR TITLE
Add Figma code connect forn River component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -177,6 +177,7 @@ module.exports = {
       files: ['**/*.figma.tsx'],
       rules: {
         'github/unescaped-html-literal': 0,
+        'i18n-text/no-en': 0,
       },
     },
   ],

--- a/packages/react/src/river/River.figma.tsx
+++ b/packages/react/src/river/River.figma.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import {Heading, Link, River, Text} from '../'
+import figma from '@figma/code-connect'
+
+figma.connect(River, 'https://www.figma.com/design/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=375-8463', {
+  props: {
+    align: figma.enum('align', {
+      start: 'start',
+      center: 'center',
+      end: 'end',
+    }),
+    imageTextRatio: figma.enum('imageTextRatio', {
+      '50:50': '50:50',
+      '60:40': '60:40',
+    }),
+    content: figma.nestedProps('Content', {
+      headingText: figma.textContent('Heading'),
+      descriptionText: figma.textContent('Description'),
+      link: figma.boolean('link?', {
+        true: <Link href="#">Link text</Link>,
+        false: undefined,
+      }),
+    }),
+  },
+
+  example: ({align, imageTextRatio, content}) => (
+    <River align={align} imageTextRatio={imageTextRatio}>
+      <River.Content>
+        <>
+          <Heading>{content.headingText}</Heading>
+          <Text>{content.descriptionText}</Text>
+          {content.link}
+        </>
+      </River.Content>
+      <River.Visual rounded>
+        <img src="https://via.placeholder.com/600x400/f5f5f5/f5f5f5.png" alt="alt description" />
+      </River.Visual>
+    </River>
+  ),
+})


### PR DESCRIPTION
## Summary

Adds basic Figma code connect to the River component. 

## List of notable changes:

- Adds Figma code connect file for the River component
- Disables `i18n-text/no-en` in Figma code connect files to support some Figma layer names

## What should reviewers focus on?

- Test River examples in dev mode on the `main` branch in Figma. 

## Screenshots:

<img width="460" alt="image" src="https://github.com/user-attachments/assets/afbd3b00-c67f-4c7d-88c3-29978a7343f7">

