### PR TITLE
Add missing href to ButtonGroup link examples

### DIFF
--- a/apps/docs/content/components/ButtonGroup/react.mdx
+++ b/apps/docs/content/components/ButtonGroup/react.mdx
@@ -45,8 +45,8 @@ The `Button` component can render as a `button` or `a` HTML element. By default,
 
 ```jsx live
 <ButtonGroup buttonsAs="a">
-  <Button>This is one link</Button>
-  <Button>This is another link</Button>
+  <Button href="#">This is one link</Button>
+  <Button href="#">This is another link</Button>
 </ButtonGroup>
 ```
 

--- a/apps/docs/content/components/ButtonGroup/react.mdx
+++ b/apps/docs/content/components/ButtonGroup/react.mdx
@@ -44,9 +44,13 @@ The ButtonGroup component can be rendered in different sizes in `medium` and `la
 The `Button` component can render as a `button` or `a` HTML element. By default, it will render as a `button`.
 
 ```jsx live
-<ButtonGroup buttonsAs="a">
-  <Button href="#">This is one link</Button>
-  <Button href="#">This is another link</Button>
+<ButtonGroup>
+  <Button as="a" href="#">
+    This is one link
+  </Button>
+  <Button as="a" href="#">
+    This is another link
+  </Button>
 </ButtonGroup>
 ```
 

--- a/apps/next-docs/content/components/ButtonGroup/react.mdx
+++ b/apps/next-docs/content/components/ButtonGroup/react.mdx
@@ -45,8 +45,8 @@ The `Button` component can render as a `button` or `a` HTML element. By default,
 
 ```jsx live
 <ButtonGroup buttonsAs="a">
-  <Button>This is one link</Button>
-  <Button>This is another link</Button>
+  <Button href="#">This is one link</Button>
+  <Button href="#">This is another link</Button>
 </ButtonGroup>
 ```
 

--- a/apps/next-docs/content/components/ButtonGroup/react.mdx
+++ b/apps/next-docs/content/components/ButtonGroup/react.mdx
@@ -44,9 +44,13 @@ The ButtonGroup component can be rendered in different sizes in `medium` and `la
 The `Button` component can render as a `button` or `a` HTML element. By default, it will render as a `button`.
 
 ```jsx live
-<ButtonGroup buttonsAs="a">
-  <Button href="#">This is one link</Button>
-  <Button href="#">This is another link</Button>
+<ButtonGroup>
+  <Button as="a" href="#">
+    This is one link
+  </Button>
+  <Button as="a" href="#">
+    This is another link
+  </Button>
 </ButtonGroup>
 ```
 


### PR DESCRIPTION
## Summary

Adds missing href to `ButtonGroup` examples in current and next docs.


## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/3754

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
