### PR TITLE
Fix PricingOptions items and header labels backgrounds

### DIFF
--- a/packages/react/src/PricingOptions/PricingOptions.module.css
+++ b/packages/react/src/PricingOptions/PricingOptions.module.css
@@ -124,18 +124,18 @@
   }
 
   .PricingOptions--layout-default .PricingOptions__label-cell {
-    margin-inline: calc(var(--brand-pricing-options-item-gap, 0px) / 2 * -1);
-    padding-inline: calc(var(--brand-pricing-options-item-gap, 0px) / 2);
+    margin-inline: calc(var(--brand-pricing-options-item-gap) / 2 * -1);
+    padding-inline: calc(var(--brand-pricing-options-item-gap) / 2);
   }
 
   .PricingOptions--layout-default .PricingOptions__label-cell:first-child {
-    margin-inline-start: calc(var(--brand-pricing-options-container-padding-inline, 0px) * -1);
-    padding-inline-start: var(--brand-pricing-options-container-padding-inline, 0px);
+    margin-inline-start: calc(var(--brand-pricing-options-container-padding-inline) * -1);
+    padding-inline-start: var(--brand-pricing-options-container-padding-inline);
   }
 
   .PricingOptions--layout-default .PricingOptions__label-cell:last-child {
-    margin-inline-end: calc(var(--brand-pricing-options-container-padding-inline, 0px) * -1);
-    padding-inline-end: var(--brand-pricing-options-container-padding-inline, 0px);
+    margin-inline-end: calc(var(--brand-pricing-options-container-padding-inline) * -1);
+    padding-inline-end: var(--brand-pricing-options-container-padding-inline);
   }
 
   /* Empty cells: transparent bg/borders but structurally visible so dividers show */

--- a/packages/react/src/PricingOptions/PricingOptions.module.css
+++ b/packages/react/src/PricingOptions/PricingOptions.module.css
@@ -101,13 +101,9 @@
     inset-inline-end: 0;
   }
 
-  /* Default layout: extend accent border into container padding to reach the container edge */
-  .PricingOptions--layout-default .PricingOptions__label-cell--has-label:first-child::after {
-    inset-inline-start: calc(var(--brand-pricing-options-container-padding-inline, 0px) * -1);
-  }
-
-  .PricingOptions--layout-default .PricingOptions__label-cell--has-label:last-child::after {
-    inset-inline-end: calc(var(--brand-pricing-options-container-padding-inline, 0px) * -1);
+  .PricingOptions--layout-default .PricingOptions__label-cell--has-label::after {
+    inset-inline-start: 0;
+    inset-inline-end: 0;
   }
 
   /* ---- Default layout labels ---- */
@@ -128,7 +124,18 @@
   }
 
   .PricingOptions--layout-default .PricingOptions__label-cell {
-    padding-inline: 0;
+    margin-inline: calc(var(--brand-pricing-options-item-gap, 0px) / 2 * -1);
+    padding-inline: calc(var(--brand-pricing-options-item-gap, 0px) / 2);
+  }
+
+  .PricingOptions--layout-default .PricingOptions__label-cell:first-child {
+    margin-inline-start: calc(var(--brand-pricing-options-container-padding-inline, 0px) * -1);
+    padding-inline-start: var(--brand-pricing-options-container-padding-inline, 0px);
+  }
+
+  .PricingOptions--layout-default .PricingOptions__label-cell:last-child {
+    margin-inline-end: calc(var(--brand-pricing-options-container-padding-inline, 0px) * -1);
+    padding-inline-end: var(--brand-pricing-options-container-padding-inline, 0px);
   }
 
   /* Empty cells: transparent bg/borders but structurally visible so dividers show */
@@ -143,7 +150,7 @@
     position: absolute;
     inset-block: 0;
     width: var(--brand-borderWidth-thin);
-    inset-inline-start: calc(var(--brand-pricing-options-item-gap) / 2 * -1);
+    inset-inline-start: 0;
     background-color: var(--brand-color-border-subtle);
   }
 

--- a/packages/react/src/PricingOptions/PricingOptions.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.tsx
@@ -159,6 +159,8 @@ const PricingOptionsRoot = forwardRef(
           ref={ref}
           {...(rest as HTMLAttributes<HTMLElement>)}
         >
+          {filteredChildren}
+
           {hasHeaderLabels && (
             <div
               className={styles['PricingOptions__labels']}
@@ -191,7 +193,6 @@ const PricingOptionsRoot = forwardRef(
               })}
             </div>
           )}
-          {filteredChildren}
         </div>
       </PricingOptionsProvider>
     )


### PR DESCRIPTION
Swaps the order of the PricingOptions item content and header labels markup to prevent a regression when customizations are applied to an item via CSS `:nth-child` (e.g., the highlighted item in https://github.com/features/copilot). Also ensures any background applied fills the entire width of the label cell.

| Before | After |
| ------ | ----- |
| <img width="1337" height="940" alt="image" src="https://github.com/user-attachments/assets/c7cf9bf6-6715-4433-83c1-4a170e0c1269" />       |  <img width="2588" height="1832" alt="screenshot-kssAMffl-000996@2x" src="https://github.com/user-attachments/assets/c68ae56e-eb2d-4d51-b25b-75b2273b039a" />     |

---

_Note: While working on this fix, I noticed a couple of potential issues with the current markup implementation for header labels. It introduces an accessibility regression since the label is no longer associated with the item itself and labels are hidden on smaller viewports. This is non-blocking for the release. I will work on a follow-up to address these issues._
