### PR TITLE
Allow VideoPlayer tooltips to be hovered

### DIFF
--- a/.changeset/heavy-turtles-accept.md
+++ b/.changeset/heavy-turtles-accept.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Tooltips in the `VideoPlayer` component are now hoverable.
+Tooltips in the `VideoPlayer` component now remain briefly visible after the pointer is moved away from the toggle. This small delay improves general usability and helps meet the [WCAG 1.4.13 criterion](https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus) for accessible hover interactions with tooltips.

--- a/.changeset/heavy-turtles-accept.md
+++ b/.changeset/heavy-turtles-accept.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Tooltips in the `VideoPlayer` component are now hoverable.

--- a/packages/react/src/VideoPlayer/VideoPlayer.module.css
+++ b/packages/react/src/VideoPlayer/VideoPlayer.module.css
@@ -183,10 +183,6 @@
   color: var(--brand-videoPlayer-controls-fgColor);
 }
 
-.VideoPlayer__iconControl:hover .VideoPlayer__tooltip {
-  opacity: 1;
-}
-
 .VideoPlayer__seek {
   flex: 1;
   display: flex;
@@ -238,10 +234,6 @@
   height: var(--brand-VideoPlayer-range-height);
   background-color: var(--brand-videoPlayer-range-bgColor-default);
   border-radius: var(--brand-VideoPlayer-range-borderRadius);
-}
-
-.VideoPlayer__range:hover .VideoPlayer__tooltip {
-  opacity: 1;
 }
 
 .VideoPlayer__rangeInput {
@@ -323,10 +315,8 @@
   width: var(--base-size-8);
   height: var(--base-size-8);
   margin-bottom: var(--base-size-16);
-  pointer-events: none;
   opacity: 0;
   transform: translate(-50%, 50%);
-  transition: transform var(--brand-animation-duration-default) var(--brand-animation-easing-default);
 }
 
 .VideoPlayer__tooltip::before {

--- a/packages/react/src/VideoPlayer/VideoPlayer.test.tsx
+++ b/packages/react/src/VideoPlayer/VideoPlayer.test.tsx
@@ -210,4 +210,33 @@ describe('VideoPlayer', () => {
 
     expect(queryByLabelText('GitHub logo')).not.toBeInTheDocument()
   })
+
+  it('keeps tooltips visible for 100ms after the user stops hovering over the associated control', async () => {
+    const user = userEvent.setup()
+
+    const {getByRole, getByText} = render(
+      <VideoPlayer poster="/example-poster.jpg" title="test video">
+        <VideoPlayer.Source src="/example.mp4" />
+        <VideoPlayer.Track src="/example.vtt" default kind="subtitles" srcLang="en" label="English" />
+      </VideoPlayer>,
+    )
+
+    const captionsButton = getByRole('button', {name: 'Enable captions'})
+
+    await user.hover(captionsButton)
+
+    const tooltip = getByText('Enable captions')
+
+    expect(tooltip).toBeVisible()
+
+    await user.unhover(captionsButton)
+    expect(tooltip).toBeVisible()
+
+    await waitFor(
+      () => {
+        expect(tooltip).not.toBeVisible()
+      },
+      {timeout: 100},
+    )
+  })
 })

--- a/packages/react/src/VideoPlayer/components/VideoTooltip/VideoTooltip.tsx
+++ b/packages/react/src/VideoPlayer/components/VideoTooltip/VideoTooltip.tsx
@@ -9,6 +9,7 @@ type VideoTooltipProps = HTMLAttributes<HTMLDivElement>
 export const VideoTooltip = ({children, className, ...rest}: VideoTooltipProps) => {
   const tooltipRef = useRef<HTMLDivElement>(null)
   const [hasFocus, setHasFocus] = useState(false)
+  const mouseenterTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
     const tooltip = tooltipRef.current
@@ -34,11 +35,30 @@ export const VideoTooltip = ({children, className, ...rest}: VideoTooltipProps) 
       setHasFocus(false)
     }
 
+    const onMouseEnterTooltip = () => {
+      if (mouseenterTimeoutRef.current) {
+        clearTimeout(mouseenterTimeoutRef.current)
+      }
+      setHasFocus(true)
+    }
+
+    const onMouseLeaveTooltip = () => {
+      if (mouseenterTimeoutRef.current) {
+        clearTimeout(mouseenterTimeoutRef.current)
+      }
+
+      mouseenterTimeoutRef.current = setTimeout(() => {
+        setHasFocus(false)
+      }, 100)
+    }
+
     parent.addEventListener('focus', checkFocus)
     parent.addEventListener('blur', checkFocus)
     parent.addEventListener('focusin', checkFocus)
     parent.addEventListener('focusout', checkFocus)
     parent.addEventListener('click', onClick)
+    parent.addEventListener('mouseenter', onMouseEnterTooltip)
+    parent.addEventListener('mouseleave', onMouseLeaveTooltip)
     window.addEventListener('keydown', handleKeyDown)
 
     return () => {
@@ -47,6 +67,8 @@ export const VideoTooltip = ({children, className, ...rest}: VideoTooltipProps) 
       parent.removeEventListener('focusin', checkFocus)
       parent.removeEventListener('focusout', checkFocus)
       parent.removeEventListener('click', onClick)
+      parent.removeEventListener('mouseenter', onMouseEnterTooltip)
+      parent.removeEventListener('mouseleave', onMouseLeaveTooltip)
       window.removeEventListener('keydown', handleKeyDown)
     }
   }, [tooltipRef])
@@ -57,11 +79,13 @@ export const VideoTooltip = ({children, className, ...rest}: VideoTooltipProps) 
       ref={tooltipRef}
       {...rest}
     >
-      <span className={styles.VideoPlayer__tooltipContent}>
-        <Text className={styles.VideoPlayer__tooltipText} weight="medium">
-          {children}
-        </Text>
-      </span>
+      {hasFocus ? (
+        <span className={styles.VideoPlayer__tooltipContent}>
+          <Text className={styles.VideoPlayer__tooltipText} weight="medium">
+            {children}
+          </Text>
+        </span>
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/VideoPlayer/components/VideoTooltip/VideoTooltip.tsx
+++ b/packages/react/src/VideoPlayer/components/VideoTooltip/VideoTooltip.tsx
@@ -85,7 +85,9 @@ export const VideoTooltip = ({children, className, ...rest}: VideoTooltipProps) 
             {children}
           </Text>
         </span>
-      ) : null}
+      ) : (
+        <span className="visually-hidden">{children}</span>
+      )}
     </div>
   )
 }

--- a/packages/react/src/VideoPlayer/components/VideoTooltip/VideoTooltip.tsx
+++ b/packages/react/src/VideoPlayer/components/VideoTooltip/VideoTooltip.tsx
@@ -9,7 +9,7 @@ type VideoTooltipProps = HTMLAttributes<HTMLDivElement>
 export const VideoTooltip = ({children, className, ...rest}: VideoTooltipProps) => {
   const tooltipRef = useRef<HTMLDivElement>(null)
   const [hasFocus, setHasFocus] = useState(false)
-  const mouseenterTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const mouseenterTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     const tooltip = tooltipRef.current

--- a/packages/react/src/VideoPlayer/components/VideoTooltip/VideoTooltip.tsx
+++ b/packages/react/src/VideoPlayer/components/VideoTooltip/VideoTooltip.tsx
@@ -19,6 +19,13 @@ export const VideoTooltip = ({children, className, ...rest}: VideoTooltipProps) 
       return
     }
 
+    const clearTimeoutAndRef = () => {
+      if (mouseenterTimeoutRef.current) {
+        clearTimeout(mouseenterTimeoutRef.current)
+        mouseenterTimeoutRef.current = null
+      }
+    }
+
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         setHasFocus(false)
@@ -36,16 +43,12 @@ export const VideoTooltip = ({children, className, ...rest}: VideoTooltipProps) 
     }
 
     const onMouseEnterTooltip = () => {
-      if (mouseenterTimeoutRef.current) {
-        clearTimeout(mouseenterTimeoutRef.current)
-      }
+      clearTimeoutAndRef()
       setHasFocus(true)
     }
 
     const onMouseLeaveTooltip = () => {
-      if (mouseenterTimeoutRef.current) {
-        clearTimeout(mouseenterTimeoutRef.current)
-      }
+      clearTimeoutAndRef()
 
       mouseenterTimeoutRef.current = setTimeout(() => {
         setHasFocus(false)
@@ -62,6 +65,8 @@ export const VideoTooltip = ({children, className, ...rest}: VideoTooltipProps) 
     window.addEventListener('keydown', handleKeyDown)
 
     return () => {
+      clearTimeoutAndRef()
+
       parent.removeEventListener('focus', checkFocus)
       parent.removeEventListener('blur', checkFocus)
       parent.removeEventListener('focusin', checkFocus)


### PR DESCRIPTION
## Summary

`VideoPlayer` tooltips no longer dismiss immediately and instead allow a small window of time in which the cursor can be moved from the trigger to the tooltip, at which point the tooltip will remain visible until the cursor leaves the tooltip.


## What should reviewers focus on?

- Check that the hovering works as expected

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/3802

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

