### PR TITLE
Fix incorrect content on docs homepage

### DIFF
--- a/apps/next-docs/content/index.tsx
+++ b/apps/next-docs/content/index.tsx
@@ -3,6 +3,7 @@ import {Grid, Card, Stack, InlineLink, Text, Heading} from '@primer/react-brand/
 import clsx from 'clsx'
 import Image from 'next/image'
 import NextLink from 'next/link'
+// eslint-disable-next-line import/extensions
 import packageInfo from '../package.json'
 
 import mona from '../src/images/mona-home.png'
@@ -10,6 +11,10 @@ import mona from '../src/images/mona-home.png'
 import styles from './index.module.css'
 
 export default function HomepageComponent() {
+  const releaseUrl = `https://github.com/primer/brand/releases/tag/${encodeURIComponent(
+    `@primer/react-brand@${packageInfo.version}`,
+  )}`
+
   return (
     <div className={clsx(styles.home, 'custom-component')}>
       <Grid>
@@ -110,12 +115,7 @@ export default function HomepageComponent() {
                     Latest release:
                   </Text>{' '}
                   <Text size="100" font="monospace">
-                    <InlineLink
-                      href={`https://github.com/primer/brand/releases/tag/${encodeURIComponent(
-                        `@primer/react-brand@${packageInfo.version}`,
-                      )}`}
-                      target="_blank"
-                    >
+                    <InlineLink href={releaseUrl} target="_blank">
                       v{packageInfo.version}
                     </InlineLink>
                   </Text>

--- a/apps/next-docs/content/index.tsx
+++ b/apps/next-docs/content/index.tsx
@@ -3,6 +3,7 @@ import {Grid, Card, Stack, InlineLink, Text, Heading} from '@primer/react-brand/
 import clsx from 'clsx'
 import Image from 'next/image'
 import NextLink from 'next/link'
+import packageInfo from '../package.json'
 
 import mona from '../src/images/mona-home.png'
 
@@ -84,24 +85,42 @@ export default function HomepageComponent() {
                   </Card>
                 </Grid.Column>
                 <Grid.Column span={{xsmall: 12, large: 6, xlarge: 4}}>
-                  <Card href="https://github.com/primer/brand/blob/main/CONTRIBUTING.md" hasBorder fullWidth>
-                    <Card.Heading as="h2">Contributing</Card.Heading>
-                    <Card.Description>Guidelines for contributing to the Product UI library.</Card.Description>
+                  <Card href="https://primer.style/brand/storybook" hasBorder fullWidth ctaText="Go to Storybook">
+                    <Card.Heading as="h2">Storybook</Card.Heading>
+                    <Card.Description>For GitHub Staff only</Card.Description>
                   </Card>
                 </Grid.Column>
               </Grid>
             </Stack>
             <div className={styles.footer}>
-              <Text as="p" size="300">
-                <Text as="span" size="300" weight="bold">
-                  Need help?&nbsp;
+              <Stack direction="vertical" gap="condensed">
+                <Text as="p" size="300">
+                  <Text as="span" size="300" weight="bold">
+                    Need help?&nbsp;
+                  </Text>
+                  If you found a bug on this website, please{' '}
+                  <InlineLink href="https://github.com/primer/brand/issues/new?template=BUG-REPORT.yml">
+                    open a new issue
+                  </InlineLink>{' '}
+                  with as much detail as possible.
                 </Text>
-                If you found a bug on this website, please{' '}
-                <InlineLink href="https://github.com/primer/brand/issues/new?template=BUG-REPORT.yml">
-                  open a new issue
-                </InlineLink>{' '}
-                with as much detail as possible.
-              </Text>
+
+                <Text as="p" size="300">
+                  <Text as="span" size="300" weight="bold">
+                    Latest release:
+                  </Text>{' '}
+                  <Text size="100" font="monospace">
+                    <InlineLink
+                      href={`https://github.com/primer/brand/releases/tag/${encodeURIComponent(
+                        `@primer/react-brand@${packageInfo.version}`,
+                      )}`}
+                      target="_blank"
+                    >
+                      v{packageInfo.version}
+                    </InlineLink>
+                  </Text>
+                </Text>
+              </Stack>
             </div>
           </Stack>
         </Grid.Column>


### PR DESCRIPTION
## Summary

Fixes incorrect content on docs homepage. The last card currently references Product UI when it should be Brand UI. 

This card is just filler, so I've replaced it with Storybook like we previously had on the old docs. This now makes it easier to get to Storybook.

Also added in the version number of our latest release, and link to the release page like we used to have before.


## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile).
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Verify homepage changes work as expected.

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Go the homepage and check the links go to the correct places: Storybook and Releases pages

## Supporting resources (related issues, external links, etc):

-
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="1299" height="412" alt="Screenshot 2025-07-10 at 15 13 03" src="https://github.com/user-attachments/assets/2f1831fb-b15c-4710-8370-33edd7828031" />


 </td>
<td valign="top">

<img width="1374" height="449" alt="Screenshot 2025-07-10 at 15 10 19" src="https://github.com/user-attachments/assets/27d7a627-dd66-4f47-9e3a-b59edaff9cb4" />


</td>
</tr>
</table>
