### PR TITLE
Improve RiverBreakout spacing

### DIFF
--- a/.changeset/lovely-rocks-bathe.md
+++ b/.changeset/lovely-rocks-bathe.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Improves spacing of RiverBreakout content

--- a/packages/react/src/river/river-shared.module.css
+++ b/packages/react/src/river/river-shared.module.css
@@ -166,6 +166,11 @@
       'text trailingComponent'
       'cta trailingComponent';
     grid-template-columns: 5fr 3fr;
+    grid-auto-rows: auto 1fr;
+  }
+
+  .RiverBreakout .River__text {
+    grid-area: text;
   }
 
   .RiverBreakout .River__call-to-action {
@@ -177,9 +182,5 @@
     grid-area: trailingComponent;
     justify-self: end;
     margin-block-start: 0;
-  }
-
-  .RiverBreakout .River__text {
-    grid-area: text;
   }
 }

--- a/packages/react/src/river/river-shared.module.css
+++ b/packages/react/src/river/river-shared.module.css
@@ -158,6 +158,10 @@
   width: 1px;
 }
 
+.RiverBreakout .River__call-to-action {
+  margin-block-end: var(--base-size-40);
+}
+
 @media screen and (min-width: 48rem) {
   .RiverBreakout .River__content {
     display: grid;
@@ -175,7 +179,7 @@
 
   .RiverBreakout .River__call-to-action {
     grid-area: cta;
-    margin-block-start: 0;
+    margin-block: 0;
   }
 
   .RiverBreakout .River__trailingComponent {


### PR DESCRIPTION
## Summary

Fixes a layout issue with RiverBreakout cta when the `trailingComponent` is taller and adds  spacing on smaller viewports.


## Steps to test:

- [StoryBook](https://primer-3355950bee-26139705.drafts.github.io/brand/storybook/?path=/story/components-riverbreakout--default)

## Supporting resources (related issues, external links, etc):

- Solves https://github.com/github/primer/issues/3939
- Fixes https://github.com/github/primer/issues/3940

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] New visual snapshots have been generated / updated for any UI changes
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

