### PR TITLE
Update BreakoutBanner docs information on leading visual accessible label

### DIFF
--- a/apps/docs/content/components/BreakoutBanner/react.mdx
+++ b/apps/docs/content/components/BreakoutBanner/react.mdx
@@ -100,8 +100,12 @@ The content alignment can be changed using the `align` prop on the root `Breakou
 
 ### Leading visual
 
+An accessible label should always be provided for the leading visual.
+
 ```jsx live
-<BreakoutBanner leadingVisual={<LogoGithubIcon size="medium" />}>
+<BreakoutBanner
+  leadingVisual={<LogoGithubIcon size="medium" aria-label="GitHub logo" />}
+>
   <BreakoutBanner.Heading>
     Where the most ambitious teams build great things
   </BreakoutBanner.Heading>

--- a/apps/docs/content/components/BreakoutBanner/react.mdx
+++ b/apps/docs/content/components/BreakoutBanner/react.mdx
@@ -100,7 +100,9 @@ The content alignment can be changed using the `align` prop on the root `Breakou
 
 ### Leading visual
 
-An accessible label should always be provided for the leading visual.
+<Note variant="warning">
+  An accessible label should always be provided for the leading visual.
+</Note>
 
 ```jsx live
 <BreakoutBanner


### PR DESCRIPTION
## Summary

Updates the BreakoutBanner documentation to include information on the leading visual accessible label. As the leading visual shouldn't be used for decorative imagery ([source](https://primer.style/brand/components/BreakoutBanner#leading-visuals)) I think it's safe to say that an accessible label should _always_ be provided.

[You can view the updated docs here
](https://primer-ed55036b48-26139705.drafts.github.io/brand/components/BreakoutBanner/react#leading-visual)

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/3845

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
