### PR TITLE
Fix section intro docs

### DIFF
--- a/apps/next-docs/content/components/SectionIntro/react.mdx
+++ b/apps/next-docs/content/components/SectionIntro/react.mdx
@@ -65,15 +65,19 @@ The content alignment can be changed using the `align` prop on the root `Section
 | `className` | `string`                   |             | `false`  | SectionIntro custom class                                     |
 | `fullWidth` | `boolean`                  |             | `false`  | Fills available space                                         |
 
-### Hero.Label
+### SectionIntro.Label
 
-| name        | type              | default | description                                  |
-| ----------- | ----------------- | ------- | -------------------------------------------- |
-| `className` | `string`          |         | Sets a custom class on the root of the label |
-| `id`        | `string`          |         | Sets a custom id on the root of the label    |
-| `ref`       | `React.RefObject` |         | Forward a Ref to the underlying DOM node     |
+Optional node that can be used to provide a label for the section.
 
-Forwards all props from the [Label component](/components/Label), including `size` and `color`.
+| name             | type                 | default   | required | description                                  |
+| ---------------- | -------------------- | --------- | -------- | -------------------------------------------- |
+| `children`       | `ReactNode`          |           | `true`   | Content to be displayed inside the label     |
+| `animate`        | `boolean`            | `false`   | `false`  | Enables the cursor animation                 |
+| `animationDelay` | `number`             | `1000`    | `false`  | Delay before the cursor animation starts     |
+| `variant`        | `'default', 'muted'` | `'muted'` | `false`  | Specify alternative text appearance          |
+| `className`      | `string`             |           | `false`  | Sets a custom class on the root of the label |
+| `id`             | `string`             |           | `false`  | Sets a custom id on the root of the label    |
+| `ref`            | `React.RefObject`    |           | `false`  | Forward a Ref to the underlying DOM node     |
 
 ### SectionIntro.Heading <Label>Required</Label>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
     },
     "apps/next-docs": {
       "name": "@primer/brand-docs",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT",
       "dependencies": {
         "@primer/doctocat-nextjs": "0.10.0",
@@ -62,9 +62,9 @@
       },
       "devDependencies": {
         "@github/prettier-config": "^0.0.6",
-        "@primer/brand-primitives": "^0.67.0",
+        "@primer/brand-primitives": "^0.68.0",
         "@primer/react": "38.18.0",
-        "@primer/react-brand": "0.67.0",
+        "@primer/react-brand": "0.68.0",
         "@swc/core": "^1.15.21",
         "@types/node": "24.12.0",
         "@types/react": "^19.2.6",
@@ -155,7 +155,7 @@
     },
     "apps/storybook": {
       "name": "@primer/brand-storybook",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-links": "10.3.4",
@@ -34996,7 +34996,7 @@
     },
     "packages/css": {
       "name": "@primer/brand-css",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "@types/node": "24.12.0",
@@ -35012,7 +35012,7 @@
     },
     "packages/design-tokens": {
       "name": "@primer/brand-primitives",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT",
       "devDependencies": {
         "@primer/primitives": "9.1.1",
@@ -35026,7 +35026,7 @@
     },
     "packages/e2e": {
       "name": "@primer/brand-e2e",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT",
       "devDependencies": {
         "@github/axe-github": "^0.8.1",
@@ -35042,7 +35042,7 @@
     },
     "packages/fonts": {
       "name": "@primer/brand-fonts",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT",
       "engines": {
         "node": ">=24.0.0",
@@ -35051,7 +35051,7 @@
     },
     "packages/react": {
       "name": "@primer/react-brand",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT",
       "dependencies": {
         "@oddbird/popover-polyfill": "0.5.2",
@@ -35191,7 +35191,7 @@
     },
     "packages/repo-configs": {
       "name": "@primer/brand-config",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT"
     }
   }


### PR DESCRIPTION
## Summary

Towards https://github.com/github/brand-marketing-design/issues/2606

Fixes a content bug/issue in Section Intro component docs.

Incorrectly shows Hero.Label instead of SectionIntro.Label.

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- updates the docs to show the correct prop values in the prop table

## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile).
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Check for accuracy

## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Scroll to bottom of this page and verify the props are now correct and don't say Hero.Label



## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
<img width="1030" height="285" alt="Screenshot 2026-06-03 at 10 31 56" src="https://github.com/user-attachments/assets/0f908c8b-2c07-4845-81fb-5c5a7baf5dd7" />

 </td>
<td valign="top">
![Uploading Screenshot 2026-06-03 at 10.31.36.png…]()

</td>
</tr>
</table>
