### PR TITLE
Update docs site title to "Primer"

### DIFF
--- a/.changeset/selfish-squids-repair.md
+++ b/.changeset/selfish-squids-repair.md
@@ -1,0 +1,5 @@
+---
+'@primer/brand-docs': patch
+---
+
+Updated documentation site title to "Primer"

--- a/apps/next-docs/.env
+++ b/apps/next-docs/.env
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_SITE_TITLE = Brand UI
+NEXT_PUBLIC_SITE_TITLE = Primer
 NEXT_PUBLIC_REPO = https://github.com/primer/brand
 NEXT_PUBLIC_REPO_SRC_PATH = app/next-docs
 NEXT_PUBLIC_PATH_PREFIX = 

--- a/apps/next-docs/content/components/Breadcrumbs/index.mdx
+++ b/apps/next-docs/content/components/Breadcrumbs/index.mdx
@@ -8,8 +8,6 @@ thumbnail: '/images/thumbnails/breadcrumbs-thumbnail.png'
 thumbnail_darkMode: '/images/thumbnails/breadcrumbs-thumbnail-dark.png'
 ---
 
----
-
 import anatomy from './images/anatomy.png'
 import variants from './images/variants.png'
 import doOverflow from './images/do-overflow.png'


### PR DESCRIPTION
## Summary

Updates the docs site title to "Primer" instead of "Brand UI". Fixes a double separator issue in Breadcrumbs docs.

| Before | After |
|--------|--------|
| ![screenshot-OthzpARv-000301@2x](https://github.com/user-attachments/assets/5704da19-286f-4a51-855b-9e54160a481b) | ![screenshot-hEJSRKCH-000302@2x](https://github.com/user-attachments/assets/72425dc1-d849-4de2-987c-d869d288e4a6)  | 
