### PR TITLE
update cta banner doc to use correct default

### DIFF
--- a/apps/docs/content/components/CTABanner/react.mdx
+++ b/apps/docs/content/components/CTABanner/react.mdx
@@ -236,7 +236,7 @@ render(<App />)
 | ---------- | ---------------------------------------------- | ----------- | -------- | ---------------------------------------------------------------- |
 | `children` | `ReactNode`, `ReactNode[]`                     | `undefined` | `true`   | Content to be displayed inside the `CTABanner.Heading` component |
 | `as`       | `'h1'`, `'h2'`, `'h3'`, `'h4'`, `'h5'`, `'h6'` | `'h3'`      | `false`  | Heading level                                                    |
-| `size`     | `'1'`, `'2'`, `'3'`, `'4'`, `'5'`, `'6'`       | `'2'`       | `false`  | Visual heading size, irrespective of level                       |
+| `size`     | `'1'`, `'2'`, `'3'`, `'4'`, `'5'`, `'6'`       | `'1'`       | `false`  | Visual heading size, irrespective of level                       |
 
 ### CTABanner.Description
 


### PR DESCRIPTION
## Summary

This patch updates the docs of the CTA banner to accurately reflect current defaults in the code. 

## List of notable changes:

- **updated** documentation for CTA Banner because it did not accurately reflect a default value.

## What should reviewers focus on?

N/A

## Steps to test:

N/A 

## Supporting resources (related issues, external links, etc):

N/A

## Contributor checklist:

- [x] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description


## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

N/A
