### PR TITLE
Expand Link underline to full width

### DIFF
--- a/.changeset/gentle-bulldogs-live.md
+++ b/.changeset/gentle-bulldogs-live.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Updated `Link` underline to fill entire width

--- a/packages/react/src/Link/Link.module.css
+++ b/packages/react/src/Link/Link.module.css
@@ -1,4 +1,5 @@
 .Link {
+  --arrow-width: var(--base-size-20);
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -16,7 +17,7 @@
   position: absolute;
   bottom: -0.15em;
   left: 0;
-  width: calc(100% - 1.5em);
+  width: calc(100% - var(--arrow-width));
   height: 2px;
   pointer-events: none;
   content: '';
@@ -65,8 +66,8 @@
 }
 
 .Link--large .Link-arrow {
-  width: 20px;
-  height: 20px;
+  width: var(--arrow-width);
+  height: var(--base-size-20);
 }
 
 .Link--arrow-start::after {


### PR DESCRIPTION
## Summary

Resolves https://github.com/primer/brand/issues/806

Increases width of underline on the `Link` component on hover interaction. See before and after videos below.


## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile).
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Ensure that the underline extends to end of text label

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Use the Storybook examples

## Supporting resources (related issues, external links, etc):

-
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">


https://github.com/user-attachments/assets/a2c5b0f0-4d47-4495-9400-30abfd3928e6



 </td>
<td valign="top">


https://github.com/user-attachments/assets/4e110a0c-55c9-4e5b-85d1-4b9a67c0f5d4



</td>
</tr>
</table>
