### PR TITLE
Increase the touch target size of SubNav.SubMenu toggle button

### DIFF
--- a/.changeset/tiny-bears-lick.md
+++ b/.changeset/tiny-bears-lick.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Increased the touch target size of `SubNav.SubMenu` toggle button

--- a/packages/react/src/SubNav/SubNav.module.css
+++ b/packages/react/src/SubNav/SubNav.module.css
@@ -630,9 +630,13 @@
   }
 
   .SubNav__sub-menu-toggle {
+    width: var(--base-size-24);
+    height: var(--base-size-24);
     border: none;
     padding: 0;
     margin: 0;
+    padding-inline-end: var(--base-size-8);
+    margin-inline-end: calc(-1 * var(--base-size-8));
     background: none;
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary

Increased the touch target size of `SubNav.SubMenu` toggle button to 24px × 24px.

The button was previously only 16px × 16px, and rather than add 4px to the left and right I've instead added 8px to the right (along with -8px of margin-right) so as to not cause any visual changes. You can see the touch target size change in the screenshots below.

## What should reviewers focus on?

- Check that you're happy with the focus styles, and that the touch target is indeed 24px × 24px.

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/4676

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/ad968a18-75fe-4c1e-9643-6fee59cca7dd)

 </td>
<td valign="top">

![image](https://github.com/user-attachments/assets/153c429d-dd17-4685-8af3-8f357d37d403)

</td>
</tr>
</table>
