### PR TITLE
Fix remix integration test

### DIFF
--- a/.github/workflows/integration_test_remix.yml
+++ b/.github/workflows/integration_test_remix.yml
@@ -19,7 +19,7 @@ jobs:
       labels: ubuntu-latest-16-cores
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -44,7 +44,7 @@ jobs:
         run: cd ./packages/react && npm pack
 
       - name: Configuring Remix.run
-        run: npx create-remix@latest ./${{env.TEST_FOLDER}} --yes
+        run: npx create-remix@latest ./${{env.TEST_FOLDER}} --yes --debug
 
       - name: Retrieving package version
         id: package-version

--- a/.github/workflows/integration_test_remix.yml
+++ b/.github/workflows/integration_test_remix.yml
@@ -44,7 +44,7 @@ jobs:
         run: cd ./packages/react && npm pack
 
       - name: Configuring Remix.run
-        run: npx create-remix@latest ./${{env.TEST_FOLDER}} --yes --debug
+        run: npx create-remix@latest ./${{env.TEST_FOLDER}} --yes --debug --no-git-init
 
       - name: Retrieving package version
         id: package-version


### PR DESCRIPTION
## Summary

Fixes Remix integration test

For posterity, it was failing because the latest version of the CLI automatically initalized git in a sub directory and attempted to make an initial commit but without an active SSH agent this isn't possible inside a GitHub action.

Fixed by removing git initialization, which isn't necessary in an ephemeral end-to-end test.
