### PR TITLE
Trap focus inside SubNav component when expanded on narrow viewports

### DIFF
--- a/.changeset/flat-pigs-dream.md
+++ b/.changeset/flat-pigs-dream.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+The `SubNav` component now traps focus inside the expanded menu on narrow viewports.

--- a/packages/react/src/SubNav/SubNav.features.stories.tsx
+++ b/packages/react/src/SubNav/SubNav.features.stories.tsx
@@ -13,6 +13,7 @@ import {RedlineBackground} from '../component-helpers'
 import {Stack} from '../Stack'
 import {expect, userEvent, within} from '@storybook/test'
 import {Button} from '../Button'
+import {waitFor} from '@testing-library/dom'
 
 export default {
   title: 'Components/SubNav/Features',
@@ -382,4 +383,74 @@ export const ForwardedRefs = () => {
       </Box>
     </>
   )
+}
+
+export const KeyboardNavigation = args => <NarrowDropdownVariant {...args} />
+
+KeyboardNavigation.parameters = {
+  layout: 'fullscreen',
+  viewport: {
+    defaultViewport: 'iphonex',
+  },
+}
+KeyboardNavigation.play = async ({canvasElement}) => {
+  const {getByRole} = within(canvasElement)
+
+  const expandButton = getByRole('button', {name: 'Navigation menu. Current page: Copilot'})
+  await userEvent.click(expandButton)
+  expect(expandButton).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Actions'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Packages'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Security'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Codespaces'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Copilot'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Copilot feature page one'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Copilot feature page two'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Copilot feature page three'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Copilot feature page four'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Code review'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Search'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Issues'})).toHaveFocus()
+
+  await userEvent.tab()
+  expect(getByRole('link', {name: 'Discussions'})).toHaveFocus()
+
+  await userEvent.tab()
+  // We have to wait here because the focus trap we're using takes a moment to update the focus
+  waitFor(() => {
+    expect(getByRole('link', {name: 'Features'})).toHaveFocus()
+  })
+
+  await userEvent.tab()
+  expect(expandButton).toHaveFocus()
+
+  await userEvent.tab({shift: true})
+  expect(getByRole('link', {name: 'Features'})).toHaveFocus()
+
+  await userEvent.tab({shift: true})
+  expect(getByRole('link', {name: 'Discussions'})).toHaveFocus()
 }

--- a/packages/react/src/SubNav/SubNav.tsx
+++ b/packages/react/src/SubNav/SubNav.tsx
@@ -22,6 +22,7 @@ import {ChevronDownIcon, ChevronUpIcon} from '@primer/octicons-react'
 import {useId} from '../hooks/useId'
 import {useKeyboardEscape} from '../hooks/useKeyboardEscape'
 import {useOnClickOutside} from '../hooks/useOnClickOutside'
+import {useFocusTrap} from '../hooks/useFocusTrap'
 import {useProvidedRefOrCreate} from '../hooks/useRef'
 import {useContainsFocus} from './useContainsFocus'
 
@@ -170,6 +171,8 @@ const _SubNavRoot = memo(
       const [hasAnchoredNav, setHasAnchoredNav] = useState(false)
 
       const {isLarge} = useWindowSize()
+
+      useFocusTrap({containerRef: innerRootRef, disabled: !isOpenAtNarrow})
 
       const childrenArr = Children.toArray(children)
 


### PR DESCRIPTION
## Summary

Traps the focus inside the SubNav component when expanded on narrow viewports.

## What should reviewers focus on?

- Check that focus is trapped inside the expanded menu on viewports
- Check that focus moves as expected in other scenarios

## Steps to test:

1. Open a SubNav in the docs or Storybook (on a narrow viewport)
1. Using the keyboard, expand the collapsed menu
1. Tab through the menu and note that keyboard focus should remain trapped within the menu.

## Supporting resources (related issues, external links, etc):

- Closes https://github.com/github/primer/issues/3796

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->

</td>
</tr>
</table>
