### PR TITLE
Remove label from Checkbox and Radio components

### DIFF
--- a/.changeset/ten-carrots-appear.md
+++ b/.changeset/ten-carrots-appear.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Removed the `Checkbox` and `Radio` components' built-in `<label>` as it was only used for styling and would result in inputs having two associated labels when used inside a `FormControl`.

--- a/apps/docs/content/components/CTAForm/react.mdx
+++ b/apps/docs/content/components/CTAForm/react.mdx
@@ -36,6 +36,7 @@ import {CTAForm} from '@primer/react-brand'
   </CTAForm.Input>
   <CTAForm.Confirm>
     <FormControl required>
+      <Checkbox name="confirm" />
       <FormControl.Label>
         <Text size="300" variant="muted">
           I agree to the{' '}
@@ -43,7 +44,6 @@ import {CTAForm} from '@primer/react-brand'
           <InlineLink href="www.github.com">Terms of Service</InlineLink>
         </Text>
       </FormControl.Label>
-      <Checkbox name="confirm" />
     </FormControl>
   </CTAForm.Confirm>
   <CTAForm.Action>Subscribe</CTAForm.Action>

--- a/apps/docs/content/components/Checkbox/react.mdx
+++ b/apps/docs/content/components/Checkbox/react.mdx
@@ -28,20 +28,20 @@ The `Checkbox` component can be used in controlled and uncontrolled modes.
 ```jsx live
 <form>
   <FormControl>
-    <FormControl.Label>Default checkbox</FormControl.Label>
     <Checkbox />
+    <FormControl.Label>Default checkbox</FormControl.Label>
   </FormControl>
   <FormControl>
-    <FormControl.Label>Always checked</FormControl.Label>
     <Checkbox checked />
+    <FormControl.Label>Always checked</FormControl.Label>
   </FormControl>
   <FormControl>
-    <FormControl.Label>Always unchecked</FormControl.Label>
     <Checkbox checked={false} />
+    <FormControl.Label>Always unchecked</FormControl.Label>
   </FormControl>
   <FormControl>
-    <FormControl.Label>Inactive</FormControl.Label>
     <Checkbox checked disabled />
+    <FormControl.Label>Inactive</FormControl.Label>
   </FormControl>
 </form>
 ```
@@ -53,8 +53,8 @@ An `indeterminate` checkbox state should be used if the input value is neither `
 ```jsx live
 <form>
   <FormControl>
-    <FormControl.Label>Indeterminate checkbox</FormControl.Label>
     <Checkbox onChange={() => {}} indeterminate={true} />
+    <FormControl.Label>Indeterminate checkbox</FormControl.Label>
   </FormControl>
 </form>
 ```
@@ -65,10 +65,10 @@ Apply an optional border using `FormControl` and `hasBorder`.
 
 ```jsx live
 <FormControl hasBorder required>
+  <Checkbox />
   <FormControl.Label>
     Contact me about GitHub Enterprise Server
   </FormControl.Label>
-  <Checkbox />
 </FormControl>
 ```
 
@@ -78,6 +78,7 @@ When using a custom label alongside a checkbox, the `Checkbox` component should 
 
 ```jsx live
 <FormControl required>
+  <Checkbox />
   <FormControl.Label>
     <Text size="200" variant="muted">
       I hereby accept the{' '}
@@ -96,10 +97,9 @@ When using a custom label alongside a checkbox, the `Checkbox` component should 
         target="_blank"
       >
         GitHub Privacy Statement.
-      </InlineLink>{' '}
+      </InlineLink>
     </Text>
   </FormControl.Label>
-  <Checkbox />
 </FormControl>
 ```
 

--- a/apps/docs/content/components/FormControl.mdx
+++ b/apps/docs/content/components/FormControl.mdx
@@ -47,8 +47,8 @@ import {FormControl} from '@primer/react-brand'
   </FormControl>
   {/* Checkbox */}
   <FormControl>
-    <FormControl.Label>Checkbox</FormControl.Label>
     <Checkbox />
+    <FormControl.Label>Checkbox</FormControl.Label>
     <FormControl.Hint>With an optional message</FormControl.Hint>
   </FormControl>
   {/* Radio */}
@@ -136,10 +136,10 @@ An example of a typical layout composed using `FormControl`:
       </Select>
     </FormControl>
     <FormControl hasBorder required>
+      <Checkbox />
       <FormControl.Label>
         Contact me about GitHub Enterprise Server
       </FormControl.Label>
-      <Checkbox />
       <FormControl.Hint>
         <Text size="200" variant="muted">
           I&apos;m interested in learning more about{' '}
@@ -173,6 +173,7 @@ An example of a typical layout composed using `FormControl`:
       </Text>
     </Container>
     <FormControl required>
+      <Checkbox />
       <FormControl.Label>
         <Text size="200" variant="muted">
           I hereby accept the{' '}
@@ -192,11 +193,9 @@ An example of a typical layout composed using `FormControl`:
             target="_blank"
           >
             GitHub Privacy Statement.
-          </InlineLink>{' '}
+          </InlineLink>
         </Text>
       </FormControl.Label>
-
-      <Checkbox />
     </FormControl>
     <Container
       sx={{

--- a/apps/docs/content/components/RadioGroup/react.mdx
+++ b/apps/docs/content/components/RadioGroup/react.mdx
@@ -106,9 +106,9 @@ When space is limited, radio inputs can be arranged horizontally using the [Stac
 ```jsx live
 <RadioGroup>
   <RadioGroup.Label visuallyHidden>Time period</RadioGroup.Label>
-  <CheckboxGroup.Caption>
+  <RadioGroup.Caption>
     Some inline radio inputs with a visually hidden label
-  </CheckboxGroup.Caption>
+  </RadioGroup.Caption>
   <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
     <FormControl>
       <FormControl.Label>Last 7 days</FormControl.Label>

--- a/apps/next-docs/content/components/CTAForm/react.mdx
+++ b/apps/next-docs/content/components/CTAForm/react.mdx
@@ -28,13 +28,13 @@ import {CTAForm} from '@primer/react-brand'
   </CTAForm.Input>
   <CTAForm.Confirm>
     <FormControl required>
+      <Checkbox name="confirm" />
       <FormControl.Label>
         <Text size="300" variant="muted">
           I agree to the <InlineLink href="www.github.com">Privacy Policy</InlineLink> and{' '}
           <InlineLink href="www.github.com">Terms of Service</InlineLink>
         </Text>
       </FormControl.Label>
-      <Checkbox name="confirm" />
     </FormControl>
   </CTAForm.Confirm>
   <CTAForm.Action>Subscribe</CTAForm.Action>

--- a/apps/next-docs/content/forms/Checkbox/react.mdx
+++ b/apps/next-docs/content/forms/Checkbox/react.mdx
@@ -24,20 +24,20 @@ The `Checkbox` component can be used in controlled and uncontrolled modes.
 ```jsx live
 <form>
   <FormControl>
-    <FormControl.Label>Default checkbox</FormControl.Label>
     <Checkbox />
+    <FormControl.Label>Default checkbox</FormControl.Label>
   </FormControl>
   <FormControl>
-    <FormControl.Label>Always checked</FormControl.Label>
     <Checkbox checked />
+    <FormControl.Label>Always checked</FormControl.Label>
   </FormControl>
   <FormControl>
-    <FormControl.Label>Always unchecked</FormControl.Label>
     <Checkbox checked={false} />
+    <FormControl.Label>Always unchecked</FormControl.Label>
   </FormControl>
   <FormControl>
-    <FormControl.Label>Inactive</FormControl.Label>
     <Checkbox checked disabled />
+    <FormControl.Label>Inactive</FormControl.Label>
   </FormControl>
 </form>
 ```
@@ -49,8 +49,8 @@ An `indeterminate` checkbox state should be used if the input value is neither `
 ```jsx live
 <form>
   <FormControl>
-    <FormControl.Label>Indeterminate checkbox</FormControl.Label>
     <Checkbox onChange={() => {}} indeterminate={true} />
+    <FormControl.Label>Indeterminate checkbox</FormControl.Label>
   </FormControl>
 </form>
 ```
@@ -61,8 +61,8 @@ Apply an optional border using `FormControl` and `hasBorder`.
 
 ```jsx live
 <FormControl hasBorder required>
-  <FormControl.Label>Contact me about GitHub Enterprise Server</FormControl.Label>
   <Checkbox />
+  <FormControl.Label>Contact me about GitHub Enterprise Server</FormControl.Label>
 </FormControl>
 ```
 
@@ -72,6 +72,7 @@ When using a custom label alongside a checkbox, the `Checkbox` component should 
 
 ```jsx live
 <FormControl required>
+  <Checkbox />
   <FormControl.Label>
     <Text size="200" variant="muted">
       I hereby accept the{' '}
@@ -86,10 +87,9 @@ When using a custom label alongside a checkbox, the `Checkbox` component should 
         target="_blank"
       >
         GitHub Privacy Statement.
-      </InlineLink>{' '}
+      </InlineLink>
     </Text>
   </FormControl.Label>
-  <Checkbox />
 </FormControl>
 ```
 

--- a/apps/next-docs/content/forms/FormControl/index.mdx
+++ b/apps/next-docs/content/forms/FormControl/index.mdx
@@ -52,8 +52,8 @@ import {FormControl} from '@primer/react-brand'
   </FormControl>
   {/* Checkbox */}
   <FormControl>
-    <FormControl.Label>Checkbox</FormControl.Label>
     <Checkbox />
+    <FormControl.Label>Checkbox</FormControl.Label>
     <FormControl.Hint>With an optional message</FormControl.Hint>
   </FormControl>
   {/* Radio */}
@@ -141,8 +141,8 @@ An example of a typical layout composed using `FormControl`:
       </Select>
     </FormControl>
     <FormControl hasBorder required>
-      <FormControl.Label>Contact me about GitHub Enterprise Server</FormControl.Label>
       <Checkbox />
+      <FormControl.Label>Contact me about GitHub Enterprise Server</FormControl.Label>
       <FormControl.Hint>
         <Text size="200" variant="muted">
           I&apos;m interested in learning more about{' '}
@@ -172,6 +172,7 @@ An example of a typical layout composed using `FormControl`:
       </Text>
     </div>
     <FormControl required>
+      <Checkbox />
       <FormControl.Label>
         <Text size="200" variant="muted">
           I hereby accept the{' '}
@@ -189,8 +190,6 @@ An example of a typical layout composed using `FormControl`:
           </InlineLink>{' '}
         </Text>
       </FormControl.Label>
-
-      <Checkbox />
     </FormControl>
     <div
       style={{

--- a/apps/next-docs/content/forms/RadioGroup/react.mdx
+++ b/apps/next-docs/content/forms/RadioGroup/react.mdx
@@ -100,7 +100,7 @@ When space is limited, radio inputs can be arranged horizontally using the [Stac
 ```jsx live
 <RadioGroup>
   <RadioGroup.Label visuallyHidden>Time period</RadioGroup.Label>
-  <CheckboxGroup.Caption>Some inline radio inputs with a visually hidden label</CheckboxGroup.Caption>
+  <RadioGroup.Caption>Some inline radio inputs with a visually hidden label</RadioGroup.Caption>
   <Stack direction="horizontal" gap="normal" padding="none" flexWrap="wrap">
     <FormControl>
       <FormControl.Label>Last 7 days</FormControl.Label>

--- a/packages/react/src/forms/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/forms/Checkbox/Checkbox.stories.tsx
@@ -60,6 +60,6 @@ export const RefCallback = () => {
     }
   }, [checkboxRef])
 
-  return <Checkbox ref={checkboxRef} onChange={handleRefCallback} />
+  return <Checkbox ref={checkboxRef} onChange={handleRefCallback} aria-label="Checkbox with ref" />
 }
 RefCallback.storyName = 'Checkbox - Ref Callback'

--- a/packages/react/src/forms/Checkbox/Checkbox.tsx
+++ b/packages/react/src/forms/Checkbox/Checkbox.tsx
@@ -70,6 +70,7 @@ const _Checkbox = (
         id={uniqueId}
         aria-invalid={validationStatus === 'error' ? 'true' : 'false'}
         aria-required={required ? 'true' : 'false'}
+        aria-checked={indeterminate ? 'mixed' : checked}
         checked={indeterminate ? false : checked}
         className={clsx(styles['Checkbox-input'])}
         disabled={disabled}

--- a/packages/react/src/forms/Checkbox/Checkbox.tsx
+++ b/packages/react/src/forms/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, InputHTMLAttributes, ReactElement, RefObject} from 'react'
+import React, {forwardRef, useCallback, type InputHTMLAttributes, type ReactElement, type RefObject} from 'react'
 import clsx from 'clsx'
 import {useId} from '../../hooks/useId'
 
@@ -18,10 +18,6 @@ export type CheckboxProps = {
    * Apply inactive visual appearance to the checkbox
    */
   disabled?: boolean
-  /**
-   * Forward a ref to the underlying input element
-   */
-  ref?: React.RefObject<HTMLInputElement>
   /**
    * Indicates whether the checkbox must be checked
    */
@@ -62,6 +58,12 @@ const _Checkbox = (
     }
   }, [indeterminate, checked, inputRef])
 
+  const onClick = useCallback(() => {
+    if (!disabled && inputRef.current) {
+      inputRef.current.click()
+    }
+  }, [disabled, inputRef])
+
   return (
     <span className={styles['Checkbox-wrapper']}>
       <input
@@ -79,9 +81,11 @@ const _Checkbox = (
         value={value}
         {...rest}
       />
-      <label
-        htmlFor={uniqueId}
-        className={clsx(styles.Checkbox, indeterminate && styles['Checkbox--indeterminate'], className)}
+      <span
+        className={clsx(styles['Checkbox'], indeterminate && styles['Checkbox--indeterminate'], className)}
+        onClick={onClick}
+        tabIndex={-1}
+        aria-hidden="true"
       >
         {indeterminate ? (
           <svg
@@ -90,12 +94,12 @@ const _Checkbox = (
             viewBox="0 0 16 16"
             width="16"
             height="16"
-            aria-label="Dash icon"
+            aria-hidden="true"
           >
             <path fillRule="evenodd" d="M2 7.75A.75.75 0 012.75 7h10a.75.75 0 010 1.5h-10A.75.75 0 012 7.75z"></path>
           </svg>
         ) : (
-          <svg viewBox="0 0 100 100" className={clsx(styles['Checkbox-checkmark'])} aria-label="Checkmark icon">
+          <svg viewBox="0 0 100 100" className={clsx(styles['Checkbox-checkmark'])} aria-hidden="true">
             <path
               className={clsx(styles['Checkbox-checkmark-path'])}
               fill="none"
@@ -108,7 +112,7 @@ const _Checkbox = (
             />
           </svg>
         )}
-      </label>
+      </span>
     </span>
   )
 }

--- a/packages/react/src/forms/FormControl/FormControl.stories.tsx
+++ b/packages/react/src/forms/FormControl/FormControl.stories.tsx
@@ -294,8 +294,8 @@ export const CheckboxPlayground = args => {
       fullWidth={args.fullWidth}
       size={args.size}
     >
-      <FormControl.Label visuallyHidden={args.visuallyHidden ? true : false}>{args.label}</FormControl.Label>
       <Checkbox disabled={args.disabled} />
+      <FormControl.Label visuallyHidden={args.visuallyHidden ? true : false}>{args.label}</FormControl.Label>
 
       {args.hint.length ? <FormControl.Hint>{args.hint}</FormControl.Hint> : null}
 

--- a/packages/react/src/forms/Radio/Radio.tsx
+++ b/packages/react/src/forms/Radio/Radio.tsx
@@ -1,6 +1,7 @@
-import React, {forwardRef, InputHTMLAttributes, ReactElement, RefObject, useRef} from 'react'
+import React, {forwardRef, useCallback, type InputHTMLAttributes, type ReactElement, type RefObject} from 'react'
 import clsx from 'clsx'
 import {useId} from '../../hooks/useId'
+import {useProvidedRefOrCreate} from '../../hooks/useRef'
 
 import type {BaseProps} from '../../component-helpers'
 
@@ -11,10 +12,6 @@ export type RadioProps = {
    * Apply inactive visual appearance to the Radio
    */
   disabled?: boolean
-  /**
-   * Forward a ref to the underlying input element
-   */
-  ref?: React.RefObject<HTMLInputElement>
   /**
    * Indicates whether the Radio must be checked
    */
@@ -31,8 +28,14 @@ const _Radio = (
   {checked, className, disabled, id, onChange, required, value, ...rest}: RadioProps,
   ref,
 ): ReactElement => {
-  const inputRef: RefObject<HTMLInputElement> | null = useRef<HTMLInputElement>(ref || null)
+  const inputRef: RefObject<HTMLInputElement> | null = useProvidedRefOrCreate<HTMLInputElement>(ref || null)
   const uniqueId = useId(id)
+
+  const onClick = useCallback(() => {
+    if (!disabled && inputRef.current) {
+      inputRef.current.click()
+    }
+  }, [disabled, inputRef])
 
   return (
     <span className={styles['Radio-wrapper']}>
@@ -50,11 +53,9 @@ const _Radio = (
         value={value}
         {...rest}
       />
-      {/** Disabled as Radio's should always be used inside FormControl per our documented guidance */}
-      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-      <label htmlFor={uniqueId} className={clsx(styles.Radio, className)}>
+      <span className={clsx(styles.Radio, className)} onClick={onClick} tabIndex={-1} aria-hidden="true">
         <span className={styles['Radio-dot']} />
-      </label>
+      </span>
     </span>
   )
 }


### PR DESCRIPTION
## Summary

Removed built-in `<label>` elements from `Checkbox` and `Radio` components. As these labels were only used to render the visual checkbox or radio button I was able to replace them with a `<span>` which forwards click events through to the underlying `<input>` in the same way a `<label>` would.

## List of notable changes:

- Remove associated label from `Checkbox` and `Radio` components
  - Labels should be provided via the `FormControl` component
- Moved `Checkbox` and `Radio` components to their logical place in the DOM in our docs examples
- Fixed a typo in our `RadioGroup` docs which mistakenly uses `CheckboxGroup` instead.
- Removed unused `ref` type from `Checkbox` and `Radio` components. We no longer need to declare it explicitly since #998.

## What should reviewers focus on?

- Check the docs to make sure I've not missed any `Checkbox` and `Radio` that still need to be wrapped in a `FormControl`
- Check that the tab order follows a logical order in the `Checkbox` and `Radio` docs.

## Supporting resources (related issues, external links, etc):

- Fixes https://github.com/github/accessibility-audits/issues/10701

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
