### PR TITLE
Add the missing prop types in PricingOptions.

### DIFF
--- a/packages/react/src/PricingOptions/PricingOptions.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.tsx
@@ -500,6 +500,7 @@ const PricingOptionsFeatureList = forwardRef<HTMLDivElement, PricingOptionsFeatu
 )
 
 type PricingOptionsFeatureListHeading = PropsWithChildren<BaseProps<HTMLDivElement>> & {
+  as?: Exclude<HeadingProps['as'], 'h1'>
   'data-testid'?: string
 }
 
@@ -514,6 +515,7 @@ const PricingOptionsFeatureListHeading = forwardRef<HTMLDivElement, PricingOptio
 )
 
 type PricingOptionsFeatureListGroupHeadingProps = PropsWithChildren<BaseProps<HTMLHeadingElement>> & {
+  as?: Exclude<HeadingProps['as'], 'h1' | 'h2'>
   'data-testid'?: string
 }
 


### PR DESCRIPTION
## Summary

Adds missing `as` prop types in `PricingOptionsFeature.ListHeading` and `PricingOptions.FeatureListGroupHeading` components.