### PR TITLE
Update SectionIntro documentation typo for label

### DIFF
--- a/apps/docs/content/components/SectionIntro/react.mdx
+++ b/apps/docs/content/components/SectionIntro/react.mdx
@@ -74,7 +74,7 @@ The content alignment can be changed using the `align` prop on the root `Section
 | `className` | `string`                   |             | `false`  | SectionIntro custom class                                     |
 | `fullWidth` | `boolean`                  |             | `false`  | Fills available space                                         |
 
-### Hero.Label
+### SectionIntro.Label
 
 | name        | type              | default | description                                  |
 | ----------- | ----------------- | ------- | -------------------------------------------- |


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

This updates `Hero.Label` to `SectionIntro.Label`.