### PR TITLE
Add a static scroll-margin-top to a footnote item

### DIFF
--- a/.changeset/strange-cooks-crash.md
+++ b/.changeset/strange-cooks-crash.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Added a scroll margin to `Footnote.Item` to prevent it from being hidden behind fixed navigation during automatic scrolling.

--- a/packages/react/src/Footnotes/Footnotes.module.css
+++ b/packages/react/src/Footnotes/Footnotes.module.css
@@ -21,7 +21,7 @@
 }
 
 .FootnotesItem {
-  scroll-margin-top: 100px;
+  scroll-margin-top: 80px;
 }
 
 .FootnotesItem__citationIcon {

--- a/packages/react/src/Footnotes/Footnotes.module.css
+++ b/packages/react/src/Footnotes/Footnotes.module.css
@@ -20,6 +20,10 @@
   padding-inline-start: var(--base-size-12);
 }
 
+.FootnotesItem {
+  scroll-margin-top: 100px;
+}
+
 .FootnotesItem__citationIcon {
   transform: scaleY(-1);
   margin-inline-start: var(--base-size-4);


### PR DESCRIPTION
## Summary

Added a static `scroll-margin-top` to `Footnote.Item`. This allows a small (100px) amount of space to be present between the top of the viewport and the `Footnote.Item` when it is navigated to.


## What should reviewers focus on?

- Are you happy with the change, and the 100px value?

## Steps to test:

1. Open [the "return links" example in the Footnotes docs](https://primer-29177d11bf-26139705.drafts.github.io/brand/components/Footnotes/react#citations-with-return-links)
1. Click the number _[1]_
1. Observe that the associated footnote is scrolled to with an offset of 100px

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/4669

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:


https://github.com/user-attachments/assets/1b76eb42-4453-42af-bf97-cbf36845b830


