### PR TITLE
Fix broken default bgcolor value in CTA Banner

### DIFF
--- a/packages/react/src/CTABanner/CTABanner.tsx
+++ b/packages/react/src/CTABanner/CTABanner.tsx
@@ -77,7 +77,7 @@ const Root = forwardRef(
       hasBorder = false,
       hasShadow = true,
       hasBackground = true,
-      backgroundColor = 'var(--brand-CTABanner-bgColor',
+      backgroundColor = 'var(--brand-CTABanner-bgColor)',
       backgroundImageSrc,
       backgroundImagePosition = 'center',
       backgroundImageSize = 'cover',


### PR DESCRIPTION
## Summary

Resolves regression to CTA banner in latest smoke test https://github.com/primer/brand/pull/807
