### PR TITLE
Fixing next.js integration test 

### DIFF
--- a/.github/workflows/integration_test_nextjs.yml
+++ b/.github/workflows/integration_test_nextjs.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           cd ${{env.NEXTJS_FOLDER}}
           cp ../packages/react/primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz ./
-          npm install primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz
+          npm install primer-react-brand-${{ steps.package-version.outputs.current-version}}.tgz --legacy-peer-deps
 
       - name: Prefer ESM imports
         run: |


### PR DESCRIPTION
## Summary

Next.js GA release via create-next-app now uses the React v19 RC, which falls outside of our SemVer scope for React (<v20) 😕. Workaround for now is to use legacy peer deps flag, as the the issue is exclusive to Next.
