### PR TITLE
Fix failing prod deployment

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -26,8 +26,8 @@ jobs:
   build_deploy:
     if: ${{ github.repository == 'primer/brand' }}
     name: Production
-    # SHA for security hardening. Points at last verified HEAD of main branch.
-    uses: primer/.github/.github/workflows/deploy.yml@rezrah/fix-prod-deployment
+    # SHA for security hardening. Points at 2.1.1 release
+    uses: primer/.github/.github/workflows/deploy.yml@2a60f4cc62889bd218f3019ce4a090ff89b71cca
     with:
       node_version: 18
       install: npm ci --legacy-peer-deps && cd apps/docs && npm ci --legacy-peer-deps && cd ..

--- a/.github/workflows/deploy_docs_preview.yml
+++ b/.github/workflows/deploy_docs_preview.yml
@@ -14,8 +14,8 @@ jobs:
   deploy:
     if: ${{ github.repository == 'primer/brand' }}
     name: Preview
-    # SHA for security hardening. Points at last verified HEAD of main branch.
-    uses: primer/.github/.github/workflows/deploy_preview.yml@cd223835608ca5e9401e0ffe6081f6d2fcc912f3
+    # SHA for security hardening. Points at 2.1.1 release
+    uses: primer/.github/.github/workflows/deploy_preview.yml@2a60f4cc62889bd218f3019ce4a090ff89b71cca
     with:
       node_version: 18
       install: npm ci --legacy-peer-deps && cd apps/docs && npm ci --legacy-peer-deps && cd ..

--- a/.github/workflows/deploy_docs_preview_forks.yml
+++ b/.github/workflows/deploy_docs_preview_forks.yml
@@ -14,8 +14,8 @@ jobs:
   deploy:
     if: ${{ github.repository != github.event.pull_request.head.repo.full_name }}
     name: Preview
-    # SHA for security hardening. Points at last verified HEAD of main branch.
-    uses: primer/.github/.github/workflows/deploy_preview.yml@cd223835608ca5e9401e0ffe6081f6d2fcc912f3
+    # SHA for security hardening. Points at 2.1.1 release
+    uses: primer/.github/.github/workflows/deploy_preview.yml@2a60f4cc62889bd218f3019ce4a090ff89b71cca
     with:
       node_version: 18
       install: npm ci --legacy-peer-deps && cd apps/docs && npm ci --legacy-peer-deps && cd ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ jobs:
   release:
     if: github.ref_name == 'main'
     name: Release
-    uses: primer/.github/.github/workflows/release.yml@v1.0.0
+
+    uses: primer/.github/.github/workflows/release.yml@2a60f4cc62889bd218f3019ce4a090ff89b71cca # SHA for security hardening. Points at v2.1.1 release
     secrets:
       gh_token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
       npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
@@ -18,7 +19,7 @@ jobs:
   release-next-minor:
     if: github.ref_name == 'next-minor'
     name: Next minor
-    uses: primer/.github/.github/workflows/release.yml@v1.0.0
+    uses: primer/.github/.github/workflows/release.yml@2a60f4cc62889bd218f3019ce4a090ff89b71cca # SHA for security hardening. Points at v2.1.1 release
     with:
       title: Release tracking (next minor)
     secrets:


### PR DESCRIPTION
## Summary

Fixes failing prod deployment by updating our reusable workflow versions. We were using an old version that relied on a now deprecated dependency [actions/upload-artifact@v3](https://github.com/actions/upload-artifact)

Edit: also fixes preview deployments, which began failing for the same reasons
