### PR TITLE
Improve Prose support for privacy-enhanced Youtube embeds

### DIFF
--- a/.changeset/small-cycles-build.md
+++ b/.changeset/small-cycles-build.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Add support for privacy-enhanced Youtube embeds in Prose. Now supports the youtube-nocookie.com hostname.

--- a/packages/react/src/Prose/Prose.module.css
+++ b/packages/react/src/Prose/Prose.module.css
@@ -320,7 +320,8 @@
 
 .Prose video,
 .Prose iframe[src*='youtube.com'],
-.Prose iframe[src*='youtu.be'] {
+.Prose iframe[src*='youtu.be'],
+.Prose iframe[src*='youtube-nocookie.com'] {
   --spacing: var(--brand-Prose-img-spacing);
 
   border-radius: var(--brand-borderRadius-medium);
@@ -336,7 +337,8 @@
 }
 
 .Prose iframe[src*='youtube.com'],
-.Prose iframe[src*='youtu.be'] {
+.Prose iframe[src*='youtu.be'],
+.Prose iframe[src*='youtube-nocookie.com'] {
   width: 100%;
   aspect-ratio: 16 / 9;
 }

--- a/packages/react/src/Prose/Prose.stories.tsx
+++ b/packages/react/src/Prose/Prose.stories.tsx
@@ -67,7 +67,7 @@ const ExampleHtmlMarkup = `
     <h6>Youtube video embed</h6>
      <p>Pellentesque non ornare ligula. Suspendisse nibh purus, pretium id tortor sit amet, tincidunt gravida augue.</p>
     <p>Nunc velit odio, posuere eu felis eget, consectetur fermentum nisi. Aenean tempor odio id ornare ultrices. Quisque blandit condimentum tellus, semper efficitur sapien dapibus nec. </p>
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/pBy1zgt0XPc?si=oPJ2zmFp6efpN15N" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/pBy1zgt0XPc?si=oPJ2zmFp6efpN15N" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
      <p>Pellentesque non ornare ligula. Suspendisse nibh purus, pretium id tortor sit amet, tincidunt gravida augue.</p>
     <p>Nunc velit odio, posuere eu felis eget, consectetur fermentum nisi. Aenean tempor odio id ornare ultrices. Quisque blandit condimentum tellus, semper efficitur sapien dapibus nec. </p>
     <h6>Native video</h6>


### PR DESCRIPTION
## Summary

Resolves https://github.com/primer/brand/issues/1095

Adds the `youtube-nocookie.com` hostname to our Prose selector allowlist for improved styling of Youtube embeds.

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Adds relevant styles
- Updates story to use cookie-less embeds

## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile).
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Check there's no regressions in the story and embed continues to apply the styles

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Use this storybook preview and verify styles are applying

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">


![Screenshot 2025-07-10 at 10 22 32](https://github.com/user-attachments/assets/d655592f-964c-47bc-bd7f-83d88e101acc)

 </td>
<td valign="top">


![Screenshot 2025-07-10 at 10 22 45](https://github.com/user-attachments/assets/724f7fe1-9ea9-48d2-b99e-835f6bbd0280)

</td>
</tr>
</table>
