### PR TITLE
Add scrolling to SubNav docs example

### DIFF
--- a/apps/docs/content/components/SubNav.mdx
+++ b/apps/docs/content/components/SubNav.mdx
@@ -91,22 +91,24 @@ Submenus appear as a dropdown by default.
 ### Optional anchor-based submenu
 
 ```jsx live
-<Container sx={{position: 'relative', height: 300}}>
-  <SubNav>
-    <SubNav.Heading href="#">Features</SubNav.Heading>
-    <SubNav.Link href="#" aria-current="page">
-      Actions
-      <SubNav.SubMenu variant="anchor">
-        <SubNav.Link href="#">Actions feature one</SubNav.Link>
-        <SubNav.Link href="#">Actions feature two</SubNav.Link>
-        <SubNav.Link href="#">Actions feature three</SubNav.Link>
-        <SubNav.Link href="#">Actions feature four</SubNav.Link>
-      </SubNav.SubMenu>
-    </SubNav.Link>
-    <SubNav.Link href="#">Packages</SubNav.Link>
-    <SubNav.Link href="#">Copilot</SubNav.Link>
-    <SubNav.Link href="#">Code review</SubNav.Link>
-  </SubNav>
+<Container sx={{position: 'relative', height: 300, overflowY: 'scroll'}}>
+  <Box style={{height: 1000}}>
+    <SubNav>
+      <SubNav.Heading href="#">Features</SubNav.Heading>
+      <SubNav.Link href="#" aria-current="page">
+        Actions
+        <SubNav.SubMenu variant="anchor">
+          <SubNav.Link href="#">Actions feature one</SubNav.Link>
+          <SubNav.Link href="#">Actions feature two</SubNav.Link>
+          <SubNav.Link href="#">Actions feature three</SubNav.Link>
+          <SubNav.Link href="#">Actions feature four</SubNav.Link>
+        </SubNav.SubMenu>
+      </SubNav.Link>
+      <SubNav.Link href="#">Packages</SubNav.Link>
+      <SubNav.Link href="#">Copilot</SubNav.Link>
+      <SubNav.Link href="#">Code review</SubNav.Link>
+    </SubNav>
+  </Box>
 </Container>
 ```
 


### PR DESCRIPTION
## Summary

Adds a vertical scroll to the _anchor-based submenu_ example in the docs. Previously, the anchor-based submenu was never visible due to the lack of scroll on the example.

## Screenshots

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/f5c261b6-67ba-42cb-a4a3-e94f3aca43ba)

 </td>
<td valign="top">

![scroll](https://github.com/user-attachments/assets/c34fd5fb-266c-4306-950f-a383587ee056)

</td>
</tr>
</table>
