### PR TITLE
Support functional refs in Checkbox and Radio components

### DIFF
--- a/.changeset/tender-wasps-float.md
+++ b/.changeset/tender-wasps-float.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed an issue where passing a functional ref to `Checkbox` or `Radio` components would prevent clicks from toggling the checked state. These components now correctly support both `RefObject` and callback refs.

--- a/packages/react/src/forms/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/forms/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,95 @@
+import React, {render, cleanup} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import {toHaveNoViolations} from 'jest-axe'
+
+import {Checkbox} from '../Checkbox'
+import {FormControl} from '../FormControl'
+
+expect.extend(toHaveNoViolations)
+
+describe('Checkbox', () => {
+  afterEach(cleanup)
+
+  it('renders a checkbox correctly into the document', () => {
+    const {getByRole} = render(
+      <FormControl>
+        <FormControl.Label>Opt in</FormControl.Label>
+        <Checkbox value="one" defaultChecked />
+      </FormControl>,
+    )
+
+    expect(getByRole('checkbox', {name: 'Opt in'})).toBeInTheDocument()
+  })
+
+  it('toggles the checkbox when clicked', async () => {
+    const user = userEvent.setup()
+
+    const {getByRole} = render(
+      <FormControl>
+        <FormControl.Label>Opt in</FormControl.Label>
+        <Checkbox value="one" defaultChecked />
+      </FormControl>,
+    )
+
+    const checkbox = getByRole('checkbox', {name: 'Opt in'})
+
+    expect(checkbox).toBeChecked()
+
+    await user.click(checkbox)
+    expect(checkbox).not.toBeChecked()
+
+    await user.click(checkbox)
+    expect(checkbox).toBeChecked()
+  })
+
+  it('toggles the checkbox when the associated span is clicked', async () => {
+    const user = userEvent.setup()
+
+    const {getByRole, container} = render(
+      <FormControl>
+        <FormControl.Label>Opt in</FormControl.Label>
+        <Checkbox value="one" defaultChecked />
+      </FormControl>,
+    )
+
+    const checkbox = getByRole('checkbox', {name: 'Opt in'})
+
+    const span = container.querySelector('span.Checkbox') as HTMLSpanElement
+    expect(span).toBeInTheDocument()
+
+    expect(checkbox).toBeChecked()
+
+    await user.click(span)
+    expect(checkbox).not.toBeChecked()
+
+    await user.click(span)
+    expect(checkbox).toBeChecked()
+  })
+
+  it('toggles the checkbox when the associated span is clicked and a functional ref is passed', async () => {
+    const user = userEvent.setup()
+    const mockRef = jest.fn()
+
+    const {getByRole, container} = render(
+      <FormControl>
+        <FormControl.Label>Opt in</FormControl.Label>
+        <Checkbox value="one" defaultChecked ref={mockRef} />
+      </FormControl>,
+    )
+
+    const checkbox = getByRole('checkbox', {name: 'Opt in'})
+    expect(mockRef).toHaveBeenCalledWith(checkbox)
+
+    const span = container.querySelector('span.Checkbox') as HTMLSpanElement
+    expect(span).toBeInTheDocument()
+
+    expect(checkbox).toBeChecked()
+
+    await user.click(span)
+    expect(checkbox).not.toBeChecked()
+
+    await user.click(span)
+    expect(checkbox).toBeChecked()
+  })
+})

--- a/packages/react/src/forms/Checkbox/Checkbox.tsx
+++ b/packages/react/src/forms/Checkbox/Checkbox.tsx
@@ -1,13 +1,13 @@
-import React, {forwardRef, useCallback, type InputHTMLAttributes, type ReactElement, type RefObject} from 'react'
+import React, {forwardRef, useCallback, useRef, type InputHTMLAttributes, type ReactElement} from 'react'
 import clsx from 'clsx'
 import {useId} from '../../hooks/useId'
 
 import type {BaseProps} from '../../component-helpers'
 import type {FormValidationStatus} from '../form-types'
 import useLayoutEffect from '../../hooks/useIsomorphicLayoutEffect'
+import {useMergedRefs} from '../../hooks/useRef'
 
 import styles from './Checkbox.module.css'
-import {useProvidedRefOrCreate} from '../../hooks/useRef'
 
 export type CheckboxProps = {
   /**
@@ -47,22 +47,24 @@ const _Checkbox = (
     value,
     ...rest
   }: CheckboxProps,
-  ref,
+  forwardedRef,
 ): ReactElement => {
-  const inputRef: RefObject<HTMLInputElement> | null = useProvidedRefOrCreate<HTMLInputElement>(ref || null)
+  const internalRef = useRef<HTMLInputElement | null>(null)
+  const mergedRef = useMergedRefs(internalRef, forwardedRef)
+
   const uniqueId = useId(id)
 
   useLayoutEffect(() => {
-    if (inputRef.current) {
-      inputRef.current.indeterminate = indeterminate || false
+    if (internalRef.current) {
+      internalRef.current.indeterminate = indeterminate || false
     }
-  }, [indeterminate, checked, inputRef])
+  }, [indeterminate, checked, internalRef])
 
   const onClick = useCallback(() => {
-    if (!disabled && inputRef.current) {
-      inputRef.current.click()
+    if (!disabled && internalRef.current) {
+      internalRef.current.click()
     }
-  }, [disabled, inputRef])
+  }, [disabled, internalRef])
 
   return (
     <span className={styles['Checkbox-wrapper']}>
@@ -76,7 +78,7 @@ const _Checkbox = (
         disabled={disabled}
         name={value}
         onChange={onChange}
-        ref={inputRef}
+        ref={mergedRef}
         required={required}
         type="checkbox"
         value={value}

--- a/packages/react/src/forms/Radio/Radio.test.tsx
+++ b/packages/react/src/forms/Radio/Radio.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {Radio} from '..'
 import {render, fireEvent} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {toHaveNoViolations} from 'jest-axe'
 import '@testing-library/jest-dom'
 
@@ -129,5 +130,24 @@ describe('Radio', () => {
     rerender(<Radio {...defaultProps} checked={true} onChange={handleChange} />)
 
     expect(radio).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('toggles the radio when the associated span is clicked and a functional ref is passed', async () => {
+    const user = userEvent.setup()
+    const mockRef = jest.fn()
+    const handleChange = jest.fn()
+
+    const {getByRole, container} = render(<Radio {...defaultProps} onChange={handleChange} ref={mockRef} />)
+
+    const radio = getByRole('radio')
+    expect(mockRef).toHaveBeenCalledWith(radio)
+
+    const span = container.querySelector('span.Radio') as HTMLSpanElement
+    expect(span).toBeInTheDocument()
+
+    expect(radio).not.toBeChecked()
+
+    await user.click(span)
+    expect(radio).toBeChecked()
   })
 })

--- a/packages/react/src/forms/Radio/Radio.tsx
+++ b/packages/react/src/forms/Radio/Radio.tsx
@@ -1,7 +1,7 @@
-import React, {forwardRef, useCallback, type InputHTMLAttributes, type ReactElement, type RefObject} from 'react'
+import React, {forwardRef, useCallback, useRef, type InputHTMLAttributes, type ReactElement} from 'react'
 import clsx from 'clsx'
 import {useId} from '../../hooks/useId'
-import {useProvidedRefOrCreate} from '../../hooks/useRef'
+import {useMergedRefs} from '../../hooks/useRef'
 
 import type {BaseProps} from '../../component-helpers'
 
@@ -26,16 +26,17 @@ export type RadioProps = {
 
 const _Radio = (
   {checked, className, disabled, id, onChange, required, value, ...rest}: RadioProps,
-  ref,
+  forwardedRef,
 ): ReactElement => {
-  const inputRef: RefObject<HTMLInputElement> | null = useProvidedRefOrCreate<HTMLInputElement>(ref || null)
+  const internalRef = useRef<HTMLInputElement | null>(null)
+  const mergedRef = useMergedRefs(internalRef, forwardedRef)
   const uniqueId = useId(id)
 
   const onClick = useCallback(() => {
-    if (!disabled && inputRef.current) {
-      inputRef.current.click()
+    if (!disabled && internalRef.current) {
+      internalRef.current.click()
     }
-  }, [disabled, inputRef])
+  }, [disabled, internalRef])
 
   return (
     <span className={styles['Radio-wrapper']}>
@@ -47,7 +48,7 @@ const _Radio = (
         disabled={disabled}
         name={value}
         onChange={onChange}
-        ref={inputRef}
+        ref={mergedRef}
         required={required}
         type="radio"
         value={value}

--- a/packages/react/src/hooks/useRef.ts
+++ b/packages/react/src/hooks/useRef.ts
@@ -14,3 +14,29 @@ export function useProvidedRefOrCreate<TRef>(providedRef?: React.RefObject<TRef>
 
   return providedRef ?? createdRef
 }
+
+/**
+ * Combines multiple refs into a single callback ref that can be attached to a DOM element.
+ * This is useful when a component needs to maintain its own internal ref while also supporting
+ * a forwarded ref from a parent component. All provided refs will point to the same DOM element.
+ * @param refs Refs to merge - can be MutableRefObjects, callback refs, or null/undefined
+ * @type T The type of the DOM element or component instance that the refs will reference.
+ */
+export function useMergedRefs<T = HTMLElement>(
+  ...refs: (React.MutableRefObject<T | null> | React.RefCallback<T> | undefined | null)[]
+) {
+  return (node: T | null) => {
+    for (const ref of refs) {
+      if (!ref) {
+        // Refs can be null or undefined — e.g. on initial render — so skip in that case
+        continue
+      }
+
+      if (typeof ref === 'function') {
+        ref(node)
+      } else {
+        ref.current = node
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes an issue where passing a functional ref to the `Checkbox` or `Radio` components would prevent clicks on the radio or checkbox elements from toggling the checked state.

This specific issue was introduced [here](https://github.com/primer/brand/commit/ce945a2f7f2095cc58dbbd5665b23d3c3e60a711) as part of work to resolve issues with screen readers announcements of labels associated with `Checkbox` and `Radio` components. Before this change, these `<input>` elements would be rendered with two associated labels; one from the `FormControl`, and the other wrapping the visual checkbox/radio svg, which caused issues for screen readers.

A similar issue existed in this component prior to this change however, and similar issues may also exist in other, unrelated components (see Other implications below).

### Repro steps
1. Navigate to [a simple checkbox example in the production docs](https://primer.style/brand/components/Checkbox/react#optional-border).
2. Replace `<Checkbox />` with `<Checkbox ref={() => {}} />`
3. Observe the clicking the checkbox no longer toggles the checkbox state.

### Summary of issue

Internally the `Checkbox` and `Radio` components require a ref to capture clicks on the `<span>` (which functions as the custom-styled input while the real input is hidden) and forward them to the underlying input. It does this by assuming that the ref used internally is a `RefObject`, and so has a `.current` property.

When a ref is passed to the `Checkbox` or `Radio` components, the component passed that ref to `useProvidedRefOrCreate` and continues to use the ref that was returned.

If no ref was provided, or a ref of type `RefObject` was provided, then this would work as expected.

If, however, a functional ref was provided to the `Checkbox` or `Radio` components, then the ref that was used internally by the component would then also be a function and so would not have a `.current` property.

This resulted in the check [here](https://github.com/primer/brand/blob/8c1301c3f9c4808584db08a2af9ab979a0e8b982/packages/react/src/forms/Checkbox/Checkbox.tsx#L62-L63) always evaluating to false as `inputRef.current` would be `undefined` (since functional refs don't have a `.current` property) meaning the click event was never forwarded to the `<input>`.

### Resolution

To resolve this, I've implemented a new hook — `useMergedRefs` — which takes an arbitrary number of refs and returns a new ref which combines all of the provided refs into a single ref.

The `Checkbox` and `Radio` components now merge the provided ref with the internal ref using `useMergedRefs` and apply the resulting ref to the `<input>` element. This means that the components can continue to use their internal refs alongside the provided ref, thereby guaranteeing that the internal ref is always a `RefObject`.

### Other implications

There may be other places in the codebase where we're making a similar assumption — that a provided ref will always be a `RefObject` — and so we may need to update other components to use `useMergedRefs` as well.

From a quick look I was able to find bugs in the `Tooltip` and `Accordion` components which relate to this same issue. I'd recommend a more detailed audit of this issue and resolutions in a follow-up PR. We'd likely be able to remove the `useProvidedRefOrCreate` hook entirely in favour of `useMergedRefs` in the future to prevent this issue from reoccurring.

## List of notable changes:

- Added `useMergedRefs` hook
- Replaced usage of `useProvidedRefOrCreate` with `useMergedRefs` in `Checkbox` and `Radio` components
- Added tests to `Checkbox` and `Radio` components to assert toggle functionality works as expected when a functional ref is passed

## What should reviewers focus on?

- Check that the issue is resolved in [the preview deployment](https://primer-ec06a86c64-26139705.drafts.github.io/brand/components/Checkbox/react#optional-border).

## Steps to test:

See Repro steps above for instructions of how to test the resolution in [the preview docs](https://primer-ec06a86c64-26139705.drafts.github.io/brand/components/Checkbox/react#optional-border).
- I've tested the fix on dotcom too and confirm that it works as expected. Feel free to do the same.

## Supporting resources (related issues, external links, etc):

- Reported in [Slack](https://github.slack.com/archives/C03FY9G00NS/p1751411031509329)

## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
