### PR TITLE
QA fixes for next docs: previews and prop values

### DIFF
--- a/apps/next-docs/content/components/CTABanner/react.mdx
+++ b/apps/next-docs/content/components/CTABanner/react.mdx
@@ -160,7 +160,7 @@ The shadow can be removed using the `hasShadow` prop. This will render the compo
 
 The default shadow colors can be customized through their respective CSS variables.
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const designTokenOverrides = `
   .custom-colors[data-color-mode='dark'] {

--- a/apps/next-docs/content/components/ComparisonTable/index.mdx
+++ b/apps/next-docs/content/components/ComparisonTable/index.mdx
@@ -131,7 +131,7 @@ The default colors can be customized through dedicated CSS variables.
 | `--brand-ComparisonTable-featured-color-start` | `--base-color-scale-pink-4`   |
 | `--brand-ComparisonTable-featured-color-end`   | `--base-color-scale-indigo-5` |
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const designTokenOverrides = `
   .custom-colors[data-color-mode='dark'] {
@@ -221,7 +221,7 @@ Comparison tables are typically generated using data from an API or content mana
 
 `ComparisonTable` accepts `ReactNode` as a valid child, to facilitate conditional and dynamic rendering.
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const comparisonTableData = {
     heading: 'GitHub vs Jenkins',

--- a/apps/next-docs/content/components/FAQ/react.mdx
+++ b/apps/next-docs/content/components/FAQ/react.mdx
@@ -191,7 +191,7 @@ Use `tabAttributes` to add arbitrary attributes to the tabs. This can be useful 
 
 ### Rendering with dynamic data
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const fixtureData = [
     {
@@ -297,7 +297,7 @@ Available options for `toggleColor` are:
 
 [See Storybook for all color options](https://primer.style/brand/storybook/?path=/story/components-accordion--toggle-colors).
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const customStyles = `
   .custom-heading {

--- a/apps/next-docs/content/components/FAQ/react.tsx
+++ b/apps/next-docs/content/components/FAQ/react.tsx
@@ -4,25 +4,24 @@ import {HeadingTags} from '../../../../../packages/react/src/Heading/Heading'
 import {AccordionToggleColors} from '../../../../../packages/react/src/Accordion/Accordion'
 
 export const FAQChildrenProp = () => (
-  <PropTableValues
-    values={['FAQ.Heading (#faq-heading)', 'FAQ.Subheading (#faq-subheading)', 'FAQ.Item (#faq-item)']}
-    addLineBreaks
-  />
+  <PropTableValues values={['FAQ.Heading', 'FAQ.Subheading', 'FAQ.Item']} addLineBreaks commaSeparated />
 )
 
-export const FAQHeadingAlignProp = () => <PropTableValues values={['start', 'center']} addLineBreaks />
-export const FAQHeadingSizeProp = () => <PropTableValues values={['medium', 'large']} addLineBreaks />
-export const FAQHeadingAsProp = () => <PropTableValues values={[...HeadingTags]} addLineBreaks />
-export const FAQHeadingToggleColorProp = () => <PropTableValues values={[...AccordionToggleColors]} addLineBreaks />
-export const FAQSubheadingAsProp = () => <PropTableValues values={HeadingTags.slice(1)} addLineBreaks />
-export const FAQQuestionAsProp = () => <PropTableValues values={HeadingTags.slice(1)} addLineBreaks />
+export const FAQHeadingAlignProp = () => <PropTableValues values={['start', 'center']} addLineBreaks commaSeparated />
+export const FAQHeadingSizeProp = () => <PropTableValues values={['medium', 'large']} addLineBreaks commaSeparated />
+export const FAQHeadingAsProp = () => <PropTableValues values={[...HeadingTags]} addLineBreaks commaSeparated />
+export const FAQHeadingToggleColorProp = () => (
+  <PropTableValues values={[...AccordionToggleColors]} addLineBreaks commaSeparated />
+)
+export const FAQSubheadingAsProp = () => <PropTableValues values={HeadingTags.slice(1)} addLineBreaks commaSeparated />
+export const FAQQuestionAsProp = () => <PropTableValues values={HeadingTags.slice(1)} addLineBreaks commaSeparated />
 
 export const FAQGroupChildrenProp = () => (
-  <PropTableValues values={['FAQ (#faq-required)', 'FAQGroup.Heading (#faqgroup-heading)']} addLineBreaks />
+  <PropTableValues values={['FAQ', 'FAQGroup.Heading']} addLineBreaks commaSeparated />
 )
 
 export const FAQItemChildrenProp = () => (
-  <PropTableValues values={['FAQ.Question (#faq-question)', 'FAQ.Answer (#faq-answer)']} addLineBreaks />
+  <PropTableValues values={['FAQ.Question', 'FAQ.Answer']} addLineBreaks commaSeparated />
 )
 
-export const FAQGroupHeadingAsProp = () => <PropTableValues values={[...HeadingTags]} addLineBreaks />
+export const FAQGroupHeadingAsProp = () => <PropTableValues values={[...HeadingTags]} addLineBreaks commaSeparated />

--- a/apps/next-docs/content/components/Pagination/index.mdx
+++ b/apps/next-docs/content/components/Pagination/index.mdx
@@ -20,7 +20,7 @@ import {Pagination} from '@primer/react-brand'
 
 ### Default
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const [currentPage, setCurrentPage] = React.useState(5)
   const totalPages = 10

--- a/apps/next-docs/content/components/SubdomainNavBar/index.mdx
+++ b/apps/next-docs/content/components/SubdomainNavBar/index.mdx
@@ -48,7 +48,7 @@ Please refer to our [Storybook examples](https://primer.style/brand/storybook/?p
 
 `SubdomainNavBar` offers an optional search form control. The form can operate in both `onSubmit` and `onChange` modes, with the latter facilitating inline results to appear.
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const inputRef = React.useRef(null)
   const [searchResults, setSearchResults] = React.useState([])
@@ -96,19 +96,17 @@ const App = () => {
   }
 
   return (
-    <div style={{position: 'relative', overflowX: 'scroll'}}>
-      <SubdomainNavBar title="Subdomain" fixed={false}>
-        <SubdomainNavBar.Link href="#collections">Collections</SubdomainNavBar.Link>
-        <SubdomainNavBar.Link href="#topics">Topics</SubdomainNavBar.Link>
-        <SubdomainNavBar.Search
-          ref={inputRef}
-          searchTerm={searchTerm}
-          onSubmit={handleSubmit}
-          onChange={handleChange}
-          searchResults={searchResults}
-        />
-      </SubdomainNavBar>
-    </div>
+    <SubdomainNavBar title="Subdomain" fixed={false}>
+      <SubdomainNavBar.Link href="#collections">Collections</SubdomainNavBar.Link>
+      <SubdomainNavBar.Link href="#topics">Topics</SubdomainNavBar.Link>
+      <SubdomainNavBar.Search
+        ref={inputRef}
+        searchTerm={searchTerm}
+        onSubmit={handleSubmit}
+        onChange={handleChange}
+        searchResults={searchResults}
+      />
+    </SubdomainNavBar>
   )
 }
 

--- a/apps/next-docs/content/components/VideoPlayer/index.mdx
+++ b/apps/next-docs/content/components/VideoPlayer/index.mdx
@@ -123,7 +123,7 @@ The `VideoPlayer` component exposes a `useVideo` hook that can be used to contro
 
 Full documentation for the `useVideo` hook can be found [below](#usevideo-context).
 
-```javascript live noinline
+```jsx filename="noinline"
 const CustomVideoPlayer = () => {
   const {isPlaying, togglePlaying, seek} = useVideo()
 

--- a/apps/next-docs/content/forms/FormControl/index.mdx
+++ b/apps/next-docs/content/forms/FormControl/index.mdx
@@ -227,7 +227,7 @@ More information on form validation best practices can be found in the [Primer U
 
 Try changing the input value to `monalisa` and submitting the form to show the `success` state.
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const inputRef = React.useRef(null)
   const [value, setValue] = React.useState('mona lisa')
@@ -331,7 +331,7 @@ When marking a field as required, it is recommended to also provide a correspond
 
 `FormControl` inputs can be used in [uncontrolled mode](https://reactjs.org/docs/uncontrolled-components.html) by forwarding a `ref` to the underlying element.
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const inputRef = React.useRef(null)
 

--- a/apps/next-docs/content/forms/Select/index.mdx
+++ b/apps/next-docs/content/forms/Select/index.mdx
@@ -161,7 +161,7 @@ Pass the `required` prop to ensure that the input field must be filled out befor
 
 `Select` inputs can be used in [uncontrolled mode](https://reactjs.org/docs/uncontrolled-components.html) by forwarding a `ref` to the underlying element.
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const selectRef = React.useRef(null)
 

--- a/apps/next-docs/content/forms/TextArea/index.mdx
+++ b/apps/next-docs/content/forms/TextArea/index.mdx
@@ -26,7 +26,7 @@ Use the [FormControl](./FormControl) component to render a Textarea with a corre
 
 ### Controlled mode
 
-```javascript live noinline
+```jsx filename="noinline"
 const TextareaExample = () => {
   // Running in controlled mode (recommended)
   const [value, setValue] = React.useState('This value was initially set through state.')
@@ -43,7 +43,7 @@ render(<TextareaExample />)
 
 ### Uncontrolled mode
 
-```javascript live noinline
+```jsx filename="noinline"
 const TextareaExample = () => {
   const ref = React.useRef()
 

--- a/apps/next-docs/content/forms/TextInput/index.mdx
+++ b/apps/next-docs/content/forms/TextInput/index.mdx
@@ -157,7 +157,7 @@ Pass the `required` prop to ensure that the input field must be filled out befor
 
 `TextInput` inputs can be used in [uncontrolled mode](https://reactjs.org/docs/uncontrolled-components.html) by forwarding a `ref` to the underlying element.
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const inputRef = React.useRef(null)
 

--- a/apps/next-docs/content/introduction/theming.mdx
+++ b/apps/next-docs/content/introduction/theming.mdx
@@ -49,7 +49,7 @@ The `ThemeProvider` applies the data attributes and handles state-changes intern
 
 The following example demonstrates how `light` mode will enable by default, and can also be changed to `dark` declaratively:
 
-```javascript live noinline
+```jsx filename="noinline"
 const Example = () => {
   const [colorMode, setColorMode] = React.useState()
 

--- a/apps/next-docs/content/layout/Stack/react.mdx
+++ b/apps/next-docs/content/layout/Stack/react.mdx
@@ -45,7 +45,7 @@ Many `Stack` props - including `direction` - accept both `string` and `Object` v
 
 Use the playground below to experiment with the various options.
 
-```javascript live noinline
+```jsx filename="noinline"
 const App = () => {
   const [alignItemsValue, setAlignItemsValue] = React.useState('center')
   const [justifyContentValue, setJustifyContentValue] = React.useState('space-between')
@@ -54,7 +54,7 @@ const App = () => {
   const handleCrossAxisChange = event => setAlignItemsValue(event.target.value)
 
   return (
-    <>
+    <div>
       <Stack
         direction="horizontal"
         alignItems={alignItemsValue}
@@ -100,7 +100,7 @@ const App = () => {
           </Select>
         </FormControl>
       </Stack>
-    </>
+    </div>
   )
 }
 

--- a/apps/next-docs/content/typography/Text/react.mdx
+++ b/apps/next-docs/content/typography/Text/react.mdx
@@ -34,24 +34,24 @@ import {Text} from '@primer/react-brand'
 ### Scale
 
 ```jsx live
-<>
+<div>
   {TextSizes.map(size => (
     <Text key={size} size={size} as="p">
       Text {size}
     </Text>
   ))}
-</>
+</div>
 ```
 
 ### Variants
 
 ```jsx live
-<>
+<div>
   <Text as="p">With GitHub Copilot, you’re always in charge.</Text>
   <Text as="p" variant="muted">
     With GitHub Copilot, you’re always in charge.
   </Text>
-</>
+</div>
 ```
 
 ### Alignment
@@ -86,7 +86,7 @@ The recommended text weight is automatically applied through Text based on its p
 Use the `weight` prop to adjust the default visual appearance if required.
 
 ```jsx live
-<>
+<div>
   <Text as="p" weight="heavy">
     heavy
   </Text>
@@ -122,7 +122,7 @@ Use the `weight` prop to adjust the default visual appearance if required.
   >
     Responsive
   </Text>
-</>
+</div>
 ```
 
 ## Component props

--- a/apps/next-docs/package.json
+++ b/apps/next-docs/package.json
@@ -31,7 +31,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@primer/doctocat-nextjs": "0.5.4",
+    "@primer/doctocat-nextjs": "0.5.5",
     "@primer/octicons-react": "19.15.1",
     "next": "15.2.4",
     "react": ">=17 <= 18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
       "version": "0.56.0",
       "license": "MIT",
       "dependencies": {
-        "@primer/doctocat-nextjs": "0.5.5-rc.5575e44",
+        "@primer/doctocat-nextjs": "0.5.5",
         "@primer/octicons-react": "19.15.1",
         "next": "15.2.4",
         "react": ">=17 <= 18",
@@ -6818,9 +6818,9 @@
       "link": true
     },
     "node_modules/@primer/doctocat-nextjs": {
-      "version": "0.5.5-rc.5575e44",
-      "resolved": "https://registry.npmjs.org/@primer/doctocat-nextjs/-/doctocat-nextjs-0.5.5-rc.5575e44.tgz",
-      "integrity": "sha512-eoMIbBTelXq4b1jbqNWKRc75Fjw4qzd5jQZvojbW/ckS1wtPFgEe5GuGbjCo2bzxaVf1OwMUMlf3cDQoBWyj3A==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@primer/doctocat-nextjs/-/doctocat-nextjs-0.5.5.tgz",
+      "integrity": "sha512-yNyPY8bhIlQPksgPanfvjOXG6rr9pKkmMgcDgvxibpWMdj6uAy1AaIDTpdaYeQ7rqHIp9Gp3acopChHJCPUj8A==",
       "license": "MIT",
       "dependencies": {
         "@next/mdx": "15.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
       "version": "0.56.0",
       "license": "MIT",
       "dependencies": {
-        "@primer/doctocat-nextjs": "0.5.4",
+        "@primer/doctocat-nextjs": "0.5.5-rc.5575e44",
         "@primer/octicons-react": "19.15.1",
         "next": "15.2.4",
         "react": ">=17 <= 18",
@@ -6818,9 +6818,9 @@
       "link": true
     },
     "node_modules/@primer/doctocat-nextjs": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@primer/doctocat-nextjs/-/doctocat-nextjs-0.5.4.tgz",
-      "integrity": "sha512-r3yJoPh8LJRogNaT8dKz8aqGBzQP9LLrkR+W36qGJqOKC9EeBM2aTj8Hshe1CcjINLUCZlLIV6qKiuxt7ToNFg==",
+      "version": "0.5.5-rc.5575e44",
+      "resolved": "https://registry.npmjs.org/@primer/doctocat-nextjs/-/doctocat-nextjs-0.5.5-rc.5575e44.tgz",
+      "integrity": "sha512-eoMIbBTelXq4b1jbqNWKRc75Fjw4qzd5jQZvojbW/ckS1wtPFgEe5GuGbjCo2bzxaVf1OwMUMlf3cDQoBWyj3A==",
       "license": "MIT",
       "dependencies": {
         "@next/mdx": "15.2.4",


### PR DESCRIPTION
## Summary

Various fixes to broken documentation pages on Next site.

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- updates javascript code fence blocks
- adds some better formatting to prop tables (more to come later)
- Use `<div>` to prevent default horizontal flex ordering in previews, where they should be stacked vertically

## Screenshots:

Example of the many fixes to code blocks

<table>
<tr>
<th> Before (static)</th> <th> After (editable)</th>
</tr>
<tr>
<td valign="top">

<!-- Insert "before" screenshot here -->
![Screenshot 2025-06-26 at 12 04 10](https://github.com/user-attachments/assets/4e3e67ac-236d-4759-b1a9-3eb3d25d8e2d)

 </td>
<td valign="top">

<!-- Insert "after" screenshot here -->
![Screenshot 2025-06-26 at 12 04 16](https://github.com/user-attachments/assets/eeaeb066-d9b5-410b-b857-57c98f9a4d0d)

</td>
</tr>
</table>
