### PR TITLE
Hotfixes for 0.41.0 RC (continued)

### DIFF
--- a/packages/react/src/river/river-shared.module.css
+++ b/packages/react/src/river/river-shared.module.css
@@ -122,7 +122,6 @@
 
 /* Large breakpoint and up */
 @media screen and (min-width: 63.25rem) {
-
   .River--align-start .River__content {
     padding-inline-end: var(--base-size-128);
   }
@@ -131,7 +130,6 @@
     padding-inline: var(--base-size-64);
   }
 }
-
 
 .RiverBreakout {
   display: flex;

--- a/packages/react/src/river/river-shared.module.css
+++ b/packages/react/src/river/river-shared.module.css
@@ -91,14 +91,6 @@
     grid-area: content;
   }
 
-  .River--align-start .River__content {
-    padding-inline-end: var(--base-size-128);
-  }
-
-  .River--align-end .River__content {
-    padding-inline: var(--base-size-64);
-  }
-
   .River__visual {
     grid-area: visual;
   }
@@ -127,6 +119,19 @@
     margin-top: var(--brand-River-spacing-inner);
   }
 }
+
+/* Large breakpoint and up */
+@media screen and (min-width: 63.25rem) {
+
+  .River--align-start .River__content {
+    padding-inline-end: var(--base-size-128);
+  }
+
+  .River--align-end .River__content {
+    padding-inline: var(--base-size-64);
+  }
+}
+
 
 .RiverBreakout {
   display: flex;


### PR DESCRIPTION
## Summary

Fixes a regression in River that is blocking the next release https://github.com/primer/brand/pull/763

## List of notable changes:

- Ensures the new internal content padding is only applied on `large` viewports and above.


## Steps to test:

1. Code review

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
