### PR TITLE
Ensure all Select, TextArea, and TextInput examples in docs have an accessible label

### DIFF
--- a/apps/docs/content/components/Select.mdx
+++ b/apps/docs/content/components/Select.mdx
@@ -6,7 +6,6 @@ storybook: '/brand/storybook/?path=/story/components-forms-select--playground'
 description: Use the select component to enable selection of one option from a list.
 ---
 
-import InlineCode from '@primer/gatsby-theme-doctocat/src/components/inline-code'
 import {PropTableValues} from '../../src/components'
 import {Label} from '@primer/react'
 import {Link} from 'gatsby'
@@ -20,7 +19,7 @@ import {Select} from '@primer/react-brand'
 ### Default
 
 ```jsx live
-<Select>
+<Select aria-label="Select a handle">
   <Select.Option value="mona">Monalisa</Select.Option>
   <Select.Option value="hubot">Hubot</Select.Option>
 </Select>
@@ -29,7 +28,7 @@ import {Select} from '@primer/react-brand'
 ### Placeholder
 
 ```jsx live
-<Select defaultValue="">
+<Select defaultValue="" aria-label="Select a handle">
   <Select.Option value="" disabled>
     Select a handle
   </Select.Option>
@@ -41,7 +40,7 @@ import {Select} from '@primer/react-brand'
 ### Option groups
 
 ```jsx live
-<Select defaultValue="">
+<Select defaultValue="" aria-label="Select a country">
   <Select.Option value="" disabled>
     Select a country
   </Select.Option>
@@ -112,7 +111,7 @@ Use `Select` alongside `FormControl` to ensure the control has a corresponding f
 ### Full width
 
 ```jsx live
-<Select fullWidth>
+<Select fullWidth aria-label="Select a handle">
   <Select.Option value="mona">Monalisa</Select.Option>
   <Select.Option value="hubot">Hubot</Select.Option>
 </Select>
@@ -147,7 +146,7 @@ Use `Select` alongside `FormControl` to ensure the control has a corresponding f
 Pass the `required` prop to ensure that the input field must be filled out before submitting the form.
 
 ```jsx live
-<Select required defaultValue="">
+<Select required defaultValue="" aria-label="Select a handle">
   <Select.Option value="" disabled>
     Select a handle
   </Select.Option>

--- a/apps/docs/content/components/TextInput.mdx
+++ b/apps/docs/content/components/TextInput.mdx
@@ -20,7 +20,7 @@ import {TextInput} from '@primer/react-brand'
 ### Default
 
 ```jsx live
-<TextInput />
+<TextInput aria-label="Demo TextInput" />
 ```
 
 ### Variants
@@ -112,7 +112,10 @@ Use `TextInput` alongside `FormControl` to ensure the control always has a corre
 The `autoComplete` prop should be provided wherever possible to allow browsers to autofill the input field. See MDN for [a complete list of autocomplete values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).
 
 ```jsx live
-<TextInput autoComplete="given-name" />
+<FormControl fullWidth>
+  <FormControl.Label>First name</FormControl.Label>
+  <TextInput autoComplete="given-name" />
+</FormControl>
 ```
 
 ### Validation
@@ -135,7 +138,7 @@ The `autoComplete` prop should be provided wherever possible to allow browsers t
 ### Full width
 
 ```jsx live
-<TextInput fullWidth />
+<TextInput fullWidth aria-label="Full width TextInput" />
 ```
 
 ### Sizes
@@ -144,9 +147,9 @@ The `autoComplete` prop should be provided wherever possible to allow browsers t
 
 ```jsx live
 <Container sx={{display: 'inline-grid', gap: 3}}>
-  <TextInput size="medium" />
+  <TextInput size="medium" aria-label="Medium TextInput" />
 
-  <TextInput size="large" />
+  <TextInput size="large" aria-label="Large TextInput" />
 </Container>
 ```
 
@@ -155,7 +158,7 @@ The `autoComplete` prop should be provided wherever possible to allow browsers t
 Pass the `required` prop to ensure that the input field must be filled out before submitting the form.
 
 ```jsx live
-<TextInput required />
+<TextInput required aria-label="Required TextInput" />
 ```
 
 ### Using `refs`

--- a/apps/docs/content/components/Textarea.mdx
+++ b/apps/docs/content/components/Textarea.mdx
@@ -38,6 +38,7 @@ const TextareaExample = () => {
 
   return (
     <Textarea
+      aria-label="Description"
       placeholder="Enter a description"
       onChange={handleChange}
       value={value}
@@ -71,6 +72,7 @@ const TextareaExample = () => {
         rows={8}
         ref={ref}
         defaultValue="Set the initial state in uncontrolled mode using the defaultValue prop"
+        aria-label="Demo Textarea"
       />
       <br /> <br />
       <Button variant="primary" type="submit">
@@ -105,7 +107,9 @@ render(<TextareaExample />)
 ### Inactive
 
 ```jsx live
-<Textarea disabled>This text is inactive</Textarea>
+<Textarea disabled aria-label="Demo Textarea">
+  This text is inactive
+</Textarea>
 ```
 
 ### Resize
@@ -113,7 +117,7 @@ render(<TextareaExample />)
 By default, `Textarea` can be resized by the user vertically and horizontally. Resizing can be prevented by setting `resize` to `none`
 
 ```jsx live
-<Textarea resize="none" />
+<Textarea resize="none" aria-label="Resizable Textarea" />
 ```
 
 ## Props

--- a/apps/next-docs/content/forms/Select/index.mdx
+++ b/apps/next-docs/content/forms/Select/index.mdx
@@ -21,7 +21,7 @@ import {Select} from '@primer/react-brand'
 ### Default
 
 ```jsx live
-<Select>
+<Select aria-label="Select a handle">
   <Select.Option value="mona">Monalisa</Select.Option>
   <Select.Option value="hubot">Hubot</Select.Option>
 </Select>
@@ -30,7 +30,7 @@ import {Select} from '@primer/react-brand'
 ### Placeholder
 
 ```jsx live
-<Select defaultValue="">
+<Select defaultValue="" aria-label="Select a handle">
   <Select.Option value="" disabled>
     Select a handle
   </Select.Option>
@@ -42,7 +42,7 @@ import {Select} from '@primer/react-brand'
 ### Option groups
 
 ```jsx live
-<Select defaultValue="">
+<Select defaultValue="" aria-label="Select a country">
   <Select.Option value="" disabled>
     Select a country
   </Select.Option>
@@ -113,7 +113,7 @@ Use `Select` alongside `FormControl` to ensure the control has a corresponding f
 ### Full width
 
 ```jsx live
-<Select fullWidth>
+<Select fullWidth aria-label="Select a handle">
   <Select.Option value="mona">Monalisa</Select.Option>
   <Select.Option value="hubot">Hubot</Select.Option>
 </Select>
@@ -148,7 +148,7 @@ Use `Select` alongside `FormControl` to ensure the control has a corresponding f
 Pass the `required` prop to ensure that the input field must be filled out before submitting the form.
 
 ```jsx live
-<Select required defaultValue="">
+<Select required defaultValue="" aria-label="Select a handle">
   <Select.Option value="" disabled>
     Select a handle
   </Select.Option>

--- a/apps/next-docs/content/forms/TextArea/index.mdx
+++ b/apps/next-docs/content/forms/TextArea/index.mdx
@@ -35,7 +35,7 @@ const TextareaExample = () => {
     setValue(event.target.value)
   }
 
-  return <Textarea placeholder="Enter a description" onChange={handleChange} value={value} />
+  return <Textarea aria-label="Description" placeholder="Enter a description" onChange={handleChange} value={value} />
 }
 
 render(<TextareaExample />)
@@ -64,6 +64,7 @@ const TextareaExample = () => {
         rows={8}
         ref={ref}
         defaultValue="Set the initial state in uncontrolled mode using the defaultValue prop"
+        aria-label="Demo Textarea"
       />
       <br /> <br />
       <Button variant="primary" type="submit">
@@ -100,7 +101,9 @@ render(<TextareaExample />)
 ### Inactive
 
 ```jsx live
-<Textarea disabled>This text is inactive</Textarea>
+<Textarea disabled aria-label="Demo Textarea">
+  This text is inactive
+</Textarea>
 ```
 
 ### Resize
@@ -108,7 +111,7 @@ render(<TextareaExample />)
 By default, `Textarea` can be resized by the user vertically and horizontally. Resizing can be prevented by setting `resize` to `none`
 
 ```jsx live
-<Textarea resize="none" />
+<Textarea resize="none" aria-label="Resizable Textarea" />
 ```
 
 ## Props

--- a/apps/next-docs/content/forms/TextInput/index.mdx
+++ b/apps/next-docs/content/forms/TextInput/index.mdx
@@ -20,7 +20,7 @@ import {TextInput} from '@primer/react-brand'
 ### Default
 
 ```jsx live
-<TextInput />
+<TextInput aria-label="Demo TextInput" />
 ```
 
 ### Variants
@@ -104,7 +104,10 @@ Use `TextInput` alongside `FormControl` to ensure the control always has a corre
 The `autoComplete` prop should be provided wherever possible to allow browsers to autofill the input field. See MDN for [a complete list of autocomplete values](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).
 
 ```jsx live
-<TextInput autoComplete="given-name" />
+<FormControl fullWidth>
+  <FormControl.Label>First name</FormControl.Label>
+  <TextInput autoComplete="given-name" />
+</FormControl>
 ```
 
 ### Validation
@@ -127,7 +130,7 @@ The `autoComplete` prop should be provided wherever possible to allow browsers t
 ### Full width
 
 ```jsx live
-<TextInput fullWidth />
+<TextInput fullWidth aria-label="Full width TextInput" />
 ```
 
 ### Sizes
@@ -136,9 +139,9 @@ The `autoComplete` prop should be provided wherever possible to allow browsers t
 
 ```jsx live
 <div style={{display: 'inline-grid', gap: 3}}>
-  <TextInput size="medium" />
+  <TextInput size="medium" aria-label="Medium TextInput" />
 
-  <TextInput size="large" />
+  <TextInput size="large" aria-label="Large TextInput" />
 </div>
 ```
 
@@ -147,7 +150,7 @@ The `autoComplete` prop should be provided wherever possible to allow browsers t
 Pass the `required` prop to ensure that the input field must be filled out before submitting the form.
 
 ```jsx live
-<TextInput required />
+<TextInput required aria-label="Required TextInput" />
 ```
 
 ### Using `refs`


### PR DESCRIPTION
## Summary

Adds an accessible label — either via `aria-label` or `FormControl` — to all Select, TextArea, and TextInput examples in the existing and next docs

## What should reviewers focus on?

Check that the labels make sense, and that I've not missed any

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/accessibility-audits/issues/10699
- Closes https://github.com/github/accessibility-audits/issues/10700
- Closes https://github.com/github/accessibility-audits/issues/10704

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

