### PR TITLE
ActionMenu falsy value bugfix

### DIFF
--- a/.changeset/kind-years-repair.md
+++ b/.changeset/kind-years-repair.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed a bug in the `ActionMenu` component where items with falsy values (eg `""`) would not trigger the `onSelect` callback when selected.

--- a/packages/react/src/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.test.tsx
@@ -349,4 +349,23 @@ describe('ActionMenu', () => {
       {timeout: 100},
     )
   })
+
+  it('should allow falsey items to be selected', () => {
+    const mockOnSelect = jest.fn()
+
+    const {getByRole} = render(
+      <ActionMenu onSelect={mockOnSelect} selectionVariant="single">
+        <ActionMenu.Button>Open menu</ActionMenu.Button>
+        <ActionMenu.Overlay aria-label="Actions">
+          <ActionMenu.Item value="test">Test string</ActionMenu.Item>
+          <ActionMenu.Item value="">Empty string</ActionMenu.Item>
+        </ActionMenu.Overlay>
+      </ActionMenu>,
+    )
+
+    fireEvent.click(getByRole('button', {name: 'Open menu'}))
+    fireEvent.click(getByRole('menuitemradio', {name: 'Empty string'}))
+
+    expect(mockOnSelect).toHaveBeenCalledWith('')
+  })
 })

--- a/packages/react/src/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.tsx
@@ -166,11 +166,9 @@ const _ActionMenuRoot = memo(
 
     const handleItemSelection = useCallback(
       (newValue: string) => {
-        if (newValue) {
-          handleOnSelect(newValue)
-          toggleMenu()
-          anchorElementRef.current?.focus()
-        }
+        handleOnSelect(newValue)
+        toggleMenu()
+        anchorElementRef.current?.focus()
       },
       [handleOnSelect, toggleMenu, anchorElementRef],
     )


### PR DESCRIPTION
## Summary

Removes check for truthiness in `handleItemSelection` in `ActionMenu.tsx` to allow falsy values to trigger item selection callback.

## List of notable changes:

- `ActionMenu.tsx`: Removed check for truthiness in `handleItemSelection` to allow falsy values to trigger item selection callback.
- `ActionMenu.test.tsx`: Added a test to assert that falsy items can be selected

## Steps to test:

1. Open [the ActionMenu Docs](https://primer-f49b2ea768-26139705.drafts.github.io/brand/components/ActionMenu)
2. Edit the first example to set one of the values to `""`
3. Open the ActionMenu and click on the item associated with that value
4. Observe that the `onSelect` callback is called and triggers an alert.


## Supporting resources (related issues, external links, etc):

- 🔗 [Link to docs](https://primer-f49b2ea768-26139705.drafts.github.io/brand/components/ActionMenu)
- Closes #906 

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
