### PR TITLE
Fix leaking props in SubdomainNavBar to remove warning from unit tests

### DIFF
--- a/.changeset/mighty-cameras-brake.md
+++ b/.changeset/mighty-cameras-brake.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Internal refactoring to `SubdomainNavBar` component to remove an unused prop — `showOnlyOnNarrow` — which was leaking into the DOM.

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.stories.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.stories.tsx
@@ -368,7 +368,7 @@ const mockSearchData = [
   },
 ]
 
-const Template: StoryFn<Args> = args => {
+const Template: StoryFn<Args> = ({showSearch, numLinks, ...args}) => {
   const inputRef = React.useRef<HTMLInputElement | null>(null)
   const [searchResults, setSearchResults] = React.useState<
     {title: string; description: string; date: string; url: string}[] | undefined
@@ -405,7 +405,7 @@ const Template: StoryFn<Args> = args => {
       <div>
         <SubdomainNavBar {...args} title={args.title}>
           {['collections', 'topics', 'articles', 'events', 'video', 'social', 'podcasts', 'books', 'guides', 'webcasts']
-            .slice(0, args.numLinks)
+            .slice(0, numLinks)
             .map(link => {
               return (
                 <SubdomainNavBar.Link key={link} href={`#${link}`}>
@@ -417,7 +417,7 @@ const Template: StoryFn<Args> = args => {
                 </SubdomainNavBar.Link>
               )
             })}
-          {args.showSearch && (
+          {showSearch && (
             <SubdomainNavBar.Search
               ref={inputRef}
               searchTerm={searchTerm}

--- a/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
+++ b/packages/react/src/SubdomainNavBar/SubdomainNavBar.tsx
@@ -322,7 +322,6 @@ function Root({
                     )}
                     {hasLinks && !menuHidden && (
                       <NavigationVisbilityObserver
-                        showOnlyOnNarrow
                         className={clsx(styles['SubdomainNavBar-primary-nav-list--visible'])}
                       >
                         {menuItems}


### PR DESCRIPTION
## Summary

Fixes props which were leaking into the DOM, both in Storybook and in the `SubdomainNavBar` component itself.

## List of notable changes:

- Explicitly destructured props in `SubdomainNavBar.stories.tsx` to prevent props leaking into the DOM of rendered story.
- Removed unused `showOnlyOnNarrow` prop from `SubdomainNavBar.tsx` to prevent it leaking into the DOM and to fix a related warning in the unit tests.

## What should reviewers focus on?

- I can't see the `showOnlyOnNarrow` prop being used anywhere, and I'm not sure it was ever implemented since being added in #451. Another set of eyes on this would be appreciated though.
- Check that the SubdomainNavBar still works in the expected way.


## Contributor checklist:

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

![image](https://github.com/user-attachments/assets/d9053a6d-b975-4b63-9d34-ee9de6184a36)

 </td>
<td valign="top">

![image](https://github.com/user-attachments/assets/1d244044-d1f1-45a2-ab35-7f6b583abbe1)

</td>
</tr>
</table>
