### PR TITLE
Ensure Icon SVGs are properly vertically aligned

### DIFF
--- a/.changeset/quiet-impalas-pay.md
+++ b/.changeset/quiet-impalas-pay.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Ensures SVGs in the Icon component are properly aligned vertically
+Ensures the `svg` in the `Icon` component is properly aligned vertically

--- a/.changeset/quiet-impalas-pay.md
+++ b/.changeset/quiet-impalas-pay.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Ensures SVGs in the Icon component are properly aligned vertically

--- a/packages/react/src/Icon/Icon.module.css
+++ b/packages/react/src/Icon/Icon.module.css
@@ -4,7 +4,7 @@
 }
 
 .Icon > svg {
-  display: block; /* Ensure SVG is unafffected by text styles and font metrics, maintaining vertical alignment */ 
+  display: block; /* Ensure SVG are unaffected by text styles and font metrics, maintaining vertical alignment */ 
 }
 
 .Icon--size-20 {

--- a/packages/react/src/Icon/Icon.module.css
+++ b/packages/react/src/Icon/Icon.module.css
@@ -3,6 +3,10 @@
   padding: 0;
 }
 
+.Icon > svg {
+  display: block;
+}
+
 .Icon--size-20 {
   width: var(--base-size-20);
   height: var(--base-size-20);

--- a/packages/react/src/Icon/Icon.module.css
+++ b/packages/react/src/Icon/Icon.module.css
@@ -4,7 +4,7 @@
 }
 
 .Icon > svg {
-  display: block; /* Ensure SVG are unaffected by text styles and font metrics, maintaining vertical alignment */ 
+  display: block; /* Ensure SVG are unaffected by text styles and font metrics, maintaining vertical alignment */
 }
 
 .Icon--size-20 {

--- a/packages/react/src/Icon/Icon.module.css
+++ b/packages/react/src/Icon/Icon.module.css
@@ -4,7 +4,7 @@
 }
 
 .Icon > svg {
-  display: block;
+  display: block; /* Ensure SVG is unafffected by text styles and font metrics, maintaining vertical alignment */ 
 }
 
 .Icon--size-20 {


### PR DESCRIPTION
## Summary

Icon component SVGs are currently affected by font styles and metrics, which can cause them to appear off-center in certain situations. This PR addresses this issue. Resolves https://github.com/orgs/github/projects/4709/views/1?pane=issue&itemId=127920860&issue=primer%7Cbrand%7C1154.

## List of notable changes:

- Makes `svg` elements inside `Icon` display `block` instead of `inline-block`
- There are no visual changes because the current version of Mona Sans used in Primer Brand does not affect the icons, unlike the dotcom version.

## What should reviewers focus on?


## Steps to test:

-  Ensure there are no regressions in `Icon` and other components that use `Icon`.
-  Test the canary release in `github/github-ui` to verify that the vertical alignment issue reported in  https://github.com/orgs/github/projects/4709/views/1?pane=issue&itemId=127920860&issue=primer%7Cbrand%7C1154 has been correctly resolved.

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="2390" height="1402" alt="screenshot-DQmjP86R-000393@2x" src="https://github.com/user-attachments/assets/0dc7ef40-b281-4114-81f0-d727405181d0" />


 </td>
<td valign="top">

<img width="2390" height="1402" alt="screenshot-NJmfC8ib-000392@2x" src="https://github.com/user-attachments/assets/da78fc9f-aecf-423f-8833-72891136ec5f" />


</td>
</tr>
</table>
