### PR TITLE
Allow inline ControlGroup examples to reflow

### DIFF
--- a/apps/docs/content/components/CheckboxGroup/react.mdx
+++ b/apps/docs/content/components/CheckboxGroup/react.mdx
@@ -133,7 +133,13 @@ When space is limited, checkboxes can be arranged horizontally using the [Stack]
   <CheckboxGroup.Caption>
     Some inline checkboxes with a visually hidden label
   </CheckboxGroup.Caption>
-  <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
+  <Stack
+    direction="horizontal"
+    gap="normal"
+    padding="none"
+    flexWrap="wrap"
+    style={{rowGap: 'var(--base-size-8)'}}
+  >
     <FormControl>
       <FormControl.Label>Choice one</FormControl.Label>
       <Checkbox value="one" />

--- a/apps/docs/content/components/CheckboxGroup/react.mdx
+++ b/apps/docs/content/components/CheckboxGroup/react.mdx
@@ -133,7 +133,7 @@ When space is limited, checkboxes can be arranged horizontally using the [Stack]
   <CheckboxGroup.Caption>
     Some inline checkboxes with a visually hidden label
   </CheckboxGroup.Caption>
-  <Stack direction="horizontal" gap="normal" padding="none">
+  <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
     <FormControl>
       <FormControl.Label>Choice one</FormControl.Label>
       <Checkbox value="one" />

--- a/apps/docs/content/components/CheckboxGroup/react.mdx
+++ b/apps/docs/content/components/CheckboxGroup/react.mdx
@@ -133,13 +133,7 @@ When space is limited, checkboxes can be arranged horizontally using the [Stack]
   <CheckboxGroup.Caption>
     Some inline checkboxes with a visually hidden label
   </CheckboxGroup.Caption>
-  <Stack
-    direction="horizontal"
-    gap="normal"
-    padding="none"
-    flexWrap="wrap"
-    style={{rowGap: 'var(--base-size-8)'}}
-  >
+  <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
     <FormControl>
       <FormControl.Label>Choice one</FormControl.Label>
       <Checkbox value="one" />

--- a/apps/docs/content/components/RadioGroup/react.mdx
+++ b/apps/docs/content/components/RadioGroup/react.mdx
@@ -109,7 +109,13 @@ When space is limited, radio inputs can be arranged horizontally using the [Stac
   <CheckboxGroup.Caption>
     Some inline radio inputs with a visually hidden label
   </CheckboxGroup.Caption>
-  <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
+  <Stack
+    direction="horizontal"
+    gap="normal"
+    padding="none"
+    flexWrap="wrap"
+    style={{rowGap: 'var(--base-size-8)'}}
+  >
     <FormControl>
       <FormControl.Label>Last 7 days</FormControl.Label>
       <Radio name="period" value="week" />

--- a/apps/docs/content/components/RadioGroup/react.mdx
+++ b/apps/docs/content/components/RadioGroup/react.mdx
@@ -109,7 +109,7 @@ When space is limited, radio inputs can be arranged horizontally using the [Stac
   <CheckboxGroup.Caption>
     Some inline radio inputs with a visually hidden label
   </CheckboxGroup.Caption>
-  <Stack direction="horizontal" gap="normal" padding="none">
+  <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
     <FormControl>
       <FormControl.Label>Last 7 days</FormControl.Label>
       <Radio name="period" value="week" />

--- a/apps/docs/content/components/RadioGroup/react.mdx
+++ b/apps/docs/content/components/RadioGroup/react.mdx
@@ -109,13 +109,7 @@ When space is limited, radio inputs can be arranged horizontally using the [Stac
   <CheckboxGroup.Caption>
     Some inline radio inputs with a visually hidden label
   </CheckboxGroup.Caption>
-  <Stack
-    direction="horizontal"
-    gap="normal"
-    padding="none"
-    flexWrap="wrap"
-    style={{rowGap: 'var(--base-size-8)'}}
-  >
+  <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
     <FormControl>
       <FormControl.Label>Last 7 days</FormControl.Label>
       <Radio name="period" value="week" />

--- a/packages/react/src/forms/CheckboxGroup/CheckboxGroup.examples.stories.tsx
+++ b/packages/react/src/forms/CheckboxGroup/CheckboxGroup.examples.stories.tsx
@@ -23,7 +23,13 @@ export const Inline: Story = {
         <CheckboxGroup.Label visuallyHidden={labelVisuallyHidden}>{labelChildren}</CheckboxGroup.Label>
         {captionChildren ? <CheckboxGroup.Caption>{captionChildren}</CheckboxGroup.Caption> : null}
 
-        <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
+        <Stack
+          direction="horizontal"
+          gap="normal"
+          padding="none"
+          flexWrap="wrap"
+          style={{rowGap: 'var(--base-size-8)'}}
+        >
           <FormControl>
             <FormControl.Label>Choice one</FormControl.Label>
             <Checkbox value="one" defaultChecked />

--- a/packages/react/src/forms/CheckboxGroup/CheckboxGroup.examples.stories.tsx
+++ b/packages/react/src/forms/CheckboxGroup/CheckboxGroup.examples.stories.tsx
@@ -23,7 +23,7 @@ export const Inline: Story = {
         <CheckboxGroup.Label visuallyHidden={labelVisuallyHidden}>{labelChildren}</CheckboxGroup.Label>
         {captionChildren ? <CheckboxGroup.Caption>{captionChildren}</CheckboxGroup.Caption> : null}
 
-        <Stack direction="horizontal" gap="normal" padding="none">
+        <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
           <FormControl>
             <FormControl.Label>Choice one</FormControl.Label>
             <Checkbox value="one" defaultChecked />

--- a/packages/react/src/forms/CheckboxGroup/CheckboxGroup.examples.stories.tsx
+++ b/packages/react/src/forms/CheckboxGroup/CheckboxGroup.examples.stories.tsx
@@ -23,13 +23,7 @@ export const Inline: Story = {
         <CheckboxGroup.Label visuallyHidden={labelVisuallyHidden}>{labelChildren}</CheckboxGroup.Label>
         {captionChildren ? <CheckboxGroup.Caption>{captionChildren}</CheckboxGroup.Caption> : null}
 
-        <Stack
-          direction="horizontal"
-          gap="normal"
-          padding="none"
-          flexWrap="wrap"
-          style={{rowGap: 'var(--base-size-8)'}}
-        >
+        <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
           <FormControl>
             <FormControl.Label>Choice one</FormControl.Label>
             <Checkbox value="one" defaultChecked />

--- a/packages/react/src/forms/RadioGroup/RadioGroup.examples.stories.tsx
+++ b/packages/react/src/forms/RadioGroup/RadioGroup.examples.stories.tsx
@@ -23,7 +23,13 @@ export const Inline: Story = {
         <RadioGroup.Label visuallyHidden={labelVisuallyHidden}>{labelChildren}</RadioGroup.Label>
         {captionChildren ? <RadioGroup.Caption>{captionChildren}</RadioGroup.Caption> : null}
 
-        <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
+        <Stack
+          direction="horizontal"
+          gap="normal"
+          padding="none"
+          flexWrap="wrap"
+          style={{rowGap: 'var(--base-size-8)'}}
+        >
           <FormControl>
             <FormControl.Label>0-99</FormControl.Label>
             <Radio name="demo" value="one" />

--- a/packages/react/src/forms/RadioGroup/RadioGroup.examples.stories.tsx
+++ b/packages/react/src/forms/RadioGroup/RadioGroup.examples.stories.tsx
@@ -23,13 +23,7 @@ export const Inline: Story = {
         <RadioGroup.Label visuallyHidden={labelVisuallyHidden}>{labelChildren}</RadioGroup.Label>
         {captionChildren ? <RadioGroup.Caption>{captionChildren}</RadioGroup.Caption> : null}
 
-        <Stack
-          direction="horizontal"
-          gap="normal"
-          padding="none"
-          flexWrap="wrap"
-          style={{rowGap: 'var(--base-size-8)'}}
-        >
+        <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
           <FormControl>
             <FormControl.Label>0-99</FormControl.Label>
             <Radio name="demo" value="one" />

--- a/packages/react/src/forms/RadioGroup/RadioGroup.examples.stories.tsx
+++ b/packages/react/src/forms/RadioGroup/RadioGroup.examples.stories.tsx
@@ -23,7 +23,7 @@ export const Inline: Story = {
         <RadioGroup.Label visuallyHidden={labelVisuallyHidden}>{labelChildren}</RadioGroup.Label>
         {captionChildren ? <RadioGroup.Caption>{captionChildren}</RadioGroup.Caption> : null}
 
-        <Stack direction="horizontal" gap="normal" padding="none">
+        <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
           <FormControl>
             <FormControl.Label>0-99</FormControl.Label>
             <Radio name="demo" value="one" />


### PR DESCRIPTION
## Summary

Updates the inline `CheckboxGroup` and `RadioGroup` examples to reflow on narrow viewports.

There's quite a large row gap between lines. This could be solved by adding `style={{ rowGap: 'var(--base-size-8)' }}` to the `Stack` used in the example. Let me know if that would be preferred.

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/4672
- Closes https://github.com/github/primer/issues/4673

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/55513135-b9fc-4c34-ba0e-d2c7a4a6966a)


 </td>
<td valign="top">

![image](https://github.com/user-attachments/assets/e4b9f01e-92b0-4805-9c00-260f834d9303)


</td>
</tr>
</table>

Having to add an inline style to the example isn't ideal, but without it the rowGap is way too big

![image](https://github.com/user-attachments/assets/2d1844e9-75ec-46b0-b5f8-a74c26aaf270)
