### PR TITLE
Downgrade oddbird popover back to 0.52.0

### DIFF
--- a/.changeset/fruity-insects-jump.md
+++ b/.changeset/fruity-insects-jump.md
@@ -8,7 +8,6 @@ Upgraded dependencies to latest minor, patch, and select major versions.
 
 `@primer/react-brand`:
 
-- `@oddbird/popover-polyfill`: 0.5.2 → 0.6.1
 - `autoprefixer`: 10.4.20 → 10.4.27
 - `css-loader`: 7.1.2 → 7.1.4
 - `mini-css-extract-plugin`: 2.9.2 → 2.10.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -33126,7 +33126,7 @@
       "version": "0.65.1",
       "license": "MIT",
       "dependencies": {
-        "@oddbird/popover-polyfill": "0.6.1",
+        "@oddbird/popover-polyfill": "0.5.2",
         "@primer/behaviors": "^1.8.2"
       },
       "devDependencies": {
@@ -33185,9 +33185,9 @@
       }
     },
     "packages/react/node_modules/@oddbird/popover-polyfill": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.6.1.tgz",
-      "integrity": "sha512-Papau51NPG+NajXvoEHCNT1CBJv4WIyvIGfH5gpJPLL8MZJt/4giC0jJ/mNZRtJmdzRuXWpUFB6QxkJa1RvMAQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.5.2.tgz",
+      "integrity": "sha512-iFrvar5SOMtKFOSjYvs4z9UlLqDdJbMx0mgISLcPedv+g0ac5sgeETLGtipHCVIae6HJPclNEH5aCyD1RZaEHw==",
       "license": "BSD-3-Clause"
     },
     "packages/repo-configs": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@oddbird/popover-polyfill": "0.6.1",
+    "@oddbird/popover-polyfill": "0.5.2",
     "@primer/behaviors": "^1.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Rolling back a project dependency to previous version to ensure comptability with downstream users.

Towards unblocking https://github.com/primer/brand/pull/1298

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Roll back @oddbird/popover to 0.5.2

## Supporting resources (related issues, external links, etc):

-
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

 </td>
<td valign="top">

</td>
</tr>
</table>
