### PR TITLE
Increase z-index on accent border

### DIFF
--- a/packages/react/src/PricingOptions/PricingOptions.module.css
+++ b/packages/react/src/PricingOptions/PricingOptions.module.css
@@ -89,6 +89,7 @@
     inset-inline-end: calc(var(--brand-pricing-options-item-gap, 0px) / 2 * -1);
     height: var(--brand-borderWidth-thin);
     background-color: var(--brand-color-text-emphasized);
+    z-index: 1;
   }
 
   /* First cell: don't overflow past container start (cards override below) */


### PR DESCRIPTION
## Summary

Patches in higher z-index for the accent border of PricingOptions for active labels.

Towards unblocking the current release https://github.com/primer/brand/pull/1307

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- Increases z-index of the pseudo accent border for PricingOptions.Label, as it's currently falling behind the background color.


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
<img width="831" height="636" alt="Screenshot 2026-04-22 at 13 42 04" src="https://github.com/user-attachments/assets/bfcf1ee4-0462-4dbe-94d4-311b45e5f670" />

 </td>
<td valign="top">
<img width="827" height="643" alt="Screenshot 2026-04-22 at 13 41 52" src="https://github.com/user-attachments/assets/046877a7-5e9d-4e3b-b199-c7a6959a9c2e" />

</td>
</tr>
</table>
