### PR TITLE
Fix TextInput, TextArea, and Select width bug

### DIFF
--- a/.changeset/sour-numbers-pretend.md
+++ b/.changeset/sour-numbers-pretend.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed bug where `TextInput`, `TextArea`, and `Select` components would expand to the width of a the validation message on the parent `FormControl`.

--- a/packages/react/src/forms/Select/Select.module.css
+++ b/packages/react/src/forms/Select/Select.module.css
@@ -84,14 +84,6 @@
 }
 
 /*
- * Visual states
- */
-
-.Select--fullWidth {
-  width: 100%;
-}
-
-/*
  * Select wrapper
  */
 

--- a/packages/react/src/forms/Select/Select.module.css
+++ b/packages/react/src/forms/Select/Select.module.css
@@ -88,8 +88,6 @@
  */
 
 .Select-wrapper {
-  width: 12.5rem;
-
   border: solid var(--brand-borderWidth-thin, 1px) var(--brand-control-color-border-default);
   border-radius: var(--brand-borderRadius-medium, 6px);
   font-family: var(--brand-body-fontFamily);

--- a/packages/react/src/forms/Select/Select.module.css
+++ b/packages/react/src/forms/Select/Select.module.css
@@ -88,6 +88,8 @@
  */
 
 .Select-wrapper {
+  width: 12.5rem;
+
   border: solid var(--brand-borderWidth-thin, 1px) var(--brand-control-color-border-default);
   border-radius: var(--brand-borderRadius-medium, 6px);
   font-family: var(--brand-body-fontFamily);
@@ -120,7 +122,7 @@
 }
 
 .Select-wrapper--fullWidth {
-  display: flex;
+  width: 100%;
 }
 
 /*

--- a/packages/react/src/forms/Select/Select.module.css.d.ts
+++ b/packages/react/src/forms/Select/Select.module.css.d.ts
@@ -6,7 +6,6 @@ declare const styles: {
   readonly "Select--medium": string;
   readonly "Select-wrapper--large": string;
   readonly "Select--large": string;
-  readonly "Select--fullWidth": string;
   readonly "Select-wrapper--fullWidth": string;
   readonly "Select--success": string;
   readonly "Select--error": string;

--- a/packages/react/src/forms/TextInput/TextInput.module.css
+++ b/packages/react/src/forms/TextInput/TextInput.module.css
@@ -83,7 +83,12 @@
 }
 
 .TextInput-wrapper--fullWidth {
+  width: 100%;
   display: flex;
+}
+
+.TextInput-wrapper:not(.TextInput-wrapper--fullWidth) {
+  width: min-content;
 }
 
 .TextInput-wrapper--monospace {

--- a/packages/react/src/forms/Textarea/Textarea.module.css
+++ b/packages/react/src/forms/Textarea/Textarea.module.css
@@ -30,10 +30,6 @@
   outline: none;
 }
 
-.Textarea:focus {
-  outline: none;
-}
-
 .Textarea-resize--vertical {
   resize: vertical;
 }

--- a/packages/react/src/forms/Textarea/Textarea.module.css
+++ b/packages/react/src/forms/Textarea/Textarea.module.css
@@ -94,6 +94,10 @@
   display: flex;
 }
 
+.Textarea-wrapper:not(.Textarea-wrapper--fullWidth) {
+  width: min-content;
+}
+
 .Textarea-wrapper--monospace {
   font-family: var(--brand-fontStack-monospace);
 }


### PR DESCRIPTION
## Summary

Fixes a bug where TextInput, TextArea, and Select components expand to the width of their parent FormControl's validation message.

https://github.com/user-attachments/assets/8a7b6730-308e-4a9d-9409-93f0fbf2c7a5

## List of notable changes:

- Resolve bug in TextInput, TextArea, and Select components
- Remove some redundant CSS from Select component


## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

