### PR TITLE
Fixed delayed appearance of heading separator in SubNav

### DIFF
--- a/.changeset/long-nails-rest.md
+++ b/.changeset/long-nails-rest.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed delayed appearance of heading separator in `SubNav`.

--- a/packages/react/src/SubNav/SubNav.module.css
+++ b/packages/react/src/SubNav/SubNav.module.css
@@ -278,6 +278,10 @@
     z-index: 9998;
   }
 
+  .SubNav__heading-separator:not(.SubNav__heading-separator--has-adjacent-label) {
+    display: none;
+  }
+
   .SubNav__links-overlay {
     position: relative;
     display: flex;

--- a/packages/react/src/SubNav/SubNav.module.css.d.ts
+++ b/packages/react/src/SubNav/SubNav.module.css.d.ts
@@ -24,6 +24,7 @@ declare const styles: {
   readonly "SubNav--open": string;
   readonly "fade-in": string;
   readonly "SubNav__header-container": string;
+  readonly "SubNav__heading-separator--has-adjacent-label": string;
   readonly "SubNav__links-overlay--open": string;
   readonly "SubNav__link--has-sub-menu": string;
   readonly "SubNav__overlay-toggle": string;

--- a/packages/react/src/SubNav/SubNav.tsx
+++ b/packages/react/src/SubNav/SubNav.tsx
@@ -239,28 +239,32 @@ const _SubNavRoot = memo(({id, children, className, 'data-testid': testId, fullW
           <div ref={rootRef} className={styles['SubNav--header-container-outer']}>
             <div className={styles['SubNav__header-container']}>
               {HeadingChild && <div className={styles['SubNav__heading-container']}>{HeadingChild}</div>}
-              {(activeLinklabel || isLarge) && (
-                <span role="separator" className={styles['SubNav__heading-separator']} aria-hidden>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="8"
-                    height="16"
-                    viewBox="0 0 8 16"
-                    fill="none"
-                    aria-hidden
-                  >
-                    <g clipPath="url(#clip0_50_1307)">
-                      <path d="M0 15.2992L5.472 0.701172H7.632L2.16 15.2992H0Z" fill="currentColor" />
-                    </g>
-                    <defs>
-                      <clipPath id="clip0_50_1307">
-                        <rect width="7.632" height="14.598" transform="translate(0 0.701172)" />
-                      </clipPath>
-                    </defs>
-                  </svg>
-                </span>
-              )}
-
+              <span
+                role="separator"
+                className={clsx(
+                  styles['SubNav__heading-separator'],
+                  activeLinklabel && styles['SubNav__heading-separator--has-adjacent-label'],
+                )}
+                aria-hidden
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="8"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  fill="none"
+                  aria-hidden
+                >
+                  <g clipPath="url(#clip0_50_1307)">
+                    <path d="M0 15.2992L5.472 0.701172H7.632L2.16 15.2992H0Z" fill="currentColor" />
+                  </g>
+                  <defs>
+                    <clipPath id="clip0_50_1307">
+                      <rect width="7.632" height="14.598" transform="translate(0 0.701172)" />
+                    </clipPath>
+                  </defs>
+                </svg>
+              </span>
               {!isLarge && (
                 <button
                   className={clsx(


### PR DESCRIPTION
## Summary

Follow up to #824 

The heading separator in SubNav now uses CSS to handle visibility instead of JS. This fixes the delayed loading issue observed in dotcom, which doesn't happen in Storybook.

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Removed the conditional JS-based logic for making the separator appear
- Added new CSS class to hide the separator when active labels aren't needed. This replicates the same behaviour that was previously applied in JS.

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">



https://github.com/user-attachments/assets/053bc728-694a-459c-abc9-cc60d39e25fc


 </td>
<td valign="top">

https://github.com/user-attachments/assets/8838ae55-7dbd-4c35-a6ad-bcdc260b12ab


<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
