### PR TITLE
Ensure subnav separator is always visible on large viewports

### DIFF
--- a/.changeset/polite-otters-compare.md
+++ b/.changeset/polite-otters-compare.md
@@ -4,5 +4,5 @@
 
 Improved accessibility of `SubNav` component when no active link — denoted by `aria-current="page"` — is present.
 
-- Hide last separator when there is no active link
+- Hide last separator (on large viewports only) when there is no active link
 - Set a fallback accessible label on the overlay toggle when there is no active link

--- a/packages/react/src/SubNav/SubNav.tsx
+++ b/packages/react/src/SubNav/SubNav.tsx
@@ -323,7 +323,7 @@ const _SubNavRoot = memo(({id, children, className, 'data-testid': testId, fullW
                 </>
               )}
 
-              {activeLinklabel ? <Separator activeLinklabel={activeLinklabel} /> : null}
+              {isLarge || activeLinklabel ? <Separator activeLinklabel={activeLinklabel} /> : null}
 
               {!isLarge && (!SubHeadingChild || subHeadingIsActive) && NarrowButton}
 


### PR DESCRIPTION
## Summary

Ensure subnav separator is always visible on large viewports

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
