### PR TITLE
Prevent NPM release on on tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 on:
   push:
+    tags-ignore:
+      - '**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

The Canary release job is incorrectly running on tags, and subsequently failing. ([Example](https://github.com/primer/brand/actions/runs/19738189348))

<img width="756" height="412" alt="Screenshot 2025-11-27 at 16 07 13" src="https://github.com/user-attachments/assets/cf57aa2b-4f7e-4c45-8d6d-f1a024d37ebd" />




This PR fixes it by explicity ignoring tags altogether as a trigger.

The root cause of the problem - and why it only started appearing now - is due to a recent switch to using a GitHub app for issuing short-lived tokens instead of relying on the default `GITHUB_TOKEN` in action runs. `GITHUB_TOKEN` didn't have enough permissions to trigger the release on tags, but the new app-issued token did. This issue was therefore a bug that never materialized until now, and lacked sufficient mitigation.


## List of notable changes:



- Add tag ignore to release.yml



## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Only verifiable by merging this PR and checking it doesn't happen again during the next release, when tags are next created


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="940" height="299" alt="Screenshot 2025-11-27 at 15 48 43" src="https://github.com/user-attachments/assets/4aea81be-f75d-40de-9270-42b22c45ee0d" />


<img width="614" height="41" alt="Screenshot 2025-11-27 at 15 48 24" src="https://github.com/user-attachments/assets/53de7cac-5a90-480c-a15e-c2fd4e7fc9ea" />


 </td>
<td valign="top">

N/A - this won't happen anymore

</td>
</tr>
</table>
