### PR TITLE
Exclude recipes, fixtures, and test-utils from coverage

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',
+    '!src/recipes/**/*',
     '!**/*.stories.{js,jsx,ts,tsx}',
     '!**/*.visual.spec.{js,jsx,ts,tsx}',
     '!**/*.d.ts',

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -9,6 +9,8 @@ module.exports = {
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',
     '!src/recipes/**/*',
+    '!src/fixtures/**/*',
+    '!src/test-utils/**/*',
     '!**/*.stories.{js,jsx,ts,tsx}',
     '!**/*.visual.spec.{js,jsx,ts,tsx}',
     '!**/*.d.ts',


### PR DESCRIPTION
Excludes the following directories from the coverage report

- `packages/react/src/recipes`
- `packages/react/src/fixtures`
- `packages/react/src/test-utils`

This gives us a more accurate figure for our overall test coverage of 85.34%, compared to 77.22% that was reported before