### PR TITLE
Fix type definitions for PricingOptions.Label

### DIFF
--- a/.changeset/friendly-tomatoes-dance.md
+++ b/.changeset/friendly-tomatoes-dance.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed type definitions for `PricingOptions.Label`. Now inclusive of all props in `Label`.

--- a/apps/docs/content/components/PricingOptions.mdx
+++ b/apps/docs/content/components/PricingOptions.mdx
@@ -546,6 +546,8 @@ One item per pricing plan to be displayed. Maximum of 3 items.
 | :--------- | :---------- | :---------: | :------: | :-------------------- |
 | `children` | `ReactNode` | `undefined` |  `true`  | The label of the item |
 
+Forwards all props from the [Label component](/components/Label).
+
 ### PricingOptions.Description
 
 | Name       | Type        |   Default   | required | Description                 |

--- a/packages/react/src/PricingOptions/PricingOptions.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.tsx
@@ -10,6 +10,7 @@ import {
   Heading as HeadingComponent,
   HeadingProps,
   Label as LabelComponent,
+  LabelProps,
   Text,
   UnorderedList,
   UnorderedListProps,
@@ -215,7 +216,7 @@ const PricingOptionsItem = forwardRef(
 
 type PricingOptionsLabelProps = PropsWithChildren<BaseProps<HTMLSpanElement>> & {
   'data-testid'?: string
-}
+} & LabelProps
 
 const PricingOptionsLabel = forwardRef<HTMLSpanElement, PricingOptionsLabelProps>(
   ({children, className, 'data-testid': testId, ...rest}, ref) => {


### PR DESCRIPTION
## Summary

Part of https://github.com/github/primer/issues/4785

PricingOptions.Label types now extend the base Label for more accurate type checking.



## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Code review
1. Check before/after screenshots
1. Try it?


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![Screenshot 2025-04-11 at 14 18 00](https://github.com/user-attachments/assets/f02b4703-b938-4335-97cf-ee2612ba8ec4)


 </td>
<td valign="top">

![Screenshot 2025-04-11 at 14 18 09](https://github.com/user-attachments/assets/58a7e6ac-684e-46c5-b203-e82048b20530)


</td>
</tr>
</table>
