### PR TITLE
Disable motion when reduced-motion preference is enabled

### DIFF
--- a/.changeset/flat-socks-bathe.md
+++ b/.changeset/flat-socks-bathe.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Disabled all transitions and auto-staggering when `reduced-motion` user preference is enabled

--- a/.changeset/wet-peas-marry.md
+++ b/.changeset/wet-peas-marry.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Removed negative margin from `RiverStoryScroll` when `reduced-motion` user preference is enabled

--- a/packages/react/src/css/reset.css
+++ b/packages/react/src/css/reset.css
@@ -73,9 +73,8 @@ select {
   *,
   *::before,
   *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+    animation: none !important;
+    transition: none !important;
     scroll-behavior: auto !important;
   }
 }

--- a/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.module.css
+++ b/packages/react/src/river/RiverStoryScroll/RiverStoryScroll.module.css
@@ -459,7 +459,7 @@
   }
 }
 
-@media screen and (min-width: 768px) and (min-height: 900px) {
+@media screen and (min-width: 768px) and (min-height: 900px) and (prefers-reduced-motion: no-preference) {
   .RiverStoryScroll {
     margin-top: -20vh;
   }


### PR DESCRIPTION
## Summary

Resolves https://github.com/primer/brand/issues/804

Animation is already heavily reduced when this OS setting is enabled, but staggered animation has not been disabled.

This change disables all motion, to ensure a consistent experience for users with this preference enabled.



## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Turned off transitions entirely in the reset file
- Fixed a reduced-motion related bug in RiverStoryScroll

## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile). 
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- This decision was made at Site Design Jamz this week. Are there any counter reasons why we would want to keep transitions enabled?

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Review the code diff
1. Use this story to test the lack of motion


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] New visual snapshots have been generated / updated for any UI changes
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">


https://github.com/user-attachments/assets/11b6bfbb-49b0-4fa8-8dc6-87927976912b



 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

https://github.com/user-attachments/assets/efacddfb-9566-4064-87a3-f4cd6c390217


</td>
</tr>
</table>


<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">


![Screenshot 2024-10-30 at 16 08 17](https://github.com/user-attachments/assets/56b8dd94-002c-4ffd-9e56-d43576ad0331)


 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->
![Screenshot 2024-10-30 at 16 08 33](https://github.com/user-attachments/assets/a77c52c6-5bc3-48a1-af77-7da59a90d9a6)



</td>
</tr>
</table>