### PR TITLE
Use clsx to combine HeroLabel and HeroEyebrow classnames

### DIFF
--- a/.changeset/ninety-taxis-lick.md
+++ b/.changeset/ninety-taxis-lick.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed a bug where passing a className to `Hero.Label` or `Hero.Eyebrow` would replace the default class.

--- a/packages/react/src/Hero/Hero.tsx
+++ b/packages/react/src/Hero/Hero.tsx
@@ -165,9 +165,9 @@ const HeroImage = forwardRef<HTMLImageElement, HeroImageProps>(
 type HeroEyebrowProps = PropsWithChildren<BaseProps<HTMLDivElement>>
 
 const HeroEyebrow = forwardRef<HTMLDivElement, HeroEyebrowProps>(
-  ({children, ...rest}: PropsWithChildren<HeroEyebrowProps>, ref) => {
+  ({children, className, ...rest}: PropsWithChildren<HeroEyebrowProps>, ref) => {
     return (
-      <div ref={ref} className={styles['Hero-eyebrow']} {...rest}>
+      <div ref={ref} className={clsx(styles['Hero-eyebrow'], className)} {...rest}>
         {children}
       </div>
     )
@@ -177,9 +177,9 @@ const HeroEyebrow = forwardRef<HTMLDivElement, HeroEyebrowProps>(
 type HeroLabelProps = LabelProps & BaseProps<HTMLSpanElement>
 
 const HeroLabel = forwardRef<HTMLSpanElement, HeroLabelProps>(
-  ({children, ...rest}: PropsWithChildren<HeroLabelProps>, ref) => {
+  ({children, className, ...rest}: PropsWithChildren<HeroLabelProps>, ref) => {
     return (
-      <Label ref={ref} className={styles['Hero-label']} {...rest}>
+      <Label ref={ref} className={clsx(styles['Hero-label'], className)} {...rest}>
         {children}
       </Label>
     )


### PR DESCRIPTION
## Summary

Fixes a bug where passing a `className` to `Hero.Label` or `Hero.Eyebrow` would replace the default class.


## Steps to test:

1. Pass a `className` prop to `Hero.Label` or `Hero.Eyebrow`
1. Ensure that the default class is not replaced when a `className` is passed

## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/issues/757

## Contributor checklist:

- [x] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
