### PR TITLE
Fix typo in RadioGroup docs

### DIFF
--- a/apps/docs/content/components/RadioGroup/react.mdx
+++ b/apps/docs/content/components/RadioGroup/react.mdx
@@ -106,9 +106,9 @@ When space is limited, radio inputs can be arranged horizontally using the [Stac
 ```jsx live
 <RadioGroup>
   <RadioGroup.Label visuallyHidden>Time period</RadioGroup.Label>
-  <CheckboxGroup.Caption>
+  <RadioGroup.Caption>
     Some inline radio inputs with a visually hidden label
-  </CheckboxGroup.Caption>
+  </RadioGroup.Caption>
   <Stack direction="horizontal" gap="normal" padding="none">
     <FormControl>
       <FormControl.Label>Last 7 days</FormControl.Label>


### PR DESCRIPTION
## Summary

Fixes a typo in one of the radio group docs examples.


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

N/A see diffs