### PR TITLE
Add non-breaking spaces between adjacent spans in EyebrowBanner

### DIFF
--- a/.changeset/witty-roses-attack.md
+++ b/.changeset/witty-roses-attack.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Added non-breaking spaces between adjacent spans in EyebrowBanner component to prevent adjacent text from being announced without a pause by some screen readers.

--- a/.changeset/witty-roses-attack.md
+++ b/.changeset/witty-roses-attack.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Added non-breaking spaces between adjacent spans in EyebrowBanner component to prevent adjacent text from being announced without a pause by some screen readers.
+Added visually-hidden, non-breaking spaces between each text item in the `EyebrowBanner` component. This improves announcements in screen readers, where they would previously be announced without a pause.

--- a/packages/react/src/EyebrowBanner/EyebrowBanner.test.tsx
+++ b/packages/react/src/EyebrowBanner/EyebrowBanner.test.tsx
@@ -162,4 +162,16 @@ describe('EyebrowBanner', () => {
     await userEvent.click(document.body)
     expect(getByTestId(EyebrowBanner.testIds.expandableArrow).classList).not.toContain(expectedClass)
   })
+
+  it('includes non-breaking spaces between text items to improve screen reader announcements', () => {
+    const {container} = render(
+      <EyebrowBanner href="/">
+        <EyebrowBanner.Label>Mock label</EyebrowBanner.Label>
+        <EyebrowBanner.Heading>{mockHeading}</EyebrowBanner.Heading>
+        <EyebrowBanner.SubHeading>{mockSubHeading}</EyebrowBanner.SubHeading>
+      </EyebrowBanner>,
+    )
+
+    expect(container).toHaveTextContent('Mock label Mock heading Mock sub-heading')
+  })
 })

--- a/packages/react/src/EyebrowBanner/EyebrowBanner.tsx
+++ b/packages/react/src/EyebrowBanner/EyebrowBanner.tsx
@@ -67,9 +67,15 @@ const _EyebrowBanner = forwardRef<HTMLAnchorElement, EyebrowBannerProps>(
       [onBlur, isFocused],
     )
 
-    const HeadingChildren = React.Children.toArray(children).filter(child => {
+    const HeadingChild = React.Children.toArray(children).filter(child => {
       if (React.isValidElement(child)) {
-        return child.type === EyebrowBannerHeading || child.type === EyebrowBannerSubHeading
+        return child.type === EyebrowBannerHeading
+      }
+    })
+
+    const SubHeadingChild = React.Children.toArray(children).filter(child => {
+      if (React.isValidElement(child)) {
+        return child.type === EyebrowBannerSubHeading
       }
     })
 
@@ -99,8 +105,14 @@ const _EyebrowBanner = forwardRef<HTMLAnchorElement, EyebrowBannerProps>(
       >
         <span className={styles['EyebrowBanner__inner']}>
           {VisualChild && <span className={styles['EyebrowBanner__leadingVisual']}>{VisualChild}</span>}
+          <span className="visually-hidden">&nbsp;</span>
           {LabelChild && !VisualChild && <>{LabelChild}</>}
-          <span className={styles['EyebrowBanner__headings']}>{HeadingChildren}</span>
+          <span className="visually-hidden">&nbsp;</span>
+          <span className={styles['EyebrowBanner__headings']}>
+            {HeadingChild}
+            <span className="visually-hidden">&nbsp;</span>
+            {SubHeadingChild}
+          </span>
 
           <span className={styles['EyebrowBanner__trailingVisual']}>
             <ExpandableArrow


### PR DESCRIPTION
## Summary

Adds non-breaking spaces between adjacent spans in `EyebrowBanner` component. 

Previously, NVDA would announce the `EyebrowBanner` in the following ways:

```
link    GitHub Universe: Dive in to AI, security, and DevExGet your tickets now to join us on Nov. 8-9.
link    NEWGitHub Copilot now available for Business
link    NEWGitHub Copilot now available for BusinessHarnessed for productivity. Designed for collaboration.
link    UPDATENow supports multiple languages
```

Now, it's announced with a pause between strings like _DevEx_ and _Get_, _Business_ and _Harnessed_, and _UPDATE_ and _Now_.

```
link     GitHub Universe: Dive in to AI, security, and DevEx Get your tickets now to join us on Nov. 8-9.
link     NEW GitHub Copilot now available for Business 
link     NEW GitHub Copilot now available for Business Harnessed for productivity. Designed for collaboration.
link     UPDATE Now supports multiple languages 
```

## What should reviewers focus on?

- Check that there have been no visual regressions with the `EyebrowBanner` component

## Steps to test

Take a look in Storybook or the docs

## Supporting resources (related issues, external links, etc)

- Closes https://github.com/github/primer/issues/3783

## Contributor checklist

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change
