### PR TITLE
Fix link to grid vs stack documentation

### DIFF
--- a/apps/next-docs/content/layout/Stack/index.mdx
+++ b/apps/next-docs/content/layout/Stack/index.mdx
@@ -10,7 +10,7 @@ tab-label: Guidelines
 
 ## Usage
 
-Use the stack component to distribute space and alignment between items in a vertical or horizontal direction (one-dimensional layout)[^1]. If you need both vertical and horizontal layout (two-dimensional layout), use the [grid](/components/Grid) component instead. When in doubt, we recommend reading the [grid vs stack](/components/Grid#grid-vs-stack) documentation.
+Use the stack component to distribute space and alignment between items in a vertical or horizontal direction (one-dimensional layout)[^1]. If you need both vertical and horizontal layout (two-dimensional layout), use the [grid](/components/Grid) component instead. When in doubt, we recommend reading the [grid vs stack](/brand/layout/Grid/#grid-vs-stack) documentation.
 
 We recommend using the stack component for inline or text based elements. Stack enables items to scale, wrap, and shrink depending on each item's content and the available space.
 


### PR DESCRIPTION
This pull request updates the documentation for the Stack component to point to the correct location for the "grid vs stack" section. The current link seems to be outdated and redirects to the homepage.

Documentation update:

* Updated the Stack component usage guidelines to link to the correct "grid vs stack" section under `/brand/layout/Grid/#grid-vs-stack` instead of `/components/Grid#grid-vs-stack`.