### PR TITLE
Add a small delay to closing of Tooltip

### DIFF
--- a/.changeset/good-fishes-yawn.md
+++ b/.changeset/good-fishes-yawn.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Added a small (200ms) delay to the closing of the Tooltip to make it easier for users to move their cursor to the contents of the Tooltip.

--- a/.changeset/good-fishes-yawn.md
+++ b/.changeset/good-fishes-yawn.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Added a small (200ms) delay to the closing of the Tooltip to make it easier for users to move their cursor to the contents of the Tooltip.
+Added a small (200ms) delay to the closing of the `Tooltip` to make it easier for users to move their cursor to the contents of the `Tooltip`.

--- a/packages/react/src/Tooltip/Tooltip.tsx
+++ b/packages/react/src/Tooltip/Tooltip.tsx
@@ -98,6 +98,14 @@ export const Tooltip = React.forwardRef(
     }, [tooltipElRef, triggerRef])
 
     useEffect(() => {
+      return () => {
+        if (closeTooltipTimeoutRef.current) {
+          clearTimeout(closeTooltipTimeoutRef.current)
+        }
+      }
+    }, [closeTooltipTimeoutRef])
+
+    useEffect(() => {
       if (!tooltipElRef.current || !triggerRef.current) return
       /*
        * ACCESSIBILITY CHECKS

--- a/packages/react/src/Tooltip/Tooltip.tsx
+++ b/packages/react/src/Tooltip/Tooltip.tsx
@@ -72,19 +72,29 @@ export const Tooltip = React.forwardRef(
     const child = Children.only(children)
     const triggerRef = useProvidedRefOrCreate(forwardedRef as React.RefObject<HTMLElement>)
     const tooltipElRef = useRef<HTMLDivElement>(null)
+    // Used to delay the closing of the tooltip to make sure the user can move the mouse from the trigger to the tooltip
+    const closeTooltipTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+    const tooltipCloseTimeout = 200
 
     const [calculatedDirection, setCalculatedDirection] = useState<TooltipDirection>(direction)
 
     const openTooltip = React.useCallback(() => {
+      if (closeTooltipTimeoutRef.current) {
+        clearTimeout(closeTooltipTimeoutRef.current)
+        closeTooltipTimeoutRef.current = null
+      }
+
       if (tooltipElRef.current && triggerRef.current && !tooltipElRef.current.matches(':popover-open')) {
         tooltipElRef.current.showPopover()
       }
     }, [tooltipElRef, triggerRef])
 
     const closeTooltip = React.useCallback(() => {
-      if (tooltipElRef.current && triggerRef.current && tooltipElRef.current.matches(':popover-open')) {
-        tooltipElRef.current.hidePopover()
-      }
+      closeTooltipTimeoutRef.current = setTimeout(() => {
+        if (tooltipElRef.current && triggerRef.current && tooltipElRef.current.matches(':popover-open')) {
+          tooltipElRef.current.hidePopover()
+        }
+      }, tooltipCloseTimeout)
     }, [tooltipElRef, triggerRef])
 
     useEffect(() => {


### PR DESCRIPTION
## Summary

Adds a small (200ms) delay to the closing of the Tooltip.

This is to allow users to more easily move their cursor over to the contents of the tooltip.


## What should reviewers focus on?

- Make sure you're happy with the timeout. I had a play around with it and 200ms felt like a good balance.

## Steps to test:

1. Look at the Tooltip stories
1. Mouse over the trigger
1. Move the mouse to the contents of the Tooltip
1. Note that the tooltip doesn't close as soon as the mouse leaves

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/3803

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

