### PR TITLE
Fix bug where SubNav Submenu links were hidden from screen readers

### DIFF
--- a/.changeset/empty-rockets-kneel.md
+++ b/.changeset/empty-rockets-kneel.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed an accessibility issue in the `SubNav` component where items within the `SubNav.SubMenu` weren't accessible to assistive technologies on narrow viewports.

--- a/packages/react/src/SubNav/SubNav.tsx
+++ b/packages/react/src/SubNav/SubNav.tsx
@@ -413,7 +413,7 @@ const SubNavLinkWithSubmenu = forwardRef<HTMLDivElement, SubNavLinkProps>(
           </button>
         )}
 
-        <div id={submenuId} className={styles['SubNav__sub-menu-children']} aria-hidden={!isExpanded}>
+        <div id={submenuId} className={styles['SubNav__sub-menu-children']} aria-hidden={isLarge && !isExpanded}>
           {SubMenuChildren}
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fix a bug where narrow-viewport `SubNav.SubMenu` links were hidden from screen readers.

This bug was introduced in https://github.com/primer/brand/pull/989

## List of notable changes:

- Removes `aria-hidden` from `SubNav.SubMenu` links when `isLarge` is `false`.

## What should reviewers focus on?

- Check that `aria-hidden` is `false` on mobile viewports.

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/fde104fd-fe31-4f46-ad57-79baa54adca6)


 </td>
<td valign="top">

![image](https://github.com/user-attachments/assets/ebd0595f-7129-44d5-ac20-a4790dd42df4)

</td>
</tr>
</table>
