### PR TITLE
fix(ci): restrict deploy workflow to push on default branch to avoid issues

### DIFF
--- a/.github/workflows/deploy_docs_preview.yml
+++ b/.github/workflows/deploy_docs_preview.yml
@@ -1,7 +1,9 @@
 name: Deploy
 
 on:
-  pull_request:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
 
 permissions:
   checks: write


### PR DESCRIPTION
## Summary

Updated the [deploy workflow](https://github.com/primer/brand/blob/main/.github/workflows/deploy_docs_preview.yml) trigger to run **only on `push` events to the default branch** instead of `pull_request`.  
This prevents OIDC token and permission errors that occur when the workflow executes from forked repositories.

## List of notable changes:

- **updated** the workflow trigger to:
  ```yaml
  on:
    push:
      branches: [$default-branch]
  ```

## Steps to test:

1. Go to my [previous PR](https://github.com/primer/brand/pull/1167/checks), and open the Checks tab
2. You'll notice the [.github/workflows/deploy_docs_preview_forks.yml ](https://github.com/primer/brand/blob/db2bbfe4bb3789df4d03d0fadb8faa07e60e5826/.github/workflows/deploy_docs_preview_forks.yml) passes, but the [.github/workflows/deploy_docs_preview.yml ](https://github.com/primer/brand/blob/db2bbfe4bb3789df4d03d0fadb8faa07e60e5826/.github/workflows/deploy_docs_preview.yml) fails.
3. I had the initiative to contribute on this fix since [Rez left a comment](https://github.com/primer/brand/pull/1167#pullrequestreview-3303684109) on my PR pointing out the need to fix this issue

## Reviewer checklist:

- [x] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [x] Check that tests prove the feature works and covers both happy and unhappy paths
- [x] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="1137" height="330" alt="image" src="https://github.com/user-attachments/assets/a5f9c2fc-c57f-4564-a6de-7a8b06b905c0" />

 </td>
<td valign="top">

Now the Deploy workflow is executed only when a push is done on the `default-branch`. Means, the workflow is not getting triggered on PRs.

</td>
</tr>
</table>

## Additional Note

- This PR follows exactly the same approach as the [actions/starter-workflow](https://github.com/actions/starter-workflows/blob/4a8f18e34dd13d2b6ee4d8da2ba72629eafe1609/pages/hugo.yml#L5-L7), to deploy on the specified event.