### PR TITLE
Fix iOS Safari Card component double-tap bug

### DIFF
--- a/.changeset/fluffy-dodos-perform.md
+++ b/.changeset/fluffy-dodos-perform.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed a bug where Card components would need to be tapped twice in iOS Safari to trigger navigation

--- a/packages/react/src/Card/Card.module.css
+++ b/packages/react/src/Card/Card.module.css
@@ -181,3 +181,11 @@
   right: 0;
   z-index: -1;
 }
+
+.Card:has(.Card__link:hover) .Card--expandableArrow {
+  transform: translateX(4px);
+}
+
+.Card:has(.Card__link:hover) .Card--expandableArrow path:nth-of-type(2) {
+  stroke-dashoffset: 20;
+}

--- a/packages/react/src/Card/Card.module.css
+++ b/packages/react/src/Card/Card.module.css
@@ -183,7 +183,7 @@
 }
 
 .Card:has(.Card__link:hover) .Card--expandableArrow {
-  transform: translateX(4px);
+  transform: translateX(var(--base-size-4));
 }
 
 .Card:has(.Card__link:hover) .Card--expandableArrow path:nth-of-type(2) {

--- a/packages/react/src/Card/Card.module.css.d.ts
+++ b/packages/react/src/Card/Card.module.css.d.ts
@@ -4,6 +4,7 @@ declare const styles: {
   readonly "Card--colorMode-dark": string;
   readonly "Card--colorMode-light": string;
   readonly "Card--disableAnimation": string;
+  readonly "Card--expandableArrow": string;
   readonly "Card--fullWidth": string;
   readonly "Card--icon": string;
   readonly "Card--maxWidth": string;

--- a/packages/react/src/Card/Card.tsx
+++ b/packages/react/src/Card/Card.tsx
@@ -1,4 +1,4 @@
-import React, {RefObject, forwardRef, useCallback} from 'react'
+import React, {RefObject, forwardRef} from 'react'
 import {isFragment} from 'react-is'
 import clsx from 'clsx'
 import {Heading, HeadingProps, Text, useTheme, CardSkewEffect, Image, type ImageProps, Label, LabelColors} from '..'
@@ -81,23 +81,6 @@ const CardRoot = forwardRef<HTMLDivElement, CardProps>(
   ) => {
     const cardRef = useProvidedRefOrCreate(ref as RefObject<HTMLDivElement>)
     const {colorMode} = useTheme()
-    const [isActive, setIsActive] = React.useState(false)
-
-    const handleActiveCard = useCallback(
-      (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-        setIsActive(true)
-        onMouseEnter?.(event)
-      },
-      [onMouseEnter, setIsActive],
-    )
-
-    const handleInactiveCard = useCallback(
-      (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-        setIsActive(false)
-        onMouseLeave?.(event)
-      },
-      [onMouseLeave, setIsActive],
-    )
 
     const filteredChildren = React.Children.toArray(children).filter(child => {
       if (React.isValidElement(child) && typeof child.type !== 'string') {
@@ -148,8 +131,6 @@ const CardRoot = forwardRef<HTMLDivElement, CardProps>(
           {React.Children.map(filteredChildren, child => {
             if (React.isValidElement(child) && typeof child.type !== 'string' && child.type === CardHeading) {
               return React.cloneElement<CardHeadingProps>(child as React.ReactElement<CardHeadingProps>, {
-                onMouseEnter: handleActiveCard,
-                onMouseLeave: handleInactiveCard,
                 href,
               })
             }
@@ -159,7 +140,10 @@ const CardRoot = forwardRef<HTMLDivElement, CardProps>(
             <Text as="span" size="200" className={clsx(stylesLink['Link--label'])}>
               {ctaText}
             </Text>
-            <ExpandableArrow className={stylesLink['Link-arrow']} expanded={isActive} aria-hidden="true" />
+            <ExpandableArrow
+              className={clsx(stylesLink['Link-arrow'], styles['Card--expandableArrow'])}
+              aria-hidden="true"
+            />
           </div>
         </div>
       </WrapperComponent>


### PR DESCRIPTION
## Summary

Fixes a bug where Card components would need to be tapped twice in iOS Safari to trigger navigation. The first click would, if fast enough, only trigger the hover state. The second click would then perform the navigation.

## List of notable changes:

- Remove mouseenter/exit event listeners from Card component
- Use CSS to trigger the arrow expansion on hover

## What should reviewers focus on?

- Test in iOS Safari — make sure that you can navigate to the associated `href` with a single click on the Card component

## Steps to test:

1. Open the Docs or Storybook on iOS Safari
2. Navigate to a Card component
3. Quickly tap the Card
4. Ensure that you are navigated to the page with only a single tap

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/primer/brand/issues/933

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
