### PR TITLE
Refactor split ActionMenu and ensure onClick and onKeyDown get called when provided

### DIFF
--- a/.changeset/tame-shirts-stare.md
+++ b/.changeset/tame-shirts-stare.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed a bug in `ActionMenu.Item` where provided `onClick` and `onKeyDown` handlers wouldn't be called. They're now called as expected.

--- a/.changeset/tame-shirts-stare.md
+++ b/.changeset/tame-shirts-stare.md
@@ -2,4 +2,7 @@
 '@primer/react-brand': patch
 ---
 
-Fixed a bug in `ActionMenu.Item` where provided `onClick` and `onKeyDown` handlers wouldn't be called. They're now called as expected.
+`ActionMenu` bugfixes:
+
+- Fixed a bug in `ActionMenu.Item` where provided `onClick` and `onKeyDown` handlers wouldn't be called.
+- Fixed a bug which allowed <kbd>Tab</kbd> to cycle through the list of `ActionMenu.Item` elements which resulted in unpredictable focus behaviour. The intended way to navigate through the list is by using the arrow keys.

--- a/packages/react/src/ActionMenu/ActionMenu.test.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.test.tsx
@@ -754,4 +754,56 @@ describe('ActionMenu', () => {
       {timeout: 100},
     )
   })
+
+  it('should call the onClick callback when an item is clicked in split-button mode when as="a"', async () => {
+    const mockOnClick = jest.fn()
+
+    const {getByRole} = render(
+      <ActionMenu mode="split-button" open>
+        <ActionMenu.Button as="a" href="#option1">
+          Primary Action
+        </ActionMenu.Button>
+        <ActionMenu.Overlay aria-label="Additional options">
+          <ActionMenu.Item as="a" href="#option1" onClick={mockOnClick}>
+            Option 1
+          </ActionMenu.Item>
+          <ActionMenu.Item as="a" href="#option2">
+            Option 2
+          </ActionMenu.Item>
+        </ActionMenu.Overlay>
+      </ActionMenu>,
+    )
+
+    const option1 = getByRole('menuitem', {name: 'Option 1'})
+    fireEvent.click(option1)
+
+    expect(mockOnClick).toHaveBeenCalled()
+  })
+
+  it('should call the onKeyDown callback when a key is pressed in split-button mode when as="a"', async () => {
+    const mockOnKeyDown = jest.fn()
+
+    const {getByRole} = render(
+      <ActionMenu mode="split-button" open>
+        <ActionMenu.Button as="a" href="#option1">
+          Primary Action
+        </ActionMenu.Button>
+        <ActionMenu.Overlay aria-label="Additional options">
+          <ActionMenu.Item as="a" href="#option1" onKeyDown={mockOnKeyDown}>
+            Option 1
+          </ActionMenu.Item>
+          <ActionMenu.Item as="a" href="#option2">
+            Option 2
+          </ActionMenu.Item>
+        </ActionMenu.Overlay>
+      </ActionMenu>,
+    )
+
+    const option1 = getByRole('menuitem', {name: 'Option 1'})
+    fireEvent.focus(option1)
+
+    fireEvent.keyDown(option1, {key: 'Enter'})
+
+    expect(mockOnKeyDown).toHaveBeenCalled()
+  })
 })

--- a/packages/react/src/ActionMenu/ActionMenu.tsx
+++ b/packages/react/src/ActionMenu/ActionMenu.tsx
@@ -468,7 +468,7 @@ const ActionMenuItem = ({
   const {size} = useActionMenuContext()
 
   const handleClick = useCallback(
-    e => {
+    (e: React.MouseEvent<HTMLLIElement>) => {
       onClick?.(e)
 
       if (!disabled) {
@@ -499,13 +499,11 @@ const ActionMenuItem = ({
       ),
       role: roleTypeMap[type || 'single'],
       'aria-disabled': disabled,
-      onClick: handleClick,
-      onKeyDown: handleKeyDown,
-      tabIndex: 0,
+      tabIndex: -1,
       'data-value': value,
       ...props,
     }),
-    [props, type, size, className, handleClick, handleKeyDown, disabled, value],
+    [props, type, size, className, disabled, value],
   )
 
   const contents = useMemo(
@@ -544,7 +542,14 @@ const ActionMenuItem = ({
 
   if (as === 'a') {
     return (
-      <li {...liProps}>
+      <li
+        // This role will be overridden by the role prop in `liProps`. It's just here to keep the linter happy
+        role="menuitem"
+        {...liProps}
+        // Intentionally not calling handle[Click/KeyDown] here so as to not call the handler
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+      >
         <a
           className={clsx(styles['ActionMenu__item-anchor'], disabled && styles['ActionMenu__item--disabled'])}
           href={props.href}
@@ -556,7 +561,14 @@ const ActionMenuItem = ({
   }
 
   return (
-    <li {...liProps} aria-checked={type === 'none' ? undefined : selected ? 'true' : 'false'}>
+    <li
+      // This role will be overridden by the role prop in `liProps`. It's just here to keep the linter happy
+      role="menuitem"
+      {...liProps}
+      aria-checked={type === 'none' ? undefined : selected ? 'true' : 'false'}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
       {contents}
     </li>
   )


### PR DESCRIPTION
## Summary

- Refactored the `ActionMenu.Item` component to remove branching logic ([previously discussed here](https://github.com/primer/brand/pull/972#discussion_r2042185895))
- Fixed a bug where `onClick` and `onKeyDown` weren't being called when provided.
- Fixed a bug where menu items could be cycled through using the <kbd>Tab</kbd> key, which resulted in unpredictable behaviour (see videos below). The intended way to navigate through the list is by using the arrow keys.


## What should reviewers focus on?

- Check that both the regular, and the link, versions of the `ActionMenuItem` still handle props in the same way.

## Supporting resources (related issues, external links, etc):

- Closes #1019

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change


## Screenshots:


<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">


https://github.com/user-attachments/assets/dc8cd090-a6ad-4494-8bbc-7480fba221a8



 </td>
<td valign="top">


https://github.com/user-attachments/assets/4839ca6d-f26a-4023-9a8a-b40f52b8d342



</td>
</tr>
</table>

