### PR TITLE
Add forward slash to next doc external links for primer.style

### DIFF
--- a/apps/next-docs/app/layout.tsx
+++ b/apps/next-docs/app/layout.tsx
@@ -20,20 +20,20 @@ type ThemeProps = Parameters<typeof Theme>[0]
 
 const headerLinks: ThemeProps['headerLinks'] = [
   {
-    href: 'https://primer.style/product',
+    href: 'https://primer.style/product/',
     title: 'Product UI',
   },
   {
-    href: 'https://primer.style/brand',
+    href: 'https://primer.style/brand/',
     title: 'Brand UI',
     isActive: true,
   },
   {
-    href: 'https://primer.style/octicons',
+    href: 'https://primer.style/octicons/',
     title: 'Octicons',
   },
   {
-    href: 'https://primer.style/accessibility',
+    href: 'https://primer.style/accessibility/',
     title: 'Accessibility',
   },
   {


### PR DESCRIPTION
## Summary

Resolves https://github.com/github/primer/issues/5379

Fixes bug where lack of trailing slash on top nav bar links is causing the URL rewrite to fail on the primer.style host. This fixes that by manually adding trailing slash.

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Go to preview URL, and click on any of the top bar external links like Product UI
1. Observe that the correct destination is loaded, instead of the primer.style homepage
