### PR TITLE
Fix bug where FAQGroup could throw an error if the grandchild was null

### DIFF
--- a/packages/react/src/FAQ/FAQ.tsx
+++ b/packages/react/src/FAQ/FAQ.tsx
@@ -75,10 +75,14 @@ const FAQRoot = forwardRef<HTMLElement, FAQRootProps>(({children, style, animate
           // If there is a subheading, ensure that the FAQ.Question is rendered as a h5
           if (hasSubheading && child.type === FAQ.Item) {
             const grandChildren = React.Children.map(child.props.children, grandChild => {
+              if (!React.isValidElement(grandChild) || typeof grandChild.type === 'string') {
+                return grandChild
+              }
+
               if (grandChild.type === FAQ.Question) {
                 return React.cloneElement(grandChild as React.ReactElement, {
                   as: 'h5',
-                  ...grandChild.props,
+                  ...(grandChild as React.ReactElement).props,
                 })
               }
               return grandChild

--- a/packages/react/src/FAQ/FAQGroup.test.tsx
+++ b/packages/react/src/FAQ/FAQGroup.test.tsx
@@ -182,4 +182,30 @@ describe('FAQGroup', () => {
       expect(faqHeading).toBeInTheDocument()
     }
   })
+
+  it('does not throw an error if an FAQGroup contains an FAQ which contains a fragment wrapping a falsey value', () => {
+    const {getByTestId} = render(
+      <FAQGroup data-testid="root">
+        <FAQGroup.Heading>Frequently asked questions</FAQGroup.Heading>
+        {testData.map((group, index) => (
+          <FAQ key={index}>
+            <FAQ.Heading>{group.heading}</FAQ.Heading>
+            <>
+              {false}
+              {group.faqs.map((faq, childIndex) => (
+                <FAQ.Item key={childIndex}>
+                  <FAQ.Question>{faq.question}</FAQ.Question>
+                  <FAQ.Answer>
+                    <p>{faq.answer}</p>
+                  </FAQ.Answer>
+                </FAQ.Item>
+              ))}
+            </>
+          </FAQ>
+        ))}
+      </FAQGroup>,
+    )
+
+    expect(getByTestId('root')).toBeInTheDocument()
+  })
 })

--- a/packages/react/src/FAQ/FAQGroup.tsx
+++ b/packages/react/src/FAQ/FAQGroup.tsx
@@ -113,10 +113,14 @@ function _FAQGroup({children, id, defaultSelectedIndex = 0, tabAttributes, ...re
 
         // Make sure that the FAQ.Question is rendered as a h5
         const grandChildren = React.Children.map(child.props.children, grandChild => {
+          if (!React.isValidElement(grandChild) || typeof grandChild.type === 'string') {
+            return grandChild
+          }
+
           if (grandChild.type === FAQ.Question) {
             return React.cloneElement(grandChild as React.ReactElement, {
               as: 'h5',
-              ...grandChild.props,
+              ...(grandChild as React.ReactElement).props,
             })
           }
           return grandChild


### PR DESCRIPTION
## Summary

In some circumstances (for example on `/features/copilot`) the FAQGroup could throw an error and not render.

This PR adds a bit of defensive code to ensure that the FAQGroup can handle null children gracefully.

## What should reviewers focus on?

-
-

## Steps to test:

1.
1.
1.

## Supporting resources (related issues, external links, etc):

-
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
