### PR TITLE
Parallelise playwright tests in axe-playwright action

### DIFF
--- a/packages/design-tokens/src/tokens/functional/colors/global.json
+++ b/packages/design-tokens/src/tokens/functional/colors/global.json
@@ -2,121 +2,121 @@
   "color": {
     "success": {
       "fg": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-green-5)",
+        "dark": "var(--base-color-scale-green-3)"
       },
       "emphasis": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-green-4)",
+        "dark": "var(--base-color-scale-green-5)"
       },
       "muted": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "#4bc36b99",
+        "dark": "#2e9e4299"
       },
       "subtle": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-green-0)",
+        "dark": "#2e9e42d9"
       }
     },
     "error": {
       "fg": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-red-5)",
+        "dark": "var(--base-color-scale-red-4)"
       },
       "emphasis": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-red-5)",
+        "dark": "var(--base-color-scale-red-5)"
       },
       "muted": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "#ff878599",
+        "dark": "#f8524999"
       },
       "subtle": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-red-0)",
+        "dark": "#f85249d9"
       }
     },
     "accent": {
       "primary": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-green-5)",
+        "dark": "var(--base-color-scale-green-3)"
       },
       "secondary": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-yellow-5)",
+        "dark": "var(--base-color-scale-yellow-3)"
       }
     },
     "text": {
       "default": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-gray-9)",
+        "dark": "var(--base-color-scale-white-0)"
       },
       "muted": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-gray-6)",
+        "dark": "var(--base-color-scale-gray-3)"
       },
       "subtle": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-gray-5)",
+        "dark": "var(--base-color-scale-gray-4)"
       },
       "onEmphasis": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-white-0)",
+        "dark": "var(--base-color-scale-black-0)"
       }
     },
     "neutral": {
       "emphasisPlus": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-gray-9)",
+        "dark": "var(--base-color-scale-gray-4)"
       },
       "emphasis": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-gray-5)",
+        "dark": "var(--base-color-scale-gray-4)"
       },
       "muted": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "#b7bfc8fe",
+        "dark": "#6e7681fe"
       },
       "subtle": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "#e9edf1fe",
+        "dark": "#6e7681ff"
       }
     },
     "canvas": {
       "default": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-white-0)",
+        "dark": "var(--base-color-scale-black-0)"
       },
       "overlay": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-white-0)",
+        "dark": "var(--base-color-scale-gray-8)"
       },
       "inset": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-gray-0)",
+        "dark": "var(--base-color-scale-black-0)"
       },
       "subtle": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-gray-0)",
+        "dark": "var(--base-color-scale-gray-8)"
       }
     },
     "border": {
       "default": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "var(--base-color-scale-gray-3)",
+        "dark": "var(--base-color-scale-gray-6)"
       },
       "muted": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "#d3d9dffe",
+        "dark": "var(--base-color-scale-gray-7)"
       },
       "subtle": {
-        "value": "hotpink",
-        "dark": "hotpink"
+        "value": "#e9edf1fe",
+        "dark": "var(--base-color-scale-gray-8)"
       }
     },
     "focus": {
-      "value": "hotpink",
-      "dark": "hotpink"
+      "value": "var(--base-color-scale-blue-5)",
+      "dark": "var(--base-color-scale-blue-3)"
     }
   }
 }

--- a/packages/design-tokens/src/tokens/functional/colors/global.json
+++ b/packages/design-tokens/src/tokens/functional/colors/global.json
@@ -2,121 +2,121 @@
   "color": {
     "success": {
       "fg": {
-        "value": "var(--base-color-scale-green-5)",
-        "dark": "var(--base-color-scale-green-3)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "emphasis": {
-        "value": "var(--base-color-scale-green-4)",
-        "dark": "var(--base-color-scale-green-5)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "muted": {
-        "value": "#4bc36b99",
-        "dark": "#2e9e4299"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "subtle": {
-        "value": "var(--base-color-scale-green-0)",
-        "dark": "#2e9e42d9"
+        "value": "hotpink",
+        "dark": "hotpink"
       }
     },
     "error": {
       "fg": {
-        "value": "var(--base-color-scale-red-5)",
-        "dark": "var(--base-color-scale-red-4)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "emphasis": {
-        "value": "var(--base-color-scale-red-5)",
-        "dark": "var(--base-color-scale-red-5)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "muted": {
-        "value": "#ff878599",
-        "dark": "#f8524999"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "subtle": {
-        "value": "var(--base-color-scale-red-0)",
-        "dark": "#f85249d9"
+        "value": "hotpink",
+        "dark": "hotpink"
       }
     },
     "accent": {
       "primary": {
-        "value": "var(--base-color-scale-green-5)",
-        "dark": "var(--base-color-scale-green-3)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "secondary": {
-        "value": "var(--base-color-scale-yellow-5)",
-        "dark": "var(--base-color-scale-yellow-3)"
+        "value": "hotpink",
+        "dark": "hotpink"
       }
     },
     "text": {
       "default": {
-        "value": "var(--base-color-scale-gray-9)",
-        "dark": "var(--base-color-scale-white-0)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "muted": {
-        "value": "var(--base-color-scale-gray-6)",
-        "dark": "var(--base-color-scale-gray-3)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "subtle": {
-        "value": "var(--base-color-scale-gray-5)",
-        "dark": "var(--base-color-scale-gray-4)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "onEmphasis": {
-        "value": "var(--base-color-scale-white-0)",
-        "dark": "var(--base-color-scale-black-0)"
+        "value": "hotpink",
+        "dark": "hotpink"
       }
     },
     "neutral": {
       "emphasisPlus": {
-        "value": "var(--base-color-scale-gray-9)",
-        "dark": "var(--base-color-scale-gray-4)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "emphasis": {
-        "value": "var(--base-color-scale-gray-5)",
-        "dark": "var(--base-color-scale-gray-4)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "muted": {
-        "value": "#b7bfc8fe",
-        "dark": "#6e7681fe"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "subtle": {
-        "value": "#e9edf1fe",
-        "dark": "#6e7681ff"
+        "value": "hotpink",
+        "dark": "hotpink"
       }
     },
     "canvas": {
       "default": {
-        "value": "var(--base-color-scale-white-0)",
-        "dark": "var(--base-color-scale-black-0)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "overlay": {
-        "value": "var(--base-color-scale-white-0)",
-        "dark": "var(--base-color-scale-gray-8)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "inset": {
-        "value": "var(--base-color-scale-gray-0)",
-        "dark": "var(--base-color-scale-black-0)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "subtle": {
-        "value": "var(--base-color-scale-gray-0)",
-        "dark": "var(--base-color-scale-gray-8)"
+        "value": "hotpink",
+        "dark": "hotpink"
       }
     },
     "border": {
       "default": {
-        "value": "var(--base-color-scale-gray-3)",
-        "dark": "var(--base-color-scale-gray-6)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "muted": {
-        "value": "#d3d9dffe",
-        "dark": "var(--base-color-scale-gray-7)"
+        "value": "hotpink",
+        "dark": "hotpink"
       },
       "subtle": {
-        "value": "#e9edf1fe",
-        "dark": "var(--base-color-scale-gray-8)"
+        "value": "hotpink",
+        "dark": "hotpink"
       }
     },
     "focus": {
-      "value": "var(--base-color-scale-blue-5)",
-      "dark": "var(--base-color-scale-blue-3)"
+      "value": "hotpink",
+      "dark": "hotpink"
     }
   }
 }

--- a/packages/e2e/scripts/playwright/axe-clean.spec.ts
+++ b/packages/e2e/scripts/playwright/axe-clean.spec.ts
@@ -115,6 +115,8 @@ const storybookRoutes = Object.values((IndexData as StoryIndex).entries)
     return !testsToSkip.includes(id)
   })
 
+test.describe.configure({mode: 'parallel'})
+
 for (const story of storybookRoutes) {
   // eslint-disable-next-line i18n-text/no-en
   describe(`Web page accessibility test for ${story.name} - ${story.story}`, () => {

--- a/packages/e2e/scripts/playwright/axe-clean.spec.ts
+++ b/packages/e2e/scripts/playwright/axe-clean.spec.ts
@@ -115,7 +115,7 @@ const storybookRoutes = Object.values((IndexData as StoryIndex).entries)
     return !testsToSkip.includes(id)
   })
 
-test.describe.configure({mode: 'parallel'})
+describe.configure({mode: 'parallel'})
 
 for (const story of storybookRoutes) {
   // eslint-disable-next-line i18n-text/no-en


### PR DESCRIPTION
## Summary

Inspired by the recent improvements to our VRT tests, this PR parallelises our axe-playwright tests, used in our UI test / Accessibility action.

| Previous time taken | Time taken now | Improvement |
| --- | --- | --- | 
| 22 mins | 7 mins | **15 mins faster** 🎉 ⚡ |

See the Playwright docs on the change here: https://playwright.dev/docs/api/class-test#test-describe-configure

## Testing

You can see from the checks associated with this PR that the action is completing successfully.

In an earlier commit (f80de414a31178cc0fcb6ded7fff9ef6f320e475) I intentionally triggered axe violations to test that they would still be reported. As you can see from [this run](https://github.com/primer/brand/actions/runs/15461299873/job/43523045254?pr=1040) they were reported successfully.

All of the axe tests run independently in our test suite with no shared state, so it seems reasonable that we should be able to parallelise them without any issues.

## What should reviewers focus on?

- If/when this PR is merged, keep an eye on the UI test / Accessibility action for your next few PRs to make sure it continues to work correctly.

## Steps to test:

1. Run the UI test / Accessibility action



## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/43a44d80-f9c8-486d-9acc-b935d33a2dce)


 </td>
<td valign="top">

![image](https://github.com/user-attachments/assets/cc9b6f6f-ec02-4a30-9fc6-99147abbf244)

</td>
</tr>
</table>
