### PR TITLE
Update Doctocat to v0.8.1

### DIFF
--- a/apps/next-docs/package.json
+++ b/apps/next-docs/package.json
@@ -31,7 +31,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@primer/doctocat-nextjs": "^0.8.0",
+    "@primer/doctocat-nextjs": "^0.8.1",
     "@primer/octicons-react": "19.21.2",
     "next": "15.5.9",
     "react": ">=18 <= 19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
       "version": "0.61.1",
       "license": "MIT",
       "dependencies": {
-        "@primer/doctocat-nextjs": "^0.8.0",
+        "@primer/doctocat-nextjs": "^0.8.1",
         "@primer/octicons-react": "19.21.2",
         "next": "15.5.9",
         "react": ">=18 <= 19",
@@ -7171,9 +7171,9 @@
       "link": true
     },
     "node_modules/@primer/doctocat-nextjs": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primer/doctocat-nextjs/-/doctocat-nextjs-0.8.0.tgz",
-      "integrity": "sha512-Vb2o7ujhCy18d8dJRlURtc/qsJEWkFiONhN6CBVkJCXTS22JexWW0F4bczZApYp//UyRmx6HYoXqrx+p5xZN6g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@primer/doctocat-nextjs/-/doctocat-nextjs-0.8.1.tgz",
+      "integrity": "sha512-djTEdyw4jQuJBU4lAptqBAaW/wJiBu48L3oZUWReKPQcDyCBx4pk6O6HRPKazns85wdgvtw8iefxP/vD5MhxcQ==",
       "license": "MIT",
       "dependencies": {
         "@next/mdx": "15.5.7",


### PR DESCRIPTION
Updates Doctocat dependency to the [latest version](https://github.com/primer/doctocat-nextjs/releases/tag/%40primer%2Fdoctocat-nextjs%400.8.1).