### PR TITLE
Update docs form validation example to demonstrate best-practise when submitting a form in an invalid state

### DIFF
--- a/apps/docs/content/components/FormControl.mdx
+++ b/apps/docs/content/components/FormControl.mdx
@@ -228,7 +228,7 @@ Labels should only be visually hidden when the context is clear from the input i
 
 The following example demonstrates declarative form validation in [controlled mode](https://reactjs.org/docs/forms.html#controlled-components).
 
-Note that, when submitting the form with an invalid value, the invalid input will receive focus to help the user correct the error. This is especially important for users navigating the form using a screen reader.
+When the form is submitted with an invalid value, the invalid input receives focus to help the user correct the error. This is especially important for users navigating the form using a screen reader.
 
 More information on form validation best practices can be found in the [Primer UI Patterns documentation](https://primer.style/ui-patterns/forms/overview#validation).
 

--- a/apps/docs/content/components/FormControl.mdx
+++ b/apps/docs/content/components/FormControl.mdx
@@ -9,7 +9,7 @@ description: Use the form control component to display form inputs alongside lab
 import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
 import {PropTableValues} from '../../src/components'
 import {Label} from '@primer/react'
-import {Heading, Text} from '@primer/react-brand'
+import {Button, Heading, Text} from '@primer/react-brand'
 import {SearchIcon} from '@primer/octicons-react'
 import {Link} from 'gatsby'
 
@@ -228,52 +228,55 @@ Labels should only be visually hidden when the context is clear from the input i
 
 The following example demonstrates declarative form validation in [controlled mode](https://reactjs.org/docs/forms.html#controlled-components).
 
-Try changing the input value to to `monalisa` to show the `success` state.
+Note that, when submitting the form with an invalid value, the invalid input will receive focus to help the user correct the error. This is especially important for users navigating the form using a screen reader.
+
+More information on form validation best practices can be found in the [Primer UI Patterns documentation](https://primer.style/ui-patterns/forms/overview#validation).
+
+Try changing the input value to `monalisa` and submitting the form to show the `success` state.
 
 ```javascript live noinline
 const App = () => {
-  const [value, setValue] = React.useState()
-  const [validationState, setValidationState] = React.useState()
+  const usernameInputRef = React.useRef(null)
+  const [value, setValue] = React.useState('mona lisa')
+  const [isValid, setIsValid] = React.useState(false)
 
-  React.useEffect(() => {
-    const defaultHandle = 'mona lisa'
-    setValue(defaultHandle)
-    validate(defaultHandle)
-  }, [])
+  const onChange = (e) => setValue(e.target.value)
 
-  const validate = (inputValue) => {
-    if (/\s/g.test(inputValue)) {
-      setValidationState('error')
-    } else {
-      setValidationState('success')
+  const onSubmit = (e) => {
+    e.preventDefault()
+    const valid = !value.includes(' ')
+    setIsValid(valid)
+
+    if (!valid) {
+      usernameInputRef.current.focus()
     }
-  }
-
-  const handleChange = (event) => {
-    event.preventDefault()
-    if (!event.target.value) {
-      setValue(undefined)
-      setValidationState(undefined)
-      return
-    }
-    setValue(event.target.value)
-    validate(event.target.value)
   }
 
   return (
-    <FormControl validationStatus={validationState} fullWidth>
-      <FormControl.Label>GitHub handle</FormControl.Label>
-      <TextInput onChange={handleChange} value={value} fullWidth />
-      {validationState && validationState === 'error' && (
-        <FormControl.Validation>
-          GitHub handles cannot contain spaces.{' '}
-          {value && `Did you mean "${value.replaceAll(' ', '')}"`}
-        </FormControl.Validation>
-      )}
-      {validationState && validationState === 'success' && (
-        <FormControl.Validation>Valid name</FormControl.Validation>
-      )}
-    </FormControl>
+    <form onSubmit={onSubmit}>
+      <Stack gap="normal">
+        <FormControl validationStatus={isValid ? 'success' : 'error'} fullWidth>
+          <FormControl.Label>GitHub handle</FormControl.Label>
+          <TextInput
+            name="username"
+            ref={usernameInputRef}
+            fullWidth
+            value={value}
+            onChange={onChange}
+          />
+          {isValid && (
+            <FormControl.Validation>Valid name</FormControl.Validation>
+          )}
+          {!isValid && (
+            <FormControl.Validation>
+              GitHub handles cannot contain spaces.{' '}
+              {value && `Did you mean "${value.replaceAll(' ', '')}"`}
+            </FormControl.Validation>
+          )}
+        </FormControl>
+        <Button type="submit">Submit</Button>
+      </Stack>
+    </form>
   )
 }
 

--- a/apps/docs/content/components/FormControl.mdx
+++ b/apps/docs/content/components/FormControl.mdx
@@ -236,7 +236,7 @@ Try changing the input value to `monalisa` and submitting the form to show the `
 
 ```javascript live noinline
 const App = () => {
-  const usernameInputRef = React.useRef(null)
+  const inputRef = React.useRef(null)
   const [value, setValue] = React.useState('mona lisa')
   const [isValid, setIsValid] = React.useState(false)
 
@@ -248,7 +248,7 @@ const App = () => {
     setIsValid(valid)
 
     if (!valid) {
-      usernameInputRef.current.focus()
+      inputRef.current.focus()
     }
   }
 
@@ -258,8 +258,7 @@ const App = () => {
         <FormControl validationStatus={isValid ? 'success' : 'error'} fullWidth>
           <FormControl.Label>GitHub handle</FormControl.Label>
           <TextInput
-            name="username"
-            ref={usernameInputRef}
+            ref={inputRef}
             fullWidth
             value={value}
             onChange={onChange}


### PR DESCRIPTION
## Summary

Primer best-practise dictates that forms submitted with invalid values should automatically move focus to the first invalid input on submit. This PR highlights that fact in the docs and updates our _Validation_ example to demo this. It also removes live validation that runs on change and replaces it with validation that runs on submit.

## What should reviewers focus on?

- Check you're happy with the wording, as well as the example

## Steps to test:

1. View the _Validation_ section of the _Form control_ page in the docs.
1. Submit the form with an invalid value.
1. Check that the invalid input receives focus.

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/3760

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/6702f33c-9b68-44cf-8d92-5688d8e94f50)


 </td>
<td valign="top">

![image](https://github.com/user-attachments/assets/9899758d-28f8-4af6-8211-9453e3ade097)

</td>
</tr>
</table>
