### PR TITLE
Close hovered `SubNav.SubMenu` on Escape

### DIFF
--- a/.changeset/calm-countries-explain.md
+++ b/.changeset/calm-countries-explain.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Allow hovered `SubNav.SubMenu` menus to be closed using <kbd>Escape</kbd> key

--- a/packages/react/src/SubNav/SubNav.test.tsx
+++ b/packages/react/src/SubNav/SubNav.test.tsx
@@ -172,4 +172,32 @@ describe('SubNav', () => {
 
     expect(toggleSubmenuButton).toHaveAttribute('aria-expanded', 'false')
   })
+
+  it('hides a hovered submenu when escape is pressed', async () => {
+    mockUseWindowSize.mockImplementation(() => ({isLarge: true}))
+
+    const {getByRole, queryByRole} = render(
+      <SubNav fullWidth>
+        <SubNav.Link href="#" aria-current="page">
+          Copilot
+          <SubNav.SubMenu>
+            <SubNav.Link href="#">Copilot feature page one</SubNav.Link>
+            <SubNav.Link href="#">Copilot feature page two</SubNav.Link>
+            <SubNav.Link href="#">Copilot feature page three</SubNav.Link>
+          </SubNav.SubMenu>
+        </SubNav.Link>
+        <SubNav.Link href="#">Code review</SubNav.Link>
+        <SubNav.Link href="#">Search</SubNav.Link>
+        <SubNav.Action href="#">Call to action</SubNav.Action>
+      </SubNav>,
+    )
+
+    await userEvent.hover(getByRole('link', {name: 'Copilot'}))
+
+    expect(getByRole('link', {name: 'Copilot feature page one'})).toBeVisible()
+
+    await userEvent.keyboard('{escape}')
+
+    expect(queryByRole('link', {name: 'Copilot feature page one'})).not.toBeInTheDocument()
+  })
 })

--- a/packages/react/src/SubNav/SubNav.tsx
+++ b/packages/react/src/SubNav/SubNav.tsx
@@ -413,7 +413,7 @@ const SubNavLinkWithSubmenu = forwardRef<HTMLDivElement, SubNavLinkProps>(
           </button>
         )}
 
-        <div id={submenuId} className={styles['SubNav__sub-menu-children']}>
+        <div id={submenuId} className={styles['SubNav__sub-menu-children']} aria-hidden={!isExpanded}>
           {SubMenuChildren}
         </div>
       </div>

--- a/packages/react/src/SubNav/SubNav.tsx
+++ b/packages/react/src/SubNav/SubNav.tsx
@@ -367,6 +367,7 @@ const SubNavLinkWithSubmenu = forwardRef<HTMLDivElement, SubNavLinkProps>(
     const collapse = useCallback(() => setIsExpanded(false), [])
     const toggleExpanded = useCallback(() => setIsExpanded(prev => !prev), [])
 
+    useKeyboardEscape(collapse)
 
     const [label, SubMenuChildren] = children as ReactNode[]
 

--- a/packages/react/src/SubNav/SubNav.tsx
+++ b/packages/react/src/SubNav/SubNav.tsx
@@ -363,19 +363,20 @@ const SubNavLinkWithSubmenu = forwardRef<HTMLDivElement, SubNavLinkProps>(
       }
     })
 
-    const [label, SubMenuChildren] = children as ReactNode[]
+    const expand = useCallback(() => setIsExpanded(true), [])
+    const collapse = useCallback(() => setIsExpanded(false), [])
+    const toggleExpanded = useCallback(() => setIsExpanded(prev => !prev), [])
 
-    const handleOnClick = useCallback(() => {
-      setIsExpanded(prev => !prev)
-    }, [])
+
+    const [label, SubMenuChildren] = children as ReactNode[]
 
     return (
       <div
         className={clsx(styles['SubNav__link--has-sub-menu'], isExpanded && styles['SubNav__link--expanded'])}
         data-testid={testId || testIds.subMenu}
         ref={ref}
-        onMouseOver={() => setIsExpanded(true)}
-        onMouseOut={() => setIsExpanded(false)}
+        onMouseOver={expand}
+        onMouseOut={collapse}
         /**
          * onFocus and onBlur need to be defined to keep the jsx-a11y/mouse-events-have-key-events
          * eslint rule happy. The focus/blur behaviour is handled by useContainsFocus
@@ -402,7 +403,7 @@ const SubNavLinkWithSubmenu = forwardRef<HTMLDivElement, SubNavLinkProps>(
         {isLarge && (
           <button
             className={styles['SubNav__sub-menu-toggle']}
-            onClick={handleOnClick}
+            onClick={toggleExpanded}
             aria-expanded={isExpanded ? 'true' : 'false'}
             aria-controls={submenuId}
             aria-label={`${isExpanded ? 'Close' : 'Open'} submenu`}


### PR DESCRIPTION
## Summary

Close hovered `SubNav.SubMenu` on <kbd>Escape</kbd>

## List of notable changes:

- Added a test to verify behaviour
- Explicitly hide collapsed submenu children with `aria-hidden`
- Create utilities for managing submenu state
- Close hovered submenu on <kbd>Escape</kbd> key press

## What should reviewers focus on?

- Check that a hovered submenu can be closed with the <kbd>Escape</kbd> ke

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/4677

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
