### PR TITLE
Fix `ActionMenu` split-button anchor size

### DIFF
--- a/.changeset/hungry-tips-sing.md
+++ b/.changeset/hungry-tips-sing.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed an issue in `ActionMenu` where anchor links in `split-button` mode were only clickable on the text. Now, the clickable area covers the full width and height of the item.

--- a/packages/react/src/ActionMenu/ActionMenu.module.css
+++ b/packages/react/src/ActionMenu/ActionMenu.module.css
@@ -175,13 +175,17 @@
   display: grid;
   align-items: center;
   grid-template-areas: 'leadingVisual text';
-  grid-template-columns: min-content min-content;
+  grid-template-columns: min-content 1fr;
   list-style: none;
   border-radius: var(--brand-borderRadius-medium);
 }
 
 .ActionMenu__item-anchor {
-  display: inline-flex;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-template-rows: subgrid;
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
   align-items: center;
   gap: var(--base-size-8);
   text-decoration: none;
@@ -207,6 +211,14 @@
 .ActionMenu__item--medium {
   padding: var(--brand-control-medium-paddingBlock-condensed) var(--brand-control-medium-paddingInline-normal);
   min-height: var(--brand-control-medium-size);
+}
+
+.ActionMenu__item--medium:has(.ActionMenu__item-anchor) {
+  padding: 0;
+}
+
+.ActionMenu__item--medium .ActionMenu__item-anchor {
+  padding: var(--brand-control-medium-paddingBlock-condensed) var(--brand-control-medium-paddingInline-normal);
 }
 
 .ActionMenu__item--small {


### PR DESCRIPTION
## Summary

Fixes [an issue](https://github.slack.com/archives/C03FY9G00NS/p1747686318725149) in `ActionMenu` where anchor links in `split-button` mode were only clickable on the text. Now, the clickable area covers the full width and height of the item.

[Storybook](https://primer-b241c5b744-26139705.drafts.github.io/brand/storybook/?path=/story/components-actionmenu-features--split-button-mode)

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![screenshot-mntadhbz-000236@2x](https://github.com/user-attachments/assets/16d03efe-4462-4d18-8f50-80c130c23a73)


 </td>
<td valign="top">

![screenshot-TstYElYb-000234@2x](https://github.com/user-attachments/assets/94fefc5b-ad3b-49c0-8c05-8f8fc8ad79a8)


</td>
</tr>
</table>
