### PR TITLE
Add grid overlay control to Storybook

### DIFF
--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -11,7 +11,7 @@ export const globalTypes = {
     description: 'Color mode (light, dark, auto, all)',
     defaultValue: 'light',
     toolbar: {
-      icon: 'globe',
+      icon: 'paintbrush',
       // array of colorMode items
       items: [
         {
@@ -32,6 +32,24 @@ export const globalTypes = {
         },
       ],
       title: 'Color mode',
+    },
+  },
+  showGrid: {
+    description: 'Show grid overlay',
+    defaultValue: false,
+    toolbar: {
+      title: 'Grid overlay',
+      icon: 'contrast',
+      items: [
+        {
+          value: true,
+          title: 'Show',
+        },
+        {
+          value: false,
+          title: 'Hide',
+        },
+      ],
     },
   },
 }
@@ -72,13 +90,47 @@ const ThemeProviderDecorator = (Story, context) => {
   )
 }
 
-export const decorators = [ThemeProviderDecorator]
+export const GridOverlayDecorator = (Story, context) => {
+  const showGrid = context.parameters?.showGrid || context.globals.showGrid
+
+  const grid = (
+    <div className={styles.grid}>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+      <div className={styles.column}></div>
+    </div>
+  )
+
+  return (
+    <>
+      {showGrid && grid}
+      <Story {...context} />
+    </>
+  )
+}
+
+export const decorators = [GridOverlayDecorator, ThemeProviderDecorator]
 
 export const parameters = {
   controls: {
     matchers: {
       color: /(background|color)$/i,
       date: /Date$/,
+    },
+  },
+  backgrounds: {
+    grid: {
+      // Disable Storybook's built-in grid as it doesn't conform to our grid
+      disable: true,
     },
   },
   viewport: {

--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import clsx from 'clsx'
 import {ThemeProvider} from '../../../packages/react/src'
 import styles from './preview.module.css'
 import '../../../packages/react/src/css/stylesheets'
@@ -34,20 +35,32 @@ export const globalTypes = {
       title: 'Color mode',
     },
   },
-  showGrid: {
+  gridOverlay: {
     description: 'Show grid overlay',
-    defaultValue: false,
+    defaultValue: 'off',
     toolbar: {
       title: 'Grid overlay',
       icon: 'contrast',
       items: [
         {
-          value: true,
-          title: 'Show',
+          value: 'off',
+          title: 'Off',
         },
         {
-          value: false,
-          title: 'Hide',
+          value: 'limited-width',
+          title: 'Limited width',
+        },
+        {
+          value: 'limited-width-no-padding',
+          title: 'Limited width (no padding)',
+        },
+        {
+          value: 'full-width',
+          title: 'Full width',
+        },
+        {
+          value: 'full-width-no-padding',
+          title: 'Full width (no padding)',
         },
       ],
     },
@@ -91,10 +104,22 @@ const ThemeProviderDecorator = (Story, context) => {
 }
 
 export const GridOverlayDecorator = (Story, context) => {
-  const showGrid = context.parameters?.showGrid || context.globals.showGrid
+  const gridOverlay = context.parameters?.gridOverlay || context.globals.gridOverlay
+
+  if (gridOverlay === 'off') {
+    return <Story {...context} />
+  }
 
   const grid = (
-    <div className={styles.grid}>
+    <div
+      className={clsx(
+        styles.grid,
+        gridOverlay === 'limited-width' && styles['grid--limited-width'],
+        gridOverlay === 'limited-width-no-padding' && styles['grid--limited-width-no-padding'],
+        gridOverlay === 'full-width' && styles['grid--full-width'],
+        gridOverlay === 'full-width-no-padding' && styles['grid--full-width-no-padding'],
+      )}
+    >
       <div className={styles.column}></div>
       <div className={styles.column}></div>
       <div className={styles.column}></div>
@@ -112,7 +137,7 @@ export const GridOverlayDecorator = (Story, context) => {
 
   return (
     <>
-      {showGrid && grid}
+      {grid}
       <Story {...context} />
     </>
   )

--- a/apps/storybook/.storybook/preview.module.css
+++ b/apps/storybook/.storybook/preview.module.css
@@ -11,3 +11,29 @@
 body {
   background-color: var(--brand-color-canvas-default);
 }
+
+:global(#storybook-root):has(.grid) {
+  position: relative;
+  height: 100%;
+}
+
+.grid {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  grid-row-gap: var(--brand-Grid-spacing-row);
+  grid-column-gap: var(--brand-Grid-spacing-column-gap);
+  pointer-events: none;
+  width: 100%;
+  height: 100%;
+  z-index: 9999999;
+}
+
+.column {
+  background-color: var(--brand-Grid-column-bgColor-overlay);
+  mix-blend-mode: difference;
+  filter: contrast(1.5) brightness(1.2);
+  min-height: var(--base-size-24);
+}

--- a/apps/storybook/.storybook/preview.module.css
+++ b/apps/storybook/.storybook/preview.module.css
@@ -14,13 +14,13 @@ body {
 
 :global(#storybook-root):has(.grid) {
   position: relative;
-  height: 100%;
 }
 
 .grid {
   position: absolute;
   top: 0;
-  left: 0;
+  left: 50%;
+  transform: translateX(-50%);
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
   grid-row-gap: var(--brand-Grid-spacing-row);
@@ -29,6 +29,25 @@ body {
   width: 100%;
   height: 100%;
   z-index: 9999999;
+  padding-inline: var(--brand-Grid-spacing-margin);
+}
+
+.grid--limited-width {
+  max-width: 1280px;
+}
+
+.grid--limited-width-no-padding {
+  max-width: 1280px;
+  padding-inline: 0;
+}
+
+.grid--full-width {
+  max-width: 100%;
+}
+
+.grid--full-width-no-padding {
+  max-width: 100%;
+  padding-inline: 0;
 }
 
 .column {


### PR DESCRIPTION
## Summary

Adds a grid overlay control to the Storybook preview.

When building the RiverAccordion I needed an easy way to check that it conformed to our standard Grid, so I added this control.

The control supports multiple grid options to allow it to be used across all of our stories.

## List of notable changes:

- Adds a grid overlay control to Storybook, which supports 5 modes
  - Off
  - Limited width — limits the grid to 1280px to match our standard Grid
  - Full width — allows the grid to expand to the full width of the viewport, similar to passing `fullWidth` to `Grid`
  - Limited width (no padding) — limits the grid to 1280px without padding
  - Full width (no padding) — allows the grid to expand to the full width of the viewport without padding
- Changes the icon for the colour mode control; a paint brush felt more appropriate

## What should reviewers focus on?

- Are you happy with this addition?

## Steps to test:

1. Open 🔗 [Storybook](https://primer-1da8e37a14-26139705.drafts.github.io/brand/storybook/?path=/story/recipes-solutions-solution-use-case--maximum&globals=gridOverlay:limited-width)
1. Click the _Grid overlay_ control
  ![image](https://github.com/user-attachments/assets/cd3b1b0e-6a67-4c1d-bdb3-44e86b768592)


## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Example screenshots

![image](https://github.com/user-attachments/assets/4bf42218-34eb-4ff8-aaa2-372cd281f60c)

![image](https://github.com/user-attachments/assets/fd9cf719-65d1-4d12-8086-d43e62d367b9)
