### PR TITLE
Upgrade actions/cache workflow dependencies to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 18
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/figma_connect_publish.yml
+++ b/.github/workflows/figma_connect_publish.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 20
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/integration_test_astro.yml
+++ b/.github/workflows/integration_test_astro.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 18
 
       - name: Caching dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -39,7 +39,7 @@ jobs:
       # workflow successfully finishes.
       # See https://github.com/actions/cache
       - name: Cache Cypress binary
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/integration_test_cra.yml
+++ b/.github/workflows/integration_test_cra.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 18
 
       - name: Caching dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -39,7 +39,7 @@ jobs:
       # workflow successfully finishes.
       # See https://github.com/actions/cache
       - name: Cache Cypress binary
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/integration_test_nextjs.yml
+++ b/.github/workflows/integration_test_nextjs.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 18
 
       - name: Caching dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -39,7 +39,7 @@ jobs:
       # workflow successfully finishes.
       # See https://github.com/actions/cache
       - name: Cache Cypress binary
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-cypress-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/integration_test_remix.yml
+++ b/.github/workflows/integration_test_remix.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: '20'
 
       - name: Caching dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/ui_test_accessibility.yml
+++ b/.github/workflows/ui_test_accessibility.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 18
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/ui_test_primitives_diff.yml
+++ b/.github/workflows/ui_test_primitives_diff.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 18
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/update_visual_snapshots.yml
+++ b/.github/workflows/update_visual_snapshots.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 18
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/visual_test_storybook.yml
+++ b/.github/workflows/visual_test_storybook.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 18
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Upgrades our `actions/cache` workflow dependencies ahead of their [upcoming deprecation](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/)
