### PR TITLE
Add brand-reviewers CODEOWNERS file for review assignments

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-# All changes should be reviewed by a member of the @react-reviewers team
+# All changes should be reviewed by a member of the @brand-reviewers team
 * @primer/brand-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes should be reviewed by a member of the @react-reviewers team
+* @primer/brand-reviewers


### PR DESCRIPTION
## Summary

I want to propose adding @primer/brand-reviewers as codeowners for the repository, so that we can turn on protections for pull requests to only be reviewed by memebers of that team. 

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

