### PR TITLE
Docs accessibility fixes

### DIFF
--- a/apps/docs/content/components/Card/react.mdx
+++ b/apps/docs/content/components/Card/react.mdx
@@ -149,29 +149,20 @@ The color of the lit area corrosponds to the nearest active, primary accent colo
 ```jsx live
 <ThemeProvider colorMode="dark">
   <Box backgroundColor="default" padding="condensed">
-    <Stack direction="vertical" padding="none">
-      <Card href="https://github.com">
-        <Card.Icon icon={CopilotIcon} color="pink" hasBackground />
-        <Card.Heading>Code search & code view</Card.Heading>
-        <Card.Description>
-          Enables you to rapidly search, navigate, and understand code, right
-          from GitHub.com.
-        </Card.Description>
-      </Card>
-      <Card
-        href="https://github.com"
-        style={{
-          ['--brand-color-accent-primary']: 'var(--base-color-scale-lime-2)',
-        }}
-      >
-        <Card.Icon icon={ZapIcon} color="lime" hasBackground />
-        <Card.Heading>Code search & code view</Card.Heading>
-        <Card.Description>
-          Enables you to rapidly search, navigate, and understand code, right
-          from GitHub.com.
-        </Card.Description>
-      </Card>
-    </Stack>
+    <Card
+      href="https://github.com"
+      fullWidth
+      style={{
+        ['--brand-color-accent-primary']: 'var(--base-color-scale-lime-2)',
+      }}
+    >
+      <Card.Icon icon={ZapIcon} color="lime" hasBackground />
+      <Card.Heading>Code search & code view</Card.Heading>
+      <Card.Description>
+        Enables you to rapidly search, navigate, and understand code, right from
+        GitHub.com.
+      </Card.Description>
+    </Card>
   </Box>
 </ThemeProvider>
 ```

--- a/apps/docs/content/components/Card/react.mdx
+++ b/apps/docs/content/components/Card/react.mdx
@@ -148,8 +148,8 @@ The color of the lit area corrosponds to the nearest active, primary accent colo
 
 ```jsx live
 <ThemeProvider colorMode="dark">
-  <Box padding="spacious" backgroundColor="default">
-    <Stack direction="horizontal" padding="none">
+  <Box backgroundColor="default" padding="condensed">
+    <Stack direction="vertical" padding="none">
       <Card href="https://github.com">
         <Card.Icon icon={CopilotIcon} color="pink" hasBackground />
         <Card.Heading>Code search & code view</Card.Heading>

--- a/apps/docs/content/components/Section/react.mdx
+++ b/apps/docs/content/components/Section/react.mdx
@@ -65,12 +65,11 @@ The default `Section` wraps its content in a semantic `<section>` element and pr
 ### With custom background color
 
 ```jsx live
-<Section backgroundColor="#FFF8F8">
+<Section backgroundColor="#2AA198">
   <SectionIntro align="center">
-    <SectionIntro.Heading size="3">Custom background</SectionIntro.Heading>
-    <SectionIntro.Description>
-      This section uses a custom background color.
-    </SectionIntro.Description>
+    <SectionIntro.Heading size="3">
+      Custom background color
+    </SectionIntro.Heading>
   </SectionIntro>
 </Section>
 ```


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

## List of notable changes:

- Updated Section example to use a background colour with sufficient contrast
- Improved styling of torchlight Card example in docs on very small (320px) viewports

## What should reviewers focus on?

- Just check you're happy with the changes

## Steps to test:

- Take a look at relevant sections in the Section docs, and the Card docs.

## Supporting resources (related issues, external links, etc):

- Towards https://github.com/github/accessibility-audits/issues/10394
- Towards https://github.com/github/accessibility-audits/issues/10368

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/97d4b575-d58a-4c37-87ab-effac1da3cfd)

 </td>
<td valign="top">

![image](https://github.com/user-attachments/assets/6b7e0849-6a5a-483b-b6ee-ba91833a3c64)

</td>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/713ddddd-ff96-4eb4-a2e9-b54098d02516)

 </td>
<td valign="top">

![image](https://github.com/user-attachments/assets/cfb40aca-d9c6-4070-9248-6a50ca0c62b8)

</td>
</tr>
</table>
