### PR TITLE
Remove aria-label from AnchorNav toggle button in favour of visually-hidden text

### DIFF
--- a/.changeset/kind-comics-tickle.md
+++ b/.changeset/kind-comics-tickle.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Improved accessibility in `AnchorNav` through clearer navigation menu labelling for screen reader users on narrow viewports.

--- a/packages/react/src/AnchorNav/AnchorNav.test.tsx
+++ b/packages/react/src/AnchorNav/AnchorNav.test.tsx
@@ -138,12 +138,10 @@ describe('AnchorNav', () => {
     const {getByTestId} = render(<MockAnchorNavFixture />)
     const menuButton = getByTestId(AnchorNav.testIds.menuButton)
 
-    expect(menuButton).toHaveAttribute('aria-label', 'open anchor navigation menu') // aria label before menu open
     expect(menuButton).toHaveAttribute('aria-expanded', 'false') // aria attribute before menu open
 
     fireEvent.click(menuButton) // toggle menu button
 
-    expect(menuButton).toHaveAttribute('aria-label', 'close anchor navigation menu') // aria label after menu open
     expect(menuButton).toHaveAttribute('aria-expanded', 'true') // aria attribute before menu open
   })
 

--- a/packages/react/src/AnchorNav/AnchorNav.tsx
+++ b/packages/react/src/AnchorNav/AnchorNav.tsx
@@ -214,9 +214,8 @@ function _AnchorNav({children, enableDefaultBgColor = false, hideUntilSticky = f
           <button
             onClick={handleMenuToggle}
             className={clsx(styles['AnchorNav-menu-button'])}
-            aria-expanded={menuOpen ? 'true' : 'false'}
+            aria-expanded={menuOpen}
             aria-controls={idForLinkContainer}
-            aria-label={`${menuOpen ? 'close' : 'open'} anchor navigation menu`}
             data-testid={testIds.menuButton}
           >
             {menuOpen ? (
@@ -224,6 +223,7 @@ function _AnchorNav({children, enableDefaultBgColor = false, hideUntilSticky = f
             ) : (
               <ChevronDownIcon size={16} className={styles['AnchorNav-menu-button-arrow']} fill="currentcolor" />
             )}
+            <span className="visually-hidden">Anchor navigation menu. Currently selected:</span>{' '}
             <Text as="span" className={clsx(styles['AnchorNav-link-label'])}>
               {currentActiveNavItem}
             </Text>

--- a/packages/react/src/AnchorNav/AnchorNav.tsx
+++ b/packages/react/src/AnchorNav/AnchorNav.tsx
@@ -223,7 +223,7 @@ function _AnchorNav({children, enableDefaultBgColor = false, hideUntilSticky = f
             ) : (
               <ChevronDownIcon size={16} className={styles['AnchorNav-menu-button-arrow']} fill="currentcolor" />
             )}
-            <span className="visually-hidden">Anchor navigation menu. Currently selected:</span>{' '}
+            <span className="visually-hidden">Anchor navigation menu. Currently selected: </span>
             <Text as="span" className={clsx(styles['AnchorNav-link-label'])}>
               {currentActiveNavItem}
             </Text>


### PR DESCRIPTION
## Summary

Following the recommendation in the related issue ([here](https://github.com/github/primer/issues/3756)), this PR removes the `aria-label` attribute from the `AnchorNav` toggle button in favour of visually-hidden text.

I confirmed this behaviour with Patrick [over Slack](https://github.slack.com/archives/C0FSWLQ0Y/p1732884521386289?thread_ts=1732710967.237599&cid=C0FSWLQ0Y) too.

## What should reviewers focus on?

- Make sure you're happy with the recommended approach


## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/3756
- 
## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
