### PR TITLE
Upgrade `@primer/behaviors` and unlock it to patch versions

### DIFF
--- a/.changeset/great-kangaroos-switch.md
+++ b/.changeset/great-kangaroos-switch.md
@@ -1,0 +1,5 @@
+---
+"@primer/react-brand": patch
+---
+
+Upgrade `@primer/behaviors`

--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,7 +6799,9 @@
       }
     },
     "node_modules/@primer/behaviors": {
-      "version": "1.8.0",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.8.2.tgz",
+      "integrity": "sha512-qIiMXxJQImuV4CFHhzDvnjBThtZue7LsJ03fLDSG7FuTcm1CSYkNnCLfJqnyDqY9LmVz7WJ6rvCGhOVEW8fLcA==",
       "license": "MIT"
     },
     "node_modules/@primer/brand-config": {
@@ -35096,7 +35098,7 @@
       "license": "MIT",
       "dependencies": {
         "@oddbird/popover-polyfill": "0.5.2",
-        "@primer/behaviors": "1.8.0"
+        "@primer/behaviors": "^1.8.2"
       },
       "devDependencies": {
         "@figma/code-connect": "1.2.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@oddbird/popover-polyfill": "0.5.2",
-    "@primer/behaviors": "1.8.0"
+    "@primer/behaviors": "^1.8.2"
   },
   "devDependencies": {
     "@figma/code-connect": "1.2.4",


### PR DESCRIPTION

I tried to upgrade `@primer/behaviors` in `github/github-ui` but ran into a version conflict:

```
npm error ❌ Found mismatched sub-dependency versions for @primer/behaviors:
npm error     - 1.8.2 in node_modules/@primer/behaviors
npm error     - 1.8.0 in node_modules/@primer/react-brand/node_modules/@primer/behaviors
```

To fix this, this PR upgrades `@primer/behaviors` from `@primer/react-brand` and unlocks it so we don't run into this in the future for patch versions.