### PR TITLE
Update release testing checklist

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -34,6 +34,8 @@ Please ensure these items are checked before merging.
     - `/solutions`
     - `/solutions/use-case/`
     - `/solutions/use-case/devops`
+    - `/contentful-lp-tests/flex-example-dark` (requires a flag)
+    - `/contentful-lp-tests/flex-example-light` (requires a flag)
   - [ ] Manually compare production site to local instance for any non-release specific regressions
 
 #### Subdomain sites

--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -16,6 +16,7 @@ Please ensure these items are checked before merging.
         Important: Verify that each workspace package has been updated correctly in their respective `package.json` files
   - [ ] Run development server
   - [ ] Manually verify release-specific bugfixes and/or features on the following pages:
+    - `/home`
     - `/features/copilot`
     - `/features/copilot/tutorials`
     - `/features/preview`


### PR DESCRIPTION
Adding two new items to the release testing checklist. These are kitchen sink pages, and will require the correct Staff flag to access. 

cc. @joshfarrant @danielguillan as PB release conductors
