### PR TITLE
Update `SubNav` docs to communicate a11y requirement

### DIFF
--- a/apps/docs/content/components/SubNav.mdx
+++ b/apps/docs/content/components/SubNav.mdx
@@ -90,7 +90,7 @@ Submenus appear as a dropdown by default.
 
 ### Optional anchor-based submenu
 
-Ensure that the text of each `SubNav.Link` within the anchor-based submenu fits entirely within a 320px wide viewport. Failure to do this violates [WCAG 1.4.10 Reflow](https://github.com/github/accessibility-audit-guide/blob/main/web/WCAG/1.4.10%20Reflow.md).
+Ensure that the text of each `SubNav.Link` within the anchor-based submenu fits entirely within a 320px-wide viewport. Failure to do this violates [WCAG 1.4.10 Reflow](https://github.com/github/accessibility-audit-guide/blob/main/web/WCAG/1.4.10%20Reflow.md).
 
 ```jsx live
 <Container sx={{position: 'relative', height: 300, overflowY: 'scroll'}}>

--- a/apps/docs/content/components/SubNav.mdx
+++ b/apps/docs/content/components/SubNav.mdx
@@ -90,6 +90,8 @@ Submenus appear as a dropdown by default.
 
 ### Optional anchor-based submenu
 
+Ensure that the text of each `SubNav.Link` within the anchor-based submenu fits entirely within a 320px wide viewport. Failure to do this violates [WCAG 1.4.10 Reflow](https://github.com/github/accessibility-audit-guide/blob/main/web/WCAG/1.4.10%20Reflow.md).
+
 ```jsx live
 <Container sx={{position: 'relative', height: 300, overflowY: 'scroll'}}>
   <Box style={{height: 1000}}>

--- a/apps/next-docs/content/components/SubNav/index.mdx
+++ b/apps/next-docs/content/components/SubNav/index.mdx
@@ -92,6 +92,8 @@ Submenus appear as a dropdown by default.
 
 ### Optional anchor-based submenu
 
+Ensure that the text of each `SubNav.Link` within the anchor-based submenu fits entirely within a 320px wide viewport. Failure to do this violates [WCAG 1.4.10 Reflow](https://github.com/github/accessibility-audit-guide/blob/main/web/WCAG/1.4.10%20Reflow.md).
+
 ```jsx live
 <div style={{position: 'relative', height: 300, width: '100%', overflowY: 'scroll'}}>
   <Box style={{height: 1000}}>

--- a/apps/next-docs/content/components/SubNav/index.mdx
+++ b/apps/next-docs/content/components/SubNav/index.mdx
@@ -92,7 +92,7 @@ Submenus appear as a dropdown by default.
 
 ### Optional anchor-based submenu
 
-Ensure that the text of each `SubNav.Link` within the anchor-based submenu fits entirely within a 320px wide viewport. Failure to do this violates [WCAG 1.4.10 Reflow](https://github.com/github/accessibility-audit-guide/blob/main/web/WCAG/1.4.10%20Reflow.md).
+Ensure that the text of each `SubNav.Link` within the anchor-based submenu fits entirely within a 320px-wide viewport. Failure to do this violates [WCAG 1.4.10 Reflow](https://github.com/github/accessibility-audit-guide/blob/main/web/WCAG/1.4.10%20Reflow.md).
 
 ```jsx live
 <div style={{position: 'relative', height: 300, width: '100%', overflowY: 'scroll'}}>


### PR DESCRIPTION
## Summary

Add documentation to `SubNav` anchor variant to communicate the requirement for individual items to fit within a 320px-wide viewport to conform with WCAG 1.4.10 Reflow given our [additional guidance](https://github.com/github/accessibility-audit-guide/blob/main/web/WCAG/1.4.10%20Reflow.md#additional-guidance)


## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/4678
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

