### PR TITLE
Update release template URLs

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -17,14 +17,11 @@ Please ensure these items are checked before merging.
   - [ ] Run development server
   - [ ] Manually verify release-specific bugfixes and/or features on the following pages:
     - `/features/copilot`
-    - `/features/copilot/getting-started`
+    - `/features/copilot/tutorials`
     - `/features/preview`
     - `/enterprise`
-    - `/enterprise/advanced-security`
     - `/enterprise/contact`
-    - `/articles/security`
-    - `/articles/security/what-is-security-testing`
-    - `/solutions/devops`
+    - `/security/advanced-security`
     - `/education`
     - `/mobile`
     - `/about/diversity`


### PR DESCRIPTION
## Summary

Update release template URLs

## List of notable changes:

- Replace `/features/copilot/getting-started` with `/features/copilot/tutorials` as it redirects
- Replace `/enterprise/advanced-security` with `/security/advanced-security` as it redirects
- Remove `/solutions/devops` as it redirects to `/solutions/use-case/devops`, which is already listed
- Remove duplicated (and incorrect) articles URLs.
