### PR TITLE
Remove @primer/brand-e2e changes from changesets

### DIFF
--- a/.changeset/curly-readers-poke.md
+++ b/.changeset/curly-readers-poke.md
@@ -1,6 +1,5 @@
 ---
 '@primer/react-brand': patch
-'@primer/brand-e2e': patch
 ---
 
 Added `aria-describedby` attribute to leading/trailing text and visuals in `TextInput` component

--- a/.changeset/forty-lamps-applaud.md
+++ b/.changeset/forty-lamps-applaud.md
@@ -1,5 +1,0 @@
----
-'@primer/brand-e2e': patch
----
-
-Updated KitchenSink to remove `FormControl.Hint` from within `FormControl.Label`


### PR DESCRIPTION
Removes  @primer/brand-e2e` changes from changesets.

These were added in previous PRs (#776, #779) as I had modified the `KitchenSink` fixture, but the changesets aren't actually required.