### PR TITLE
Improves types in useTabs hook

### DIFF
--- a/.changeset/olive-planets-live.md
+++ b/.changeset/olive-planets-live.md
@@ -2,5 +2,5 @@
 '@primer/react-brand': patch
 ---
 
-- Added an aria-label to the list of tabs in the `IDE` component.
+- Added an `aria-label` to the list of tabs in the `IDE` component.
 - Improved types in `useTabs` hook, which is used internally in the `IDE` and `Tabs` components.

--- a/.changeset/olive-planets-live.md
+++ b/.changeset/olive-planets-live.md
@@ -2,4 +2,5 @@
 '@primer/react-brand': patch
 ---
 
-Added an aria-label to the list of tabs in the `IDE` component
+- Added an aria-label to the list of tabs in the `IDE` component.
+- Improved types in `useTabs` hook, which is used internally in the `IDE` and `Tabs` components.

--- a/.changeset/olive-planets-live.md
+++ b/.changeset/olive-planets-live.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Added an aria-label to the list of tabs in the `IDE` component

--- a/packages/react/src/IDE/IDE.tsx
+++ b/packages/react/src/IDE/IDE.tsx
@@ -700,7 +700,11 @@ const _Editor = memo(
           data-testid={testId || testIds.editor}
           {...rest}
         >
-          <div className={styles['IDE__Editor-tabs']} data-testid={testIds.editorTabs} {...tabs.getTabListProps()}>
+          <div
+            className={styles['IDE__Editor-tabs']}
+            data-testid={testIds.editorTabs}
+            {...tabs.getTabListProps({label: 'files'})}
+          >
             {files.map((file, index) => {
               const language = file.name.split('.').pop()
               const isActiveTab = tabs.activeTab === index.toString()

--- a/packages/react/src/hooks/useTabs.test.tsx
+++ b/packages/react/src/hooks/useTabs.test.tsx
@@ -869,6 +869,18 @@ describe('useTabs', () => {
     })
 
     expect(result.current.focusedTab).toBe('test-2')
+
+    act(() => {
+      result.current.focusTab('test-3')
+    })
+
+    expect(result.current.focusedTab).toBe('test-3')
+
+    act(() => {
+      result.current.focusTab('test-3')
+    })
+
+    expect(result.current.focusedTab).toBe('test-3')
   })
 
   it('does not change the active tab when focusTab is called', () => {

--- a/packages/react/src/hooks/useTabs.test.tsx
+++ b/packages/react/src/hooks/useTabs.test.tsx
@@ -1,4 +1,4 @@
-import React, {createRef, MutableRefObject} from 'react'
+import React from 'react'
 
 import {act, render, renderHook} from '@testing-library/react'
 import '@testing-library/jest-dom'
@@ -23,7 +23,7 @@ type TestComponentProps = {
  *    function to match real-world usage.
  */
 const renderUseTabsHook = (initialOptions?: UseTabsOptions) => {
-  const result = React.createRef<UseTabs>() as MutableRefObject<UseTabs>
+  const result = React.createRef<UseTabs>() as React.MutableRefObject<UseTabs>
 
   const MockTabs = ({useTabsOptions}: TestComponentProps) => {
     const useTabsResult = useTabs(useTabsOptions)
@@ -334,7 +334,7 @@ describe('useTabs', () => {
   })
 
   it("sets the tab element to the provided RefObject's current property", () => {
-    const ref = createRef<HTMLDetailsElement>()
+    const ref = React.createRef<HTMLDetailsElement>()
 
     // We intentionally use `renderHook` here as we want to pass a custom ref
     const {result} = renderHook(useTabs)

--- a/packages/react/src/hooks/useTabs.test.tsx
+++ b/packages/react/src/hooks/useTabs.test.tsx
@@ -285,7 +285,7 @@ describe('useTabs', () => {
     expect(result.current.activeTab).toBe('test-2')
   })
 
-  it("focusses the tab when an inactive tab's onFocus callback is called", () => {
+  it("focuses the tab when an inactive tab's onFocus callback is called", () => {
     const {result} = renderUseTabsHook({defaultTab: 'test-1'})
 
     expect(result.current.focusedTab).toBeNull()
@@ -300,7 +300,7 @@ describe('useTabs', () => {
     expect(result.current.focusedTab).toBe('test-2')
   })
 
-  it("focusses the tab when an active tab's onFocus callback is called", () => {
+  it("focuses the tab when an active tab's onFocus callback is called", () => {
     const {result} = renderUseTabsHook({defaultTab: 'test-2'})
 
     expect(result.current.focusedTab).toBeNull()

--- a/packages/react/src/hooks/useTabs.test.tsx
+++ b/packages/react/src/hooks/useTabs.test.tsx
@@ -268,7 +268,7 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onClick?.()
+      tabProps.onClick()
     })
 
     expect(result.current.activeTab).toBe('test-2')
@@ -282,7 +282,7 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onClick?.()
+      tabProps.onClick()
     })
 
     expect(result.current.activeTab).toBe('test-2')
@@ -296,7 +296,7 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
@@ -310,7 +310,7 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
@@ -406,13 +406,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowLeft'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowLeft'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -424,13 +424,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowRight'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowRight'))
     })
 
     expect(result.current.focusedTab).toBe('test-3')
@@ -442,13 +442,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowUp'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowUp'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -460,13 +460,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowDown'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowDown'))
     })
 
     expect(result.current.focusedTab).toBe('test-3')
@@ -478,13 +478,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowUp'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowUp'))
     })
 
     expect(result.current.focusedTab).toBe('test-2')
@@ -496,13 +496,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowDown'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowDown'))
     })
 
     expect(result.current.focusedTab).toBe('test-2')
@@ -514,13 +514,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowLeft'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowLeft'))
     })
 
     expect(result.current.focusedTab).toBe('test-2')
@@ -532,13 +532,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowRight'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowRight'))
     })
 
     expect(result.current.focusedTab).toBe('test-2')
@@ -550,13 +550,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-3')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('Home'))
+      tabProps.onKeyDown(mockKeyboardEvent('Home'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -568,13 +568,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-1')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-1')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('End'))
+      tabProps.onKeyDown(mockKeyboardEvent('End'))
     })
 
     expect(result.current.focusedTab).toBe('test-3')
@@ -586,13 +586,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-1')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-1')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowLeft'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowLeft'))
     })
 
     expect(result.current.focusedTab).toBe('test-3')
@@ -604,13 +604,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-3')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowRight'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowRight'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -622,13 +622,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-1')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-1')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowUp'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowUp'))
     })
 
     expect(result.current.focusedTab).toBe('test-3')
@@ -640,13 +640,13 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-3')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowDown'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowDown'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -658,14 +658,14 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
     expect(result.current.activeTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowLeft'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowLeft'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -678,14 +678,14 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
     expect(result.current.activeTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowRight'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowRight'))
     })
 
     expect(result.current.focusedTab).toBe('test-3')
@@ -698,14 +698,14 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
     expect(result.current.activeTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowUp'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowUp'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -718,14 +718,14 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
     expect(result.current.activeTab).toBe('test-2')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowDown'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowDown'))
     })
 
     expect(result.current.focusedTab).toBe('test-3')
@@ -738,14 +738,14 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-3')
     expect(result.current.activeTab).toBe('test-3')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('Home'))
+      tabProps.onKeyDown(mockKeyboardEvent('Home'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -758,14 +758,14 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-1')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-1')
     expect(result.current.activeTab).toBe('test-1')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('End'))
+      tabProps.onKeyDown(mockKeyboardEvent('End'))
     })
 
     expect(result.current.focusedTab).toBe('test-3')
@@ -778,14 +778,14 @@ describe('useTabs', () => {
     const tab2Props = result.current.getTabProps('test-2')
 
     act(() => {
-      tab2Props.onFocus?.()
+      tab2Props.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
     expect(result.current.activeTab).toBe('test-1')
 
     act(() => {
-      tab2Props.onKeyDown?.(mockKeyboardEvent(' '))
+      tab2Props.onKeyDown(mockKeyboardEvent(' '))
     })
 
     expect(result.current.activeTab).toBe('test-2')
@@ -797,14 +797,14 @@ describe('useTabs', () => {
     const tab2Props = result.current.getTabProps('test-2')
 
     act(() => {
-      tab2Props.onFocus?.()
+      tab2Props.onFocus()
     })
 
     expect(result.current.focusedTab).toBe('test-2')
     expect(result.current.activeTab).toBe('test-1')
 
     act(() => {
-      tab2Props.onKeyDown?.(mockKeyboardEvent('Enter'))
+      tab2Props.onKeyDown(mockKeyboardEvent('Enter'))
     })
 
     expect(result.current.activeTab).toBe('test-2')
@@ -899,7 +899,7 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onClick?.()
+      tabProps.onClick()
     })
 
     expect(onTabActivate).toHaveBeenLastCalledWith('test-2', expect.any(HTMLElement))
@@ -912,11 +912,11 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowRight'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowRight'))
     })
 
     expect(onTabActivate).toHaveBeenLastCalledWith('test-3', expect.any(HTMLElement))
@@ -929,11 +929,11 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowRight'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowRight'))
     })
 
     expect(onTabActivate).not.toHaveBeenCalled()
@@ -946,11 +946,11 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent(' '))
+      tabProps.onKeyDown(mockKeyboardEvent(' '))
     })
 
     expect(onTabActivate).toHaveBeenLastCalledWith('test-2', expect.any(HTMLElement))
@@ -963,11 +963,11 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('Enter'))
+      tabProps.onKeyDown(mockKeyboardEvent('Enter'))
     })
 
     expect(onTabActivate).toHaveBeenLastCalledWith('test-2', expect.any(HTMLElement))
@@ -980,11 +980,11 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent(' '))
+      tabProps.onKeyDown(mockKeyboardEvent(' '))
     })
 
     expect(onTabActivate).not.toHaveBeenCalled()
@@ -997,11 +997,11 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('Enter'))
+      tabProps.onKeyDown(mockKeyboardEvent('Enter'))
     })
 
     expect(onTabActivate).not.toHaveBeenCalled()
@@ -1029,11 +1029,11 @@ describe('useTabs', () => {
     const horizontalTabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      horizontalTabProps.onFocus?.()
+      horizontalTabProps.onFocus()
     })
 
     act(() => {
-      horizontalTabProps.onKeyDown?.(mockKeyboardEvent('ArrowLeft'))
+      horizontalTabProps.onKeyDown(mockKeyboardEvent('ArrowLeft'))
     })
 
     expect(result.current.focusedTab).toBe('test-2')
@@ -1045,13 +1045,13 @@ describe('useTabs', () => {
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      verticalTabProps.onKeyDown?.(mockKeyboardEvent('ArrowLeft'))
+      verticalTabProps.onKeyDown(mockKeyboardEvent('ArrowLeft'))
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      verticalTabProps.onKeyDown?.(mockKeyboardEvent('ArrowUp'))
+      verticalTabProps.onKeyDown(mockKeyboardEvent('ArrowUp'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -1063,11 +1063,11 @@ describe('useTabs', () => {
     const verticalTabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      verticalTabProps.onFocus?.()
+      verticalTabProps.onFocus()
     })
 
     act(() => {
-      verticalTabProps.onKeyDown?.(mockKeyboardEvent('ArrowUp'))
+      verticalTabProps.onKeyDown(mockKeyboardEvent('ArrowUp'))
     })
 
     expect(result.current.focusedTab).toBe('test-2')
@@ -1079,13 +1079,13 @@ describe('useTabs', () => {
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      horizontalTabProps.onKeyDown?.(mockKeyboardEvent('ArrowUp'))
+      horizontalTabProps.onKeyDown(mockKeyboardEvent('ArrowUp'))
     })
 
     expect(result.current.focusedTab).toBe('test-2')
 
     act(() => {
-      horizontalTabProps.onKeyDown?.(mockKeyboardEvent('ArrowLeft'))
+      horizontalTabProps.onKeyDown(mockKeyboardEvent('ArrowLeft'))
     })
 
     expect(result.current.focusedTab).toBe('test-1')
@@ -1120,7 +1120,7 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     const tab3 = getAllByRole('tab')[2]
@@ -1128,7 +1128,7 @@ describe('useTabs', () => {
     const focusSpy = jest.spyOn(tab3, 'focus')
 
     act(() => {
-      tabProps.onKeyDown?.(mockKeyboardEvent('ArrowRight'))
+      tabProps.onKeyDown(mockKeyboardEvent('ArrowRight'))
     })
 
     expect(focusSpy).toHaveBeenCalledTimes(1)
@@ -1140,18 +1140,18 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     const leftArrowEvent = mockKeyboardEvent('ArrowLeft')
     const rightArrowEvent = mockKeyboardEvent('ArrowRight')
 
     act(() => {
-      tabProps.onKeyDown?.(leftArrowEvent)
+      tabProps.onKeyDown(leftArrowEvent)
     })
 
     act(() => {
-      tabProps.onKeyDown?.(rightArrowEvent)
+      tabProps.onKeyDown(rightArrowEvent)
     })
 
     expect(leftArrowEvent.preventDefault).toHaveBeenCalledTimes(1)
@@ -1164,18 +1164,18 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     const homeEvent = mockKeyboardEvent('Home')
     const endEvent = mockKeyboardEvent('End')
 
     act(() => {
-      tabProps.onKeyDown?.(homeEvent)
+      tabProps.onKeyDown(homeEvent)
     })
 
     act(() => {
-      tabProps.onKeyDown?.(endEvent)
+      tabProps.onKeyDown(endEvent)
     })
 
     expect(homeEvent.preventDefault).toHaveBeenCalledTimes(1)
@@ -1188,18 +1188,18 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     const spaceEvent = mockKeyboardEvent(' ')
     const enterEvent = mockKeyboardEvent('Enter')
 
     act(() => {
-      tabProps.onKeyDown?.(spaceEvent)
+      tabProps.onKeyDown(spaceEvent)
     })
 
     act(() => {
-      tabProps.onKeyDown?.(enterEvent)
+      tabProps.onKeyDown(enterEvent)
     })
 
     expect(spaceEvent.preventDefault).toHaveBeenCalledTimes(1)
@@ -1212,7 +1212,7 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      tabProps.onFocus?.()
+      tabProps.onFocus()
     })
 
     const tabEvent = mockKeyboardEvent('Tab')
@@ -1220,15 +1220,15 @@ describe('useTabs', () => {
     const letterEvent = mockKeyboardEvent('a')
 
     act(() => {
-      tabProps.onKeyDown?.(tabEvent)
+      tabProps.onKeyDown(tabEvent)
     })
 
     act(() => {
-      tabProps.onKeyDown?.(escapeEvent)
+      tabProps.onKeyDown(escapeEvent)
     })
 
     act(() => {
-      tabProps.onKeyDown?.(letterEvent)
+      tabProps.onKeyDown(letterEvent)
     })
 
     expect(tabEvent.preventDefault).not.toHaveBeenCalled()

--- a/packages/react/src/hooks/useTabs.test.tsx
+++ b/packages/react/src/hooks/useTabs.test.tsx
@@ -84,14 +84,15 @@ describe('useTabs', () => {
     })
   })
 
-  it('returns an object with the expected shape from getTabListProps when called with no arguments', () => {
+  it('returns an object with the expected shape from getTabListProps', () => {
     const {result} = renderUseTabsHook()
 
-    const tabListProps = result.current.getTabListProps()
+    const tabListProps = result.current.getTabListProps({label: 'Test tabs'})
 
     expect(tabListProps).toEqual({
       role: expect.any(String),
       'aria-orientation': expect.any(String),
+      'aria-label': expect.any(String),
     })
   })
 
@@ -166,7 +167,7 @@ describe('useTabs', () => {
   it('sets the role of the tab list to "tablist"', () => {
     const {result} = renderUseTabsHook()
 
-    const tabListProps = result.current.getTabListProps()
+    const tabListProps = result.current.getTabListProps({label: 'Test tabs'})
 
     expect(tabListProps.role).toBe('tablist')
   })
@@ -174,7 +175,7 @@ describe('useTabs', () => {
   it('sets the aria-orientation of the tab list to "horizontal" by default', () => {
     const {result} = renderUseTabsHook()
 
-    const tabListProps = result.current.getTabListProps()
+    const tabListProps = result.current.getTabListProps({label: 'Test tabs'})
 
     expect(tabListProps['aria-orientation']).toBe('horizontal')
   })
@@ -182,7 +183,7 @@ describe('useTabs', () => {
   it('sets the aria-orientation of the tab list to "vertical" when specified', () => {
     const {result} = renderUseTabsHook({orientation: 'vertical'})
 
-    const tabListProps = result.current.getTabListProps()
+    const tabListProps = result.current.getTabListProps({label: 'Test tabs'})
 
     expect(tabListProps['aria-orientation']).toBe('vertical')
   })
@@ -267,7 +268,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onClick isn't correct
       tabProps.onClick?.()
     })
 
@@ -282,7 +282,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onClick isn't correct
       tabProps.onClick?.()
     })
 
@@ -297,7 +296,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -312,7 +310,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -409,7 +406,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -428,7 +424,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -447,7 +442,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -466,7 +460,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -485,7 +478,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -504,7 +496,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -523,7 +514,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -542,7 +532,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -561,7 +550,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -580,7 +568,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-1')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -599,7 +586,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-1')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -618,7 +604,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -637,7 +622,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-1')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -656,7 +640,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -675,7 +658,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -696,7 +678,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -717,7 +698,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -738,7 +718,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -759,7 +738,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -780,7 +758,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-1')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -801,7 +778,6 @@ describe('useTabs', () => {
     const tab2Props = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tab2Props.onFocus?.()
     })
 
@@ -821,7 +797,6 @@ describe('useTabs', () => {
     const tab2Props = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tab2Props.onFocus?.()
     })
 
@@ -924,7 +899,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onClick isn't correct
       tabProps.onClick?.()
     })
 
@@ -938,7 +912,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -956,7 +929,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -974,7 +946,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -992,7 +963,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -1010,7 +980,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -1028,7 +997,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -1061,7 +1029,6 @@ describe('useTabs', () => {
     const horizontalTabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       horizontalTabProps.onFocus?.()
     })
 
@@ -1096,7 +1063,6 @@ describe('useTabs', () => {
     const verticalTabProps = result.current.getTabProps('test-3')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       verticalTabProps.onFocus?.()
     })
 
@@ -1128,11 +1094,11 @@ describe('useTabs', () => {
   it('updates the aria-orientation attribute when orientation changes', () => {
     const {result, rerender} = renderUseTabsHook({orientation: 'horizontal'})
 
-    expect(result.current.getTabListProps()['aria-orientation']).toBe('horizontal')
+    expect(result.current.getTabListProps({label: 'Test tabs'})['aria-orientation']).toBe('horizontal')
 
     rerender({useTabsOptions: {orientation: 'vertical'}})
 
-    expect(result.current.getTabListProps()['aria-orientation']).toBe('vertical')
+    expect(result.current.getTabListProps({label: 'Test tabs'})['aria-orientation']).toBe('vertical')
   })
 
   it('calls element.focus() when focusTab is called', () => {
@@ -1154,7 +1120,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -1175,7 +1140,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -1200,7 +1164,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -1225,7 +1188,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 
@@ -1250,7 +1212,6 @@ describe('useTabs', () => {
     const tabProps = result.current.getTabProps('test-2')
 
     act(() => {
-      // @ts-expect-error The type for onFocus isn't correct
       tabProps.onFocus?.()
     })
 

--- a/packages/react/src/hooks/useTabs.test.tsx
+++ b/packages/react/src/hooks/useTabs.test.tsx
@@ -66,6 +66,10 @@ const mockKeyboardEvent = (key: string) =>
   } as unknown as React.KeyboardEvent<HTMLElement>)
 
 describe('useTabs', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('returns an object with the expected shape', () => {
     const {result} = renderUseTabsHook()
 
@@ -1094,8 +1098,6 @@ describe('useTabs', () => {
     })
 
     expect(focusSpy).toHaveBeenCalledTimes(1)
-
-    focusSpy.mockRestore()
   })
 
   it('calls element.focus() when keyboard navigation occurs', () => {
@@ -1117,8 +1119,6 @@ describe('useTabs', () => {
     })
 
     expect(focusSpy).toHaveBeenCalledTimes(1)
-
-    focusSpy.mockRestore()
   })
 
   it('calls preventDefault on arrow key events', () => {

--- a/packages/react/src/hooks/useTabs.test.tsx
+++ b/packages/react/src/hooks/useTabs.test.tsx
@@ -326,7 +326,6 @@ describe('useTabs', () => {
     const mockTabElement = {} as HTMLElement
 
     act(() => {
-      // @ts-expect-error The type for tabProps isn't correct
       tabProps.ref(mockTabElement)
     })
 
@@ -345,7 +344,6 @@ describe('useTabs', () => {
     const mockTabElement = {} as HTMLElement
 
     act(() => {
-      // @ts-expect-error The type for tabProps isn't correct
       tabProps.ref(mockTabElement)
     })
 

--- a/packages/react/src/hooks/useTabs.test.tsx
+++ b/packages/react/src/hooks/useTabs.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, {MutableRefObject} from 'react'
 
-import {act, render, renderHook} from '@testing-library/react'
+import {act, render} from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 import {useTabs, type UseTabs, type UseTabsOptions} from './useTabs'
@@ -23,7 +23,7 @@ type TestComponentProps = {
  *    function to match real-world usage.
  */
 const renderUseTabsHook = (initialOptions?: UseTabsOptions) => {
-  const result = React.createRef<UseTabs>() as React.MutableRefObject<UseTabs>
+  const result = React.createRef<UseTabs>() as MutableRefObject<UseTabs>
 
   const MockTabs = ({useTabsOptions}: TestComponentProps) => {
     const useTabsResult = useTabs(useTabsOptions)
@@ -66,10 +66,6 @@ const mockKeyboardEvent = (key: string) =>
   } as unknown as React.KeyboardEvent<HTMLElement>)
 
 describe('useTabs', () => {
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
   it('returns an object with the expected shape', () => {
     const {result} = renderUseTabsHook()
 
@@ -289,7 +285,7 @@ describe('useTabs', () => {
     expect(result.current.activeTab).toBe('test-2')
   })
 
-  it("focuses the tab when an inactive tab's onFocus callback is called", () => {
+  it("focusses the tab when an inactive tab's onFocus callback is called", () => {
     const {result} = renderUseTabsHook({defaultTab: 'test-1'})
 
     expect(result.current.focusedTab).toBeNull()
@@ -304,7 +300,7 @@ describe('useTabs', () => {
     expect(result.current.focusedTab).toBe('test-2')
   })
 
-  it("focuses the tab when an active tab's onFocus callback is called", () => {
+  it("focusses the tab when an active tab's onFocus callback is called", () => {
     const {result} = renderUseTabsHook({defaultTab: 'test-2'})
 
     expect(result.current.focusedTab).toBeNull()
@@ -317,42 +313,6 @@ describe('useTabs', () => {
     })
 
     expect(result.current.focusedTab).toBe('test-2')
-  })
-
-  it('passes the tab element to the provided functional ref', () => {
-    const functionalRef = jest.fn()
-    // We intentionally use `renderHook` here as we want to pass a custom ref
-    const {result} = renderHook(useTabs)
-
-    const tabProps = result.current.getTabProps('test-2', functionalRef)
-
-    const mockTabElement = {} as HTMLElement
-
-    act(() => {
-      // @ts-expect-error The type for tabProps isn't correct
-      tabProps.ref(mockTabElement)
-    })
-
-    expect(functionalRef).toHaveBeenCalledTimes(1)
-    expect(functionalRef).toHaveBeenLastCalledWith(mockTabElement)
-  })
-
-  it("sets the tab element to the provided RefObject's current property", () => {
-    const ref = React.createRef<HTMLDetailsElement>()
-
-    // We intentionally use `renderHook` here as we want to pass a custom ref
-    const {result} = renderHook(useTabs)
-
-    const tabProps = result.current.getTabProps('test-2', ref)
-
-    const mockTabElement = {} as HTMLElement
-
-    act(() => {
-      // @ts-expect-error The type for tabProps isn't correct
-      tabProps.ref(mockTabElement)
-    })
-
-    expect(ref.current).toBe(mockTabElement)
   })
 
   it('sets the role of a tab panel to "tabpanel"', () => {
@@ -869,18 +829,6 @@ describe('useTabs', () => {
     })
 
     expect(result.current.focusedTab).toBe('test-2')
-
-    act(() => {
-      result.current.focusTab('test-3')
-    })
-
-    expect(result.current.focusedTab).toBe('test-3')
-
-    act(() => {
-      result.current.focusTab('test-3')
-    })
-
-    expect(result.current.focusedTab).toBe('test-3')
   })
 
   it('does not change the active tab when focusTab is called', () => {
@@ -1146,6 +1094,8 @@ describe('useTabs', () => {
     })
 
     expect(focusSpy).toHaveBeenCalledTimes(1)
+
+    focusSpy.mockRestore()
   })
 
   it('calls element.focus() when keyboard navigation occurs', () => {
@@ -1167,6 +1117,8 @@ describe('useTabs', () => {
     })
 
     expect(focusSpy).toHaveBeenCalledTimes(1)
+
+    focusSpy.mockRestore()
   })
 
   it('calls preventDefault on arrow key events', () => {

--- a/packages/react/src/hooks/useTabs.test.tsx
+++ b/packages/react/src/hooks/useTabs.test.tsx
@@ -1,6 +1,6 @@
-import React, {MutableRefObject} from 'react'
+import React, {createRef, MutableRefObject} from 'react'
 
-import {act, render} from '@testing-library/react'
+import {act, render, renderHook} from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 import {useTabs, type UseTabs, type UseTabsOptions} from './useTabs'
@@ -317,6 +317,42 @@ describe('useTabs', () => {
     })
 
     expect(result.current.focusedTab).toBe('test-2')
+  })
+
+  it('passes the tab element to the provided functional ref', () => {
+    const functionalRef = jest.fn()
+    // We intentionally use `renderHook` here as we want to pass a custom ref
+    const {result} = renderHook(useTabs)
+
+    const tabProps = result.current.getTabProps('test-2', functionalRef)
+
+    const mockTabElement = {} as HTMLElement
+
+    act(() => {
+      // @ts-expect-error The type for tabProps isn't correct
+      tabProps.ref(mockTabElement)
+    })
+
+    expect(functionalRef).toHaveBeenCalledTimes(1)
+    expect(functionalRef).toHaveBeenLastCalledWith(mockTabElement)
+  })
+
+  it("sets the tab element to the provided RefObject's current property", () => {
+    const ref = createRef<HTMLDetailsElement>()
+
+    // We intentionally use `renderHook` here as we want to pass a custom ref
+    const {result} = renderHook(useTabs)
+
+    const tabProps = result.current.getTabProps('test-2', ref)
+
+    const mockTabElement = {} as HTMLElement
+
+    act(() => {
+      // @ts-expect-error The type for tabProps isn't correct
+      tabProps.ref(mockTabElement)
+    })
+
+    expect(ref.current).toBe(mockTabElement)
   })
 
   it('sets the role of a tab panel to "tabpanel"', () => {

--- a/packages/react/src/hooks/useTabs.ts
+++ b/packages/react/src/hooks/useTabs.ts
@@ -108,12 +108,9 @@ export const useTabs = ({
     [setTabState],
   )
 
-  const focusTab = useCallback(
-    (id: string) => {
-      tabRefs.current.get(id)?.focus()
-    },
-    [setTabState],
-  )
+  const focusTab = useCallback((id: string) => {
+    tabRefs.current.get(id)?.focus()
+  }, [])
 
   const activateTab = useCallback(
     (id: string) => {

--- a/packages/react/src/hooks/useTabs.ts
+++ b/packages/react/src/hooks/useTabs.ts
@@ -1,13 +1,17 @@
-import {useCallback, useState, useRef, type HTMLAttributes, type KeyboardEvent} from 'react'
+import {useCallback, useState, useRef, type KeyboardEvent} from 'react'
 import {useId} from '../hooks/useId'
 
 export type OnTabActivate = (id: string, activeTabRef?: HTMLElement) => void
+
+type Orientation = 'horizontal' | 'vertical'
+type TabId = `tabs-${string}-tab-${string}`
+type TabPanelId = `tabs-${string}-panel-${string}`
 
 export type UseTabsOptions = {
   defaultTab?: string
   autoActivate?: boolean
   onTabActivate?: OnTabActivate
-  orientation?: 'horizontal' | 'vertical'
+  orientation?: Orientation
 }
 
 export type TabState = {
@@ -16,19 +20,41 @@ export type TabState = {
   tabs: Set<string>
 }
 
-export type TabListProps = {
-  label?: string
-  labelledBy?: string
+type TabListProps = {
+  role: 'tablist'
+  'aria-orientation': Orientation
 }
+
+type TabProps = {
+  role: 'tab'
+  id: TabId
+  'aria-controls': TabPanelId
+  'aria-selected': boolean
+  tabIndex: 0 | -1
+  onClick: () => void
+  onKeyDown: (event: KeyboardEvent) => void
+  onFocus: () => void
+  ref: (element: HTMLElement | null) => void
+}
+
+type TabPanelProps = {
+  role: 'tabpanel'
+  id: TabPanelId
+  'aria-labelledby': TabId
+  hidden: boolean
+  tabIndex: 0
+}
+
+type LabelOrLabelledBy = {label: string; labelledBy?: never} | {labelledBy: string; label?: never}
 
 export type UseTabs = {
   activeTab: string | null
   focusedTab: string | null
   activateTab: (id: string) => void
   focusTab: (id: string) => void
-  getTabListProps: (props?: TabListProps) => HTMLAttributes<HTMLElement>
-  getTabProps: (id: string, externalRef?: React.Ref<HTMLElement>) => HTMLAttributes<HTMLElement>
-  getTabPanelProps: (id: string) => HTMLAttributes<HTMLElement>
+  getTabListProps: (props: LabelOrLabelledBy) => TabListProps
+  getTabProps: (id: string, externalRef?: React.Ref<HTMLElement>) => TabProps
+  getTabPanelProps: (id: string) => TabPanelProps
 }
 
 export const useTabs = ({
@@ -63,8 +89,8 @@ export const useTabs = ({
   // Refs to store tab elements for focus management
   const tabRefs = useRef<Map<string, HTMLElement>>(new Map())
 
-  const getTabId = useCallback((id: string) => `tabs-${uniqueId}-tab-${id}`, [uniqueId])
-  const getPanelId = useCallback((id: string) => `tabs-${uniqueId}-panel-${id}`, [uniqueId])
+  const getTabId = useCallback<(id: string) => TabId>(id => `tabs-${uniqueId}-tab-${id}`, [uniqueId])
+  const getPanelId = useCallback<(id: string) => TabPanelId>(id => `tabs-${uniqueId}-panel-${id}`, [uniqueId])
 
   const registerTab = useCallback(
     (id: string, element: HTMLElement) => {
@@ -188,8 +214,8 @@ export const useTabs = ({
     [setTabState],
   )
 
-  const getTabListProps = useCallback(
-    ({label, labelledBy}: TabListProps = {}) => ({
+  const getTabListProps = useCallback<UseTabs['getTabListProps']>(
+    ({label, labelledBy}) => ({
       role: 'tablist',
       'aria-orientation': orientation,
       ...(label && {'aria-label': label}),
@@ -198,7 +224,7 @@ export const useTabs = ({
     [orientation],
   )
 
-  const getTabProps = useCallback(
+  const getTabProps = useCallback<UseTabs['getTabProps']>(
     (id: string, externalRef?: React.ForwardedRef<HTMLElement>) => ({
       role: 'tab',
       id: getTabId(id),
@@ -225,7 +251,7 @@ export const useTabs = ({
     [tabState.activeTab, getTabId, getPanelId, onTabClick, onTabKeyDown, onTabFocus, registerTab],
   )
 
-  const getTabPanelProps = useCallback(
+  const getTabPanelProps = useCallback<UseTabs['getTabPanelProps']>(
     (id: string) => ({
       role: 'tabpanel',
       id: getPanelId(id),

--- a/packages/react/src/hooks/useTabs.ts
+++ b/packages/react/src/hooks/useTabs.ts
@@ -110,19 +110,7 @@ export const useTabs = ({
 
   const focusTab = useCallback(
     (id: string) => {
-      const element = tabRefs.current.get(id)
-      if (element) {
-        element.focus()
-        setTabState(prev => {
-          if (prev.focusedTab === id) {
-            return prev
-          }
-          return {
-            ...prev,
-            focusedTab: id,
-          }
-        })
-      }
+      tabRefs.current.get(id)?.focus()
     },
     [setTabState],
   )


### PR DESCRIPTION
## Summary

Improves types in `useTabs` hook, improves `useTabs` tests, and fixes an accessibility issue in the IDE component which these type improvements automatically highlighted.


## List of notable changes

- Fixes incorrect `onClick`, `onKeyDown`, and `onFocus` types
- Enforces that either a `label` or `labelledBy` is passed to `getTabListProps()`
- Updates the `focusTab` function to only focus the element and nothing else. `onFocus` will handle the state updates. Previously two duplicate state updates were being triggered.
- Generally makes typings in the hook more accurate
- Removes `@ts-expect-error` from `useTabs.test.tsx`, now that the types are fixed
- Adds a missing `label` to the tablist in the IDE component which was highlighted by these type improvements (thanks, TypeScript! 🎉)

## What should reviewers focus on?

- Check out the test tweaks
- Make sure you're happy with the changes to `useTabs`.
- Make sure you're happy with the new tablist label in the IDE component.

## Steps to test

1.

## Supporting resources (related issues, external links, etc)

- 

## Contributor checklist

- [x] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [x] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="740" height="106" alt="image" src="https://github.com/user-attachments/assets/f33f573a-12eb-4fdd-8260-fde203489217" />

 </td>
<td valign="top">

<img width="965" height="113" alt="image" src="https://github.com/user-attachments/assets/f3d58954-94ee-416b-b206-e9d7f105343c" />

</td>
</tr>
</table>