### PR TITLE
Removed aria-describedby from `AnchorNav.Link` component

### DIFF
--- a/.changeset/hot-ways-shout.md
+++ b/.changeset/hot-ways-shout.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Removed `aria-describedby` from `AnchorNav.Link` component.

--- a/packages/react/src/AnchorNav/AnchorNav.tsx
+++ b/packages/react/src/AnchorNav/AnchorNav.tsx
@@ -317,7 +317,6 @@ function _AnchorNavLink({
   const [intersectionEntry, setIntersectionEntry] = useState<IntersectionObserverEntry>()
 
   const isAnchor = /^#/.test(href)
-  const sansAnchor = isAnchor ? href.replace(/^#/, '') : href
   const anchoredContentIsVisible = !!intersectionEntry?.isIntersecting
 
   const handleIntersectionUpdate = ([nextEntry]: IntersectionObserverEntry[]): void => {
@@ -367,7 +366,6 @@ function _AnchorNavLink({
         anchoredContentIsVisible && styles['AnchorNav-link--is-active'],
       )}
       href={isAnchor ? href : `#${href}`}
-      aria-describedby={sansAnchor}
       aria-current={anchoredContentIsVisible && 'true'}
       data-first={isActive}
       data-active={anchoredContentIsVisible ? 'true' : 'false'}


### PR DESCRIPTION
## Summary

Removed `aria-describedby` from `AnchorNav.Link` component.

## What should reviewers focus on?

- If possible, test with a screen reader to ensure the heading content isn't announced after the navigation link.
- Otherwise, just verify via the rendered markup.

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/primer/brand/issues/1022

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:



<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/ccd7335b-6e0d-433e-90aa-4700901353d6)


 </td>
<td valign="top">

![image](https://github.com/user-attachments/assets/e7e23ec9-49c4-41ea-a16f-9137585a4a1b)

</td>
</tr>
</table>
