### PR TITLE
Demo PR — do not merge

### DIFF
--- a/packages/react/src/ActionMenu/ActionMenu.module.css
+++ b/packages/react/src/ActionMenu/ActionMenu.module.css
@@ -90,7 +90,6 @@
   visibility: hidden;
   background-color: var(--brand-color-canvas-default);
   border: var(--brand-borderWidth-thin) solid var(--brand-color-border-muted);
-  border-radius: var(--brand-borderRadius-large);
   max-height: 460px;
   overflow-y: auto;
   box-shadow: 0px 100px 80px rgba(0, 0, 0, 0.01), 0px 41px 33px rgba(0, 0, 0, 0.02), 0px 22px 17px rgba(0, 0, 0, 0.02),


### PR DESCRIPTION
In this PR I removed a style (`border-radius`) from the ActionMenu's popover menu. This should result in the popover having no border radius.

If you look at the [Storybook preview](https://primer-7aeecb491d-26139705.drafts.github.io/brand/storybook/?path=/story/components-actionmenu--default), you'll see that the popover doesn't have a border radius, as expected.

<img width="367" height="337" alt="image" src="https://github.com/user-attachments/assets/02d0f670-34f2-4b4d-ab31-d552025f5a97" />

If you look at the [Docs preview](https://primer-7aeecb491d-26139705.drafts.github.io/brand/components/ActionMenu/#default), you'll see that the popover still has a border radius, despite it having been removed by this PR.

<img width="982" height="628" alt="image" src="https://github.com/user-attachments/assets/640f6638-f02f-493a-8172-d42c1dcb2070" />

---

In the docs, the border radius isn't present in the styles which come from the version of Primer Brand built locally

<img width="617" height="219" alt="image" src="https://github.com/user-attachments/assets/4b0923f3-2798-496a-9d30-facd682cef6a" />

However it's then added back in by the version of Primer Brand pulled from npm

<img width="620" height="228" alt="image" src="https://github.com/user-attachments/assets/b8d7711f-640c-411f-8be5-14d1196e24a8" />
