### PR TITLE
Remove the hover text-decoration transition in `InlineLink`

### DIFF
--- a/packages/react/src/InlineLink/InlineLink.module.css
+++ b/packages/react/src/InlineLink/InlineLink.module.css
@@ -4,7 +4,6 @@
   text-decoration-color: var(--brand-InlineLink-color-rest);
   text-decoration-thickness: var(--brand-borderWidth-thin);
   text-underline-position: under;
-  transition: var(--brand-InlineLink-transition-timing) text-decoration;
 }
 
 .InlineLink:hover {


### PR DESCRIPTION
## Summary

We can't animate the text-decoration-thickness, we can animate a border, but since this is 1px transition, transitioning it is practically useless. Tested it on dotcom.

<!--
A few sentences describing the changes being proposed in this pull request.
-->

## List of notable changes:

- **removed* `transition: var(--brand-InlineLink-transition-timing) text-decoration;` from `InlineLink` styles.

## What should reviewers focus on?

- Hover effect on `InlineLink`

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1.
1.
1.

## Supporting resources (related issues, external links, etc):

- https://github.com/github/github/pull/359872
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
