### PR TITLE
Add note to action menu docs about split button mode links

### DIFF
--- a/apps/docs/content/components/ActionMenu.mdx
+++ b/apps/docs/content/components/ActionMenu.mdx
@@ -77,6 +77,11 @@ render(<App />)
 
 In this `mode`, the `ActionMenu` can be shown as a split button with an action (left) and dropdown button (right) with an additional list of actions.
 
+<Note>
+  In split-button mode, each action must be rendered as a link element using the
+  as="a" prop, including the main button and all menu items.
+</Note>
+
 ```jsx live
 <ActionMenu mode="split-button">
   <ActionMenu.Button

--- a/apps/next-docs/content/components/ActionMenu/index.mdx
+++ b/apps/next-docs/content/components/ActionMenu/index.mdx
@@ -75,6 +75,11 @@ render(<App />)
 
 In this `mode`, the `ActionMenu` can be shown as a split button with an action (left) and dropdown button (right) with an additional list of actions.
 
+<Note>
+  In split-button mode, each action must be rendered as a link element using the as="a" prop, including the main button
+  and all menu items.
+</Note>
+
 ```jsx live
 <ActionMenu mode="split-button">
   <ActionMenu.Button variant="subtle" as="a" href="#location-for-link" leadingVisual={<StarIcon />}>


### PR DESCRIPTION
## Summary

Closes https://github.com/primer/brand/issues/1021

Split-button mode in the ActionMenu component only works with links at this time. This adds some notice about this constraint to our public docs.

## Screenshots:
Gatsby docs
![Screenshot 2025-06-03 at 12 27 23](https://github.com/user-attachments/assets/f1539165-22fb-4a19-b4fb-1ffcfc3c1b44)
Next docs
![Screenshot 2025-06-03 at 12 29 35](https://github.com/user-attachments/assets/b3ba1d77-1e35-4083-8c5e-2e3bbad0c705)
