### PR TITLE
Fix docs links

### DIFF
--- a/apps/next-docs/app/layout.tsx
+++ b/apps/next-docs/app/layout.tsx
@@ -58,6 +58,9 @@ const RootLayout: FC<{children: ReactNode}> = async ({children}) => {
     <html
       lang="en"
       dir="ltr"
+      // Lets Next.js disable smooth scrolling during route transitions so navigation reliably
+      // scrolls to top. See https://nextjs.org/docs/messages/missing-data-scroll-behavior
+      data-scroll-behavior="smooth"
       // Hacks to suppress hydration errors. TODO: Remove this once we have a better solution.
       className="js-focus-visible"
       data-js-focus-visible=""

--- a/apps/next-docs/content/components/ActionMenu/index.mdx
+++ b/apps/next-docs/content/components/ActionMenu/index.mdx
@@ -5,7 +5,7 @@ keywords: ['dropdown', 'select', 'menu', 'options', 'popup']
 show-tabs: false
 ready: true
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=4912%3A32799'
-source: https://github.com/primer/brand/tree/main/packages/react/src/ActionMenu/ActionMenu.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/ActionMenu/ActionMenu.tsx
 storybook: '/brand/storybook/?path=/story/components-actionmenu--default'
 thumbnail: '/images/thumbnails/action-menu-thumbnail.png'
 thumbnail_darkMode: '/images/thumbnails/action-menu-thumbnail-dark.png'

--- a/apps/next-docs/content/components/Avatar/react.mdx
+++ b/apps/next-docs/content/components/Avatar/react.mdx
@@ -5,8 +5,8 @@ keywords: ['image', 'thumbnail', 'profile', 'user', 'organization']
 show-tabs: true
 tab-label: React
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Avatar/Avatar.tsx
-storybook: '/brand/storybook/?path=/story/components-Avatar--playground'
+source: https://github.com/primer/brand/blob/main/packages/react/src/Avatar/Avatar.tsx
+storybook: '/brand/storybook/?path=/story/components-avatar--playground'
 ---
 
 import {Label} from '@primer/react'

--- a/apps/next-docs/content/components/Bento/index.mdx
+++ b/apps/next-docs/content/components/Bento/index.mdx
@@ -226,7 +226,7 @@ Required node that is used to provide a heading for the `Bento.Content`.
 | `className` | `string`                   |             | `false`  | Custom class name for the heading component           |
 | `children`  | `ReactNode`, `ReactNode[]` | `undefined` | `true`   | Content to be displayed inside the heading component. |
 
-Forwards all props from the [Heading component](/components/Heading), including `as`, `size`, and `weight`.
+Forwards all props from the [Heading component](/typography/Heading), including `as`, `size`, and `weight`.
 
 ### Bento.Visual
 

--- a/apps/next-docs/content/components/Breadcrumbs/react.mdx
+++ b/apps/next-docs/content/components/Breadcrumbs/react.mdx
@@ -5,7 +5,7 @@ keywords: ['navigation']
 show-tabs: true
 tab-label: React
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Breadcrumbs/Breadcrumbs.tsx
 storybook: '/brand/storybook/?path=/story/components-breadcrumbs--playground'
 ---
 

--- a/apps/next-docs/content/components/Button/index.mdx
+++ b/apps/next-docs/content/components/Button/index.mdx
@@ -134,5 +134,5 @@ Read more about [descriptive buttons](https://primer.style/design/guides/accessi
 ## Related components
 
 - [ButtonGroup](/components/ButtonGroup): To display a group of related buttons.
-- [Link](/components/Link): To display a link that navigates to another page.
+- [Link](https://primer.style/brand/storybook/?path=/story/components-link--default): To display a link that navigates to another page.
 - [Hero](/components/Hero): To display a large heading and a description with a ButtonGroup.

--- a/apps/next-docs/content/components/Button/index.mdx
+++ b/apps/next-docs/content/components/Button/index.mdx
@@ -134,5 +134,5 @@ Read more about [descriptive buttons](https://primer.style/design/guides/accessi
 ## Related components
 
 - [ButtonGroup](/components/ButtonGroup): To display a group of related buttons.
-- [Link](https://primer.style/brand/storybook/?path=/story/components-link--default): To display a link that navigates to another page.
+- [Link](/brand/storybook/?path=/story/components-link--default): To display a link that navigates to another page.
 - [Hero](/components/Hero): To display a large heading and a description with a ButtonGroup.

--- a/apps/next-docs/content/components/ButtonGroup/index.mdx
+++ b/apps/next-docs/content/components/ButtonGroup/index.mdx
@@ -58,6 +58,6 @@ The button group component has two sizes: `medium` and `large`. The `medium` siz
 ## Related components
 
 - [Button](/components/Button): To display a button that performs an action.
-- [Link](https://primer.style/brand/storybook/?path=/story/components-link--default): To display a link that navigates to another page.
+- [Link](/brand/storybook/?path=/story/components-link--default): To display a link that navigates to another page.
 - [Hero](/components/Hero): To display a large heading and a description with a button group.
 - [CTA banner](/components/CTABanner): To draw attention to or create urgency around a user action.

--- a/apps/next-docs/content/components/ButtonGroup/index.mdx
+++ b/apps/next-docs/content/components/ButtonGroup/index.mdx
@@ -58,6 +58,6 @@ The button group component has two sizes: `medium` and `large`. The `medium` siz
 ## Related components
 
 - [Button](/components/Button): To display a button that performs an action.
-- [Link](/components/Link): To display a link that navigates to another page.
+- [Link](https://primer.style/brand/storybook/?path=/story/components-link--default): To display a link that navigates to another page.
 - [Hero](/components/Hero): To display a large heading and a description with a button group.
 - [CTA banner](/components/CTABanner): To draw attention to or create urgency around a user action.

--- a/apps/next-docs/content/components/ButtonGroup/react.mdx
+++ b/apps/next-docs/content/components/ButtonGroup/react.mdx
@@ -5,7 +5,7 @@ keywords: ['buttons', 'control', 'action', 'group', 'paired']
 show-tabs: true
 tab-label: React
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/ButtonGroup/ButtonGroup.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/ButtonGroup/ButtonGroup.tsx
 storybook: '/brand/storybook/?path=/story/components-buttongroup--playground'
 ---
 

--- a/apps/next-docs/content/components/CTABanner/index.mdx
+++ b/apps/next-docs/content/components/CTABanner/index.mdx
@@ -61,7 +61,7 @@ The CTA banner uses a solid background color by default. This is the recommended
   </Dont>
 </DoDontContainer>
 
-Avoid using noisy or textured images that will make the content hard to read. Make sure that the combination of background and foreground guarantees compliance with WCAG contrast guidelines. Use an [online contrast checker](https://webaim.org/resources/contrastchecker/) or a [Figma plugin](/guides/accessibility/tools#contrast-plugin) to test your contrast.
+Avoid using noisy or textured images that will make the content hard to read. Make sure that the combination of background and foreground guarantees compliance with WCAG contrast guidelines. Use an [online contrast checker](https://webaim.org/resources/contrastchecker/) or a [Figma plugin](https://primer.style/accessibility/tools-and-resources/#contrast-plugin) to test your contrast.
 
 <DoDontContainer>
   <Do>

--- a/apps/next-docs/content/components/CTAForm/index.mdx
+++ b/apps/next-docs/content/components/CTAForm/index.mdx
@@ -93,7 +93,7 @@ It is crucial to provide a clear description of the checkbox's purpose and hyper
 
 ## Related components
 
-- [Button](/components/Button): To display a button that preforms an action.
+- [Button](/components/Button): To display a button that performs an action.
 - [Text input](/forms/TextInput): To create an input form for single-line text field.
 - [Checkbox](/forms/Checkbox): To select options or acknowledge information.
 - [CTA Banner](/components/CTABanner): To draw attention to or create urgency around a user action.

--- a/apps/next-docs/content/components/CTAForm/index.mdx
+++ b/apps/next-docs/content/components/CTAForm/index.mdx
@@ -23,7 +23,7 @@ The CTA form is designed to capture user input and call to actions on a website.
 
 The CTA form presents a concise label, prompting users to provide specific input in the form field. Once users enter the required information, they can trigger the call-to-action through the button. Additionally, the CTA form supports an optional checkbox to seek additional user behavior or acknowledge certain terms.
 
-By adopting the same guidelines as the respective [text input](/components/TextInput) component, [button](/components/Button) component, and [checkbox](/components/Checkbox) component, the CTA form ensures consistency in design and enhances user familiarity with the interface.
+By adopting the same guidelines as the respective [text input](/forms/TextInput) component, [button](/components/Button) component, and [checkbox](/forms/Checkbox) component, the CTA form ensures consistency in design and enhances user familiarity with the interface.
 
 We recommend the CTA form over the [CTA banner](/components/CTABanner) when the main action for a user to take is to submit a form (e.g subscribe to a newsletter) vs taking actions (sign in or bring the user to a pricing page).
 
@@ -94,6 +94,6 @@ It is crucial to provide a clear description of the checkbox's purpose and hyper
 ## Related components
 
 - [Button](/components/Button): To display a button that preforms an action.
-- [Text input](/components/TextInput): To create an input form for single-line text field.
-- [Checkbox](/components/Checkbox): To select options or acknowledge information.
+- [Text input](/forms/TextInput): To create an input form for single-line text field.
+- [Checkbox](/forms/Checkbox): To select options or acknowledge information.
 - [CTA Banner](/components/CTABanner): To draw attention to or create urgency around a user action.

--- a/apps/next-docs/content/components/CTAForm/react.mdx
+++ b/apps/next-docs/content/components/CTAForm/react.mdx
@@ -5,9 +5,9 @@ keywords: ['call to action', 'form', 'input']
 show-tabs: true
 tab-label: React
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/CTAForm/CTAForm.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/CTAForm/CTAForm.tsx
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=1377%3A30754'
-storybook: '/brand/storybook/?path=/story/components-CTAForm--playground'
+storybook: '/brand/storybook/?path=/story/components-ctaform--playground'
 ---
 
 ```js

--- a/apps/next-docs/content/components/Card/index.mdx
+++ b/apps/next-docs/content/components/Card/index.mdx
@@ -60,7 +60,7 @@ When using an image as the visual asset, we recommend using the same aspect rati
   </Dont>
 </DoDontContainer>
 
-Cards typically appear in groups of three or four in desktop viewports. For smaller viewports, or when more than four cards are needed, we recommend stacking the cards vertically. You can use the [Grid](/components/Grid) or the [Stack](/components/Stack) component to achieve this.
+Cards typically appear in groups of three or four in desktop viewports. For smaller viewports, or when more than four cards are needed, we recommend stacking the cards vertically. You can use the [Grid](/layout/Grid) or the [Stack](/layout/Stack) component to achieve this.
 
 Use center alignment when stacking multiple cards up to a maximum of three. For four (or more) use start alignment.
 

--- a/apps/next-docs/content/components/Card/react.mdx
+++ b/apps/next-docs/content/components/Card/react.mdx
@@ -5,7 +5,7 @@ keywords: ['card', 'link', 'summary', 'content', 'information']
 show-tabs: true
 tab-label: React
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Card/Card.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Card/Card.tsx
 storybook: '/brand/storybook/?path=/story/components-card--playground'
 a11yReviewed: true
 ---

--- a/apps/next-docs/content/components/Card/react.mdx
+++ b/apps/next-docs/content/components/Card/react.mdx
@@ -225,7 +225,7 @@ Forwards all the props from the [Image component](/components/Image), including 
 | `variant`  | <CardLabelVariantsProp />  | `token` | `false`  | Presentation of the label above the heading |
 
 Forwards common span props such as `className`, `id`, and `ref`. `variant="token"` renders a
-[Token](/components/Token), and `variant="accent-text"` renders [EyebrowText](/components/EyebrowText)
+[Token](/components/Token), and `variant="accent-text"` renders [EyebrowText](https://primer.style/brand/storybook/?path=/story/components-eyebrowtext--default)
 with its accent presentation.
 
 ### Card.Tokens
@@ -243,7 +243,7 @@ with its accent presentation.
 | `className` | `string`                   |             | `false`  | Custom class name for the heading component          |
 | `children`  | `ReactNode`, `ReactNode[]` | `undefined` | `true`   | Content to be displayed inside the heading component |
 
-Forwards all the props from the [Heading component](/components/Heading), including `as`, `size`, and `weight`.
+Forwards all the props from the [Heading component](/typography/Heading), including `as`, `size`, and `weight`.
 
 ### Card.Description
 

--- a/apps/next-docs/content/components/Card/react.mdx
+++ b/apps/next-docs/content/components/Card/react.mdx
@@ -225,7 +225,7 @@ Forwards all the props from the [Image component](/components/Image), including 
 | `variant`  | <CardLabelVariantsProp />  | `token` | `false`  | Presentation of the label above the heading |
 
 Forwards common span props such as `className`, `id`, and `ref`. `variant="token"` renders a
-[Token](/components/Token), and `variant="accent-text"` renders [EyebrowText](https://primer.style/brand/storybook/?path=/story/components-eyebrowtext--default)
+[Token](/components/Token), and `variant="accent-text"` renders [EyebrowText](/brand/storybook/?path=/story/components-eyebrowtext--default)
 with its accent presentation.
 
 ### Card.Tokens

--- a/apps/next-docs/content/components/FAQ/react.mdx
+++ b/apps/next-docs/content/components/FAQ/react.mdx
@@ -355,7 +355,7 @@ Available options for `toggleColor` are:
   <FAQHeadingToggleColorProp />
 </p>
 
-[See Storybook for all color options](https://primer.style/brand/storybook/?path=/story/components-accordion--toggle-colors).
+[See Storybook for all color options](https://primer.style/brand/storybook/?path=/story/components-accordion-features--togglecolors).
 
 ```jsx filename="noinline"
 const App = () => {

--- a/apps/next-docs/content/components/FAQ/react.mdx
+++ b/apps/next-docs/content/components/FAQ/react.mdx
@@ -497,4 +497,4 @@ render(<App />)
 | :--- | :------------------------ | :-----: | :---------------------------------- |
 | `as` | <FAQGroupHeadingAsProp /> |         | Applies the underlying HTML element |
 
-Forwards all the props from the [Heading component](/components/Heading), including `size`, and `weight`.
+Forwards all the props from the [Heading component](/typography/Heading), including `size`, and `weight`.

--- a/apps/next-docs/content/components/FAQ/react.mdx
+++ b/apps/next-docs/content/components/FAQ/react.mdx
@@ -355,7 +355,7 @@ Available options for `toggleColor` are:
   <FAQHeadingToggleColorProp />
 </p>
 
-[See Storybook for all color options](https://primer.style/brand/storybook/?path=/story/components-accordion-features--togglecolors).
+[See Storybook for all color options](/brand/storybook/?path=/story/components-accordion-features--toggle-colors).
 
 ```jsx filename="noinline"
 const App = () => {

--- a/apps/next-docs/content/components/Footnotes/react.mdx
+++ b/apps/next-docs/content/components/Footnotes/react.mdx
@@ -5,7 +5,7 @@ keywords: ['content', 'footnotes', 'citations', 'contextual information']
 show-tabs: true
 tab-label: React
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Footnotes/Footnotes.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Footnotes/Footnotes.tsx
 storybook: '/brand/storybook/?path=/story/components-footnotes--default'
 ---
 

--- a/apps/next-docs/content/components/Hero/index.mdx
+++ b/apps/next-docs/content/components/Hero/index.mdx
@@ -28,7 +28,7 @@ The description must maintain a minimum contrast ratio of 4.5:1 at all times. Si
 
 The hero component is not designed to provide a lot of information to the user. Consider using other components, such as the [section intro](/components/SectionIntro) or the [river](/components/River) component instead.
 
-The hero heading is rendered as an `h1` element by default. You can modify the heading level but be aware that this will affect the page's heading structure and may impact accessibility. [See heading accesibility](/typography/Heading#accessibility) for more information.
+The hero heading is rendered as an `h1` element by default. You can modify the heading level but be aware that this will affect the page's heading structure and may impact accessibility. [See heading accessibility](/typography/Heading#accessibility) for more information.
 
 The hero can optionally include primary and secondary actions. These actions are rendered as a [button group](/components/ButtonGroup) and follow the same guidelines as the button group component.
 

--- a/apps/next-docs/content/components/Hero/index.mdx
+++ b/apps/next-docs/content/components/Hero/index.mdx
@@ -28,7 +28,7 @@ The description must maintain a minimum contrast ratio of 4.5:1 at all times. Si
 
 The hero component is not designed to provide a lot of information to the user. Consider using other components, such as the [section intro](/components/SectionIntro) or the [river](/components/River) component instead.
 
-The hero heading is rendered as an `h1` element by default. You can modify the heading level but be aware that this will affect the page's heading structure and may impact accessibility. [See heading accesibility](/components/Heading#accessibility) for more information.
+The hero heading is rendered as an `h1` element by default. You can modify the heading level but be aware that this will affect the page's heading structure and may impact accessibility. [See heading accesibility](/typography/Heading#accessibility) for more information.
 
 The hero can optionally include primary and secondary actions. These actions are rendered as a [button group](/components/ButtonGroup) and follow the same guidelines as the button group component.
 

--- a/apps/next-docs/content/components/Hero/react.mdx
+++ b/apps/next-docs/content/components/Hero/react.mdx
@@ -175,7 +175,7 @@ Use [VideoPlayer](/components/VideoPlayer), a native `<video>` element or a YouT
 | `id`        | `string`          |         | Sets a custom id                         |
 | `ref`       | `React.RefObject` |         | Forward a Ref to the underlying DOM node |
 
-Forwards all props from the [Heading component](/components/Heading), including `as`, `size`, and `weight`.
+Forwards all props from the [Heading component](/typography/Heading), including `as`, `size`, and `weight`.
 
 ### Hero.Description
 
@@ -184,7 +184,7 @@ Forwards all props from the [Heading component](/components/Heading), including 
 | `className` | `string`                       |                                       | Sets a custom CSS class             |
 | `variant`   | <HeroDescriptionVariantProp /> | <HeroDescriptionVariantPropDefault /> | Specify alternative text appearance |
 
-Forwards `size` and `weight` props from the [Text component](/components/Text).
+Forwards `size` and `weight` props from the [Text component](/typography/Text).
 
 ### Hero.PrimaryAction
 

--- a/apps/next-docs/content/components/IDE/index.mdx
+++ b/apps/next-docs/content/components/IDE/index.mdx
@@ -168,9 +168,7 @@ Simulate GitHub Copilot Chat using the `IDE.Chat` sub-component. The script is f
 
 See Storybook for a comprehensive example of the Chat feature, inclusive of syntax highlighting.
 
-<a href="https://primer.style/brand/storybook/?path=/story/components-ide-features--chatonly">
-  See Chat example in Storybook
-</a>
+<a href="/brand/storybook/?path=/story/components-ide-features--chat-only">See Chat example in Storybook</a>
 
 </Note>
 

--- a/apps/next-docs/content/components/IDE/index.mdx
+++ b/apps/next-docs/content/components/IDE/index.mdx
@@ -3,7 +3,7 @@ title: IDE
 description: Use the IDE to showcase a simulated integrated developer environment, complete with a code editor and AI chat that's intended to enhance code representation in marketing contexts.
 keywords: ['code', 'editor', 'chat', 'suggestions', 'AI']
 show-tabs: false
-source: https://github.com/primer/brand/tree/main/packages/react/src/IDE/IDE.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/IDE/IDE.tsx
 storybook: '/brand/storybook/?path=/story/components-ide--playground'
 thumbnail: '/images/thumbnails/ide-thumbnail.png'
 thumbnail_darkMode: '/images/thumbnails/ide-thumbnail-dark.png'
@@ -168,7 +168,7 @@ Simulate GitHub Copilot Chat using the `IDE.Chat` sub-component. The script is f
 
 See Storybook for a comprehensive example of the Chat feature, inclusive of syntax highlighting.
 
-<a href="https://primer.style/brand/storybook/?path=/story/components-ide-features--chat-only">
+<a href="https://primer.style/brand/storybook/?path=/story/components-ide-features--chatonly">
   See Chat example in Storybook
 </a>
 

--- a/apps/next-docs/content/components/Icon/index.mdx
+++ b/apps/next-docs/content/components/Icon/index.mdx
@@ -4,7 +4,7 @@ description: Use the icon component to display Octicons with an optional backgro
 keywords: ['Octicon', 'symbol']
 show-tabs: false
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Icon/Icon.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Icon/Icon.tsx
 storybook: '/brand/storybook/?path=/story/components-icon--playground'
 figma: https://www.figma.com/design/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=15397-35
 thumbnail: '/images/thumbnails/icon-thumbnail.png'

--- a/apps/next-docs/content/components/Label/index.mdx
+++ b/apps/next-docs/content/components/Label/index.mdx
@@ -95,4 +95,4 @@ You can add a leading icon to enhance the visual context. It is recommended you 
 ## Related components
 
 - [Button](/components/Button): To provide an action.
-- [Link](/components/Link): To provide navigation.
+- [Link](https://primer.style/brand/storybook/?path=/story/components-link--default): To provide navigation.

--- a/apps/next-docs/content/components/Label/index.mdx
+++ b/apps/next-docs/content/components/Label/index.mdx
@@ -95,4 +95,4 @@ You can add a leading icon to enhance the visual context. It is recommended you 
 ## Related components
 
 - [Button](/components/Button): To provide an action.
-- [Link](https://primer.style/brand/storybook/?path=/story/components-link--default): To provide navigation.
+- [Link](/brand/storybook/?path=/story/components-link--default): To provide navigation.

--- a/apps/next-docs/content/components/LogoSuite/react.mdx
+++ b/apps/next-docs/content/components/LogoSuite/react.mdx
@@ -664,11 +664,11 @@ The `takeoverButton` prop on `LogoSuite.Logobar` adds an interactive hover effec
 | :--------------- | :-------- | :---------- | :----------------------------------------- |
 | `visuallyHidden` | `boolean` | `undefined` | The horizontal alignment of the LogoSuite. |
 
-Forwards all props from the [Heading component](/components/Heading), including `as`, `size`, and `weight`.
+Forwards all props from the [Heading component](/typography/Heading), including `as`, `size`, and `weight`.
 
 ### LogoSuite.Description
 
-Forwards all props from the [Text component](/components/Text), including `as`, `size`, and `variant`.
+Forwards all props from the [Text component](/typography/Text), including `as`, `size`, and `variant`.
 
 ### LogoSuite.Logobar
 

--- a/apps/next-docs/content/components/MediaPlaylist/index.mdx
+++ b/apps/next-docs/content/components/MediaPlaylist/index.mdx
@@ -117,7 +117,7 @@ import {MediaPlaylist} from '@primer/react-brand'
 | `description` | `ReactNode` |         | Optional metadata rendered under the title, such as a video duration  |
 | `children`    | `ReactNode` |         | Custom item heading content when title/description props are not used |
 
-`MediaPlaylist.ItemHeading` renders as a `span` and extends the [`Text`](/components/Text) component, excluding the `as` prop.
+`MediaPlaylist.ItemHeading` renders as a `span` and extends the [`Text`](/typography/Text) component, excluding the `as` prop.
 
 ### MediaPlaylist.ItemContent <Label>Required</Label>
 

--- a/apps/next-docs/content/components/Pagination/index.mdx
+++ b/apps/next-docs/content/components/Pagination/index.mdx
@@ -4,7 +4,7 @@ description: Use Pagination to display a sequence of links that allow navigation
 keywords: ['page numbers', 'page navigation']
 show-tabs: false
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Pagination/Pagination.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Pagination/Pagination.tsx
 storybook: '/brand/storybook/?path=/story/components-pagination--playground'
 thumbnail: '/images/thumbnails/pagination-thumbnail.png'
 thumbnail_darkMode: '/images/thumbnails/pagination-thumbnail-dark.png'

--- a/apps/next-docs/content/components/Pillar/index.mdx
+++ b/apps/next-docs/content/components/Pillar/index.mdx
@@ -66,7 +66,7 @@ Stack multiple pillars to create a collection of items. Ensure that all the item
   </Dont>
 </DoDontContainer>
 
-When presenting more than four pillars, we recommend displaying them in multiple rows. You can use the [Grid](/components/Grid) or the [Stack](/components/Stack) component to achieve this. We recommend using a grid with three or four columns and balancing the number of pillars on each row.
+When presenting more than four pillars, we recommend displaying them in multiple rows. You can use the [Grid](/layout/Grid) or the [Stack](/layout/Stack) component to achieve this. We recommend using a grid with three or four columns and balancing the number of pillars on each row.
 
 ![An image showing a group of numerous Pillars stacked in a three column grid.](https://github.com/primer/brand/assets/912236/350c5eab-bd21-450c-a7a3-60e29c828a3f)
 

--- a/apps/next-docs/content/components/Pillar/react.mdx
+++ b/apps/next-docs/content/components/Pillar/react.mdx
@@ -157,7 +157,7 @@ Forwards all the props from the [Image component](/components/Image), including 
 | `className` | `string`                     |             | `false`  | Custom class name for the heading component           |
 | `children`  | `ReactNode`, `ReactNode[]`   | `undefined` | `true`   | Content to be displayed inside the heading component. |
 
-Forwards all the props from the [Heading component](/components/Heading), including `as`, `size`, and `weight`.
+Forwards all the props from the [Heading component](/typography/Heading), including `as`, `size`, and `weight`.
 
 ### Pillar.Description
 

--- a/apps/next-docs/content/components/Pillar/react.mdx
+++ b/apps/next-docs/content/components/Pillar/react.mdx
@@ -5,7 +5,7 @@ keywords: ['feature', 'benefit', 'icon']
 show-tabs: true
 tab-label: React
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Pillar/Pillar.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Pillar/Pillar.tsx
 storybook: '/brand/storybook/?path=/story/components-pillar--playground'
 figma: https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=6849-31364&mode=design
 ---

--- a/apps/next-docs/content/components/PricingOptions/index.mdx
+++ b/apps/next-docs/content/components/PricingOptions/index.mdx
@@ -244,7 +244,7 @@ This is the two-item layout for the pricing options component.
 `PricingOptions` supports a maximum of four items in both `default` and `card` layouts.
 
 Please refer to our [Storybook
-examples](https://primer.style/brand/storybook/?path=/story/components-pricingoptions-features--threeoptions)
+examples](/brand/storybook/?path=/story/components-pricingoptions-features--three-options)
 to see the component in a full-width context as originally intended.
 
 <Note>

--- a/apps/next-docs/content/components/PricingOptions/index.mdx
+++ b/apps/next-docs/content/components/PricingOptions/index.mdx
@@ -244,7 +244,7 @@ This is the two-item layout for the pricing options component.
 `PricingOptions` supports a maximum of four items in both `default` and `card` layouts.
 
 Please refer to our [Storybook
-examples](https://primer.style/brand/storybook/?path=/story/components-pricingoptions-features--three-options)
+examples](https://primer.style/brand/storybook/?path=/story/components-pricingoptions-features--threeoptions)
 to see the component in a full-width context as originally intended.
 
 <Note>

--- a/apps/next-docs/content/components/River/react.mdx
+++ b/apps/next-docs/content/components/River/react.mdx
@@ -276,14 +276,14 @@ Use the `imageBackgroundColor` prop on `River.Visual` to create a full-bleed con
 
 ### River.Content and RiverBreakout.Content <Label>Required</Label>
 
-[`Label`](https://primer.style/brand/components/Label), [`Text`](https://primer.style/brand/typography/Text),[`Heading`](https://primer.style/brand/typography/Heading), [`Link`](https://primer.style/brand/storybook/?path=/story/components-link--default) are the only `children` accepted. They can be composed in any order, but their rendered output will always be in a predetermined order.
+[`Label`](/components/Label), [`Text`](/typography/Text),[`Heading`](/typography/Heading), [`Link`](/brand/storybook/?path=/story/components-link--default) are the only `children` accepted. They can be composed in any order, but their rendered output will always be in a predetermined order.
 
-| Name        | Type                                                                                                                                                                  | Default | Description                                      |
-| :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-----: | :----------------------------------------------- |
-| `children`  | [`Text`](https://primer.style/brand/typography/Text),[`Heading`](https://primer.style/brand/typography/Heading), [`Link`](https://primer.style/brand/storybook/?path=/story/components-link--default) |         | Content that corrosponds to the adjacent visual. |
-| `className` | `string`                                                                                                                                                              |         | Sets a custom class on the root element          |
-| `id`        | `string`                                                                                                                                                              |         | Sets a custom id                                 |
-| `ref`       | `React.RefObject`                                                                                                                                                     |         | Forward a Ref to the underlying DOM node         |
+| Name        | Type                                                                                                                          | Default | Description                                      |
+| :---------- | :---------------------------------------------------------------------------------------------------------------------------- | :-----: | :----------------------------------------------- |
+| `children`  | [`Text`](/typography/Text),[`Heading`](/typography/Heading), [`Link`](/brand/storybook/?path=/story/components-link--default) |         | Content that corresponds to the adjacent visual. |
+| `className` | `string`                                                                                                                      |         | Sets a custom class on the root element          |
+| `id`        | `string`                                                                                                                      |         | Sets a custom id                                 |
+| `ref`       | `React.RefObject`                                                                                                             |         | Forward a Ref to the underlying DOM node         |
 
 ### RiverBreakout
 

--- a/apps/next-docs/content/components/River/react.mdx
+++ b/apps/next-docs/content/components/River/react.mdx
@@ -276,11 +276,11 @@ Use the `imageBackgroundColor` prop on `River.Visual` to create a full-bleed con
 
 ### River.Content and RiverBreakout.Content <Label>Required</Label>
 
-[`Label`](https://primer.style/brand/components/Label), [`Text`](https://primer.style/brand/components/Text),[`Heading`](https://primer.style/brand/components/Heading), [`Link`](https://primer.style/brand/components/Link) are the only `children` accepted. They can be composed in any order, but their rendered output will always be in a predetermined order.
+[`Label`](https://primer.style/brand/components/Label), [`Text`](https://primer.style/brand/typography/Text),[`Heading`](https://primer.style/brand/typography/Heading), [`Link`](https://primer.style/brand/storybook/?path=/story/components-link--default) are the only `children` accepted. They can be composed in any order, but their rendered output will always be in a predetermined order.
 
 | Name        | Type                                                                                                                                                                  | Default | Description                                      |
 | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-----: | :----------------------------------------------- |
-| `children`  | [`Text`](https://primer.style/brand/components/Text),[`Heading`](https://primer.style/brand/components/Heading), [`Link`](https://primer.style/brand/components/Link) |         | Content that corrosponds to the adjacent visual. |
+| `children`  | [`Text`](https://primer.style/brand/typography/Text),[`Heading`](https://primer.style/brand/typography/Heading), [`Link`](https://primer.style/brand/storybook/?path=/story/components-link--default) |         | Content that corrosponds to the adjacent visual. |
 | `className` | `string`                                                                                                                                                              |         | Sets a custom class on the root element          |
 | `id`        | `string`                                                                                                                                                              |         | Sets a custom id                                 |
 | `ref`       | `React.RefObject`                                                                                                                                                     |         | Forward a Ref to the underlying DOM node         |

--- a/apps/next-docs/content/components/River/react.mdx
+++ b/apps/next-docs/content/components/River/react.mdx
@@ -6,7 +6,7 @@ show-tabs: true
 tab-label: React
 ready: true
 figma: https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=418%3A8416
-source: https://github.com/primer/brand/blob/main/packages/react/src/River/River.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/river/River/River.tsx
 storybook: '/brand/storybook/?path=/story/components-river--default'
 ---
 

--- a/apps/next-docs/content/components/RiverAccordion/index.mdx
+++ b/apps/next-docs/content/components/RiverAccordion/index.mdx
@@ -192,7 +192,7 @@ Use the `gridline` variant to add horizontal border lines, equal-width columns, 
 | :--------- | :------- | :-----: | :----------- |
 | `children` | `string` |         | Heading text |
 
-`RiverAccordion.Heading` extends the [`Heading`](/components/Heading) component and supports all `Heading` props.
+`RiverAccordion.Heading` extends the [`Heading`](/typography/Heading) component and supports all `Heading` props.
 
 ### RiverAccordion.Content <Label>Required</Label>
 

--- a/apps/next-docs/content/components/RiverBreakoutTabs/index.mdx
+++ b/apps/next-docs/content/components/RiverBreakoutTabs/index.mdx
@@ -112,7 +112,7 @@ import {RiverBreakoutTabs} from '@primer/react-brand'
 | `as`       | `'h2' \| 'h3'` | `'h3'`  | Semantic heading level for assistive technologies           |
 | `id`       | `string`       |         | Optional custom ID used for `aria-labelledby` relationships |
 
-`RiverBreakoutTabs.A11yHeading` extends the [`Heading`](/components/Heading) component.
+`RiverBreakoutTabs.A11yHeading` extends the [`Heading`](/typography/Heading) component.
 
 ### RiverBreakoutTabs.Item <Label>Required</Label>
 
@@ -129,7 +129,7 @@ import {RiverBreakoutTabs} from '@primer/react-brand'
 | :--------- | :---------- | :-----: | :---------------- |
 | `children` | `ReactNode` |         | Item heading text |
 
-`RiverBreakoutTabs.Heading` extends the [`Heading`](/components/Heading) component.
+`RiverBreakoutTabs.Heading` extends the [`Heading`](/typography/Heading) component.
 
 ### RiverBreakoutTabs.Content <Label>Required</Label>
 

--- a/apps/next-docs/content/components/Section/index.mdx
+++ b/apps/next-docs/content/components/Section/index.mdx
@@ -43,6 +43,6 @@ The container maintains content margins and allows the use of the Grid to consis
 ## Related components
 
 - [SectionIntro](/components/SectionIntro): to add a heading and optional description to the section.
-- [Stack](/components/Stack): to enable layout of its immediate children along the vertical or horizontal axis.
-- [Grid](/components/Grid): to create flexible and responsive grid-based layouts.
-- [Box](/components/Box): to applying one-off styles to an element.
+- [Stack](/layout/Stack): to enable layout of its immediate children along the vertical or horizontal axis.
+- [Grid](/layout/Grid): to create flexible and responsive grid-based layouts.
+- [Box](/layout/Box): to applying one-off styles to an element.

--- a/apps/next-docs/content/components/Section/index.mdx
+++ b/apps/next-docs/content/components/Section/index.mdx
@@ -45,4 +45,4 @@ The container maintains content margins and allows the use of the Grid to consis
 - [SectionIntro](/components/SectionIntro): to add a heading and optional description to the section.
 - [Stack](/layout/Stack): to enable layout of its immediate children along the vertical or horizontal axis.
 - [Grid](/layout/Grid): to create flexible and responsive grid-based layouts.
-- [Box](/layout/Box): to applying one-off styles to an element.
+- [Box](/layout/Box): to apply one-off styles to an element.

--- a/apps/next-docs/content/components/Section/react.mdx
+++ b/apps/next-docs/content/components/Section/react.mdx
@@ -5,7 +5,7 @@ keywords: ['layout', 'container', 'content', 'structure', 'page']
 show-tabs: true
 tab-label: React
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Section/Section.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Section/Section.tsx
 storybook: '/brand/storybook/?path=/story/components-section--default'
 ---
 

--- a/apps/next-docs/content/components/SectionIntro/react.mdx
+++ b/apps/next-docs/content/components/SectionIntro/react.mdx
@@ -88,7 +88,7 @@ Required node that is used to provide a heading for the section.
 | `className` | `string`                   |             | `false`  | Custom class name for the heading component           |
 | `children`  | `ReactNode`, `ReactNode[]` | `undefined` | `true`   | Content to be displayed inside the heading component. |
 
-Forwards all props from the [Heading component](/components/Heading), including `as`, `size`, and `weight`.
+Forwards all props from the [Heading component](/typography/Heading), including `as`, `size`, and `weight`.
 
 ### SectionIntro.Description
 

--- a/apps/next-docs/content/components/SectionIntro/react.mdx
+++ b/apps/next-docs/content/components/SectionIntro/react.mdx
@@ -7,7 +7,7 @@ tab-label: React
 ready: true
 figma: https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=3891%3A17104&t=j6zvLXblgsO36Wmu-11
 source: https://github.com/primer/brand/blob/main/packages/react/src/SectionIntro/SectionIntro.tsx
-storybook: '/brand/storybook/?path=/story/components-SectionIntro--playground'
+storybook: '/brand/storybook/?path=/story/components-sectionintro--playground'
 ---
 
 import {Label} from '@primer/react'

--- a/apps/next-docs/content/components/SectionIntroStacked/index.mdx
+++ b/apps/next-docs/content/components/SectionIntroStacked/index.mdx
@@ -150,7 +150,7 @@ Required node that is used to provide a heading for the section.
 | `id`        | `string`                   |             | `false`  | Sets a custom id on the root element                  |
 | `animate`   | `AnimateProps`             |             | `false`  | Animation configuration for the component             |
 
-Forwards all props from the [Heading component](/components/Heading), including `as`, `size`, and `weight`.
+Forwards all props from the [Heading component](/typography/Heading), including `as`, `size`, and `weight`.
 
 ### SectionIntroStacked.Link
 
@@ -164,7 +164,7 @@ Optional node that can be used to provide a link.
 | `className` | `string`                   |             | `false`  | Sets a custom class on the root element |
 | `id`        | `string`                   |             | `false`  | Sets a custom id on the root element    |
 
-Forwards most props from the [Link component](/components/Link), but with a default `size` of `medium`.
+Forwards most props from the [Link component](https://primer.style/brand/storybook/?path=/story/components-link--default), but with a default `size` of `medium`.
 
 ### SectionIntroStacked.Description
 
@@ -219,7 +219,7 @@ Optional heading for an item when using sub-components.
 | `className` | `string`                   |             | `false`  | Sets a custom class on the root element    |
 | `id`        | `string`                   |             | `false`  | Sets a custom id on the root element       |
 
-Forwards all props from the [Heading component](/components/Heading), including `as`, `size`, and `weight`. Defaults to `as="h3"`.
+Forwards all props from the [Heading component](/typography/Heading), including `as`, `size`, and `weight`. Defaults to `as="h3"`.
 
 ### SectionIntroStacked.ItemDescription
 

--- a/apps/next-docs/content/components/SectionIntroStacked/index.mdx
+++ b/apps/next-docs/content/components/SectionIntroStacked/index.mdx
@@ -5,7 +5,7 @@ keywords: ['heading', 'intro', 'section']
 show-tabs: false
 ready: true
 source: https://github.com/primer/brand/blob/main/packages/react/src/SectionIntroStacked/SectionIntroStacked.tsx
-storybook: '/brand/storybook/?path=/story/components-SectionIntroStacked--playground'
+storybook: '/brand/storybook/?path=/story/components-sectionintrostacked--playground'
 thumbnail: '/images/thumbnails/section-intro-stacked-thumbnail.png'
 thumbnail_darkMode: '/images/thumbnails/section-intro-stacked-thumbnail-dark.png'
 ---

--- a/apps/next-docs/content/components/SectionIntroStacked/index.mdx
+++ b/apps/next-docs/content/components/SectionIntroStacked/index.mdx
@@ -164,7 +164,7 @@ Optional node that can be used to provide a link.
 | `className` | `string`                   |             | `false`  | Sets a custom class on the root element |
 | `id`        | `string`                   |             | `false`  | Sets a custom id on the root element    |
 
-Forwards most props from the [Link component](https://primer.style/brand/storybook/?path=/story/components-link--default), but with a default `size` of `medium`.
+Forwards most props from the [Link component](/brand/storybook/?path=/story/components-link--default), but with a default `size` of `medium`.
 
 ### SectionIntroStacked.Description
 

--- a/apps/next-docs/content/components/Statistic/index.mdx
+++ b/apps/next-docs/content/components/Statistic/index.mdx
@@ -105,7 +105,7 @@ import {Statistic} from '@primer/react-brand'
 
 ### Statistic.Heading
 
-Forwards all the props from the [Heading component](/components/Heading), including `as`, `size`, and `weight`.
+Forwards all the props from the [Heading component](/typography/Heading), including `as`, `size`, and `weight`.
 
 ### Statistic.Description
 
@@ -113,4 +113,4 @@ Forwards all the props from the [Heading component](/components/Heading), includ
 | :-------- | :---------------------------------- | :---------: | :----------------------------------- |
 | `variant` | <StatisticDescriptionVariantProp /> | `'default'` | Visual presentation of the component |
 
-Forwards most props from the [Text component](/components/Text), including `size`.
+Forwards most props from the [Text component](/typography/Text), including `size`.

--- a/apps/next-docs/content/components/Statistic/index.mdx
+++ b/apps/next-docs/content/components/Statistic/index.mdx
@@ -4,7 +4,7 @@ description: Use the statistic component display concise numerical information
 keywords: ['number', 'percentage', 'value', 'metric']
 show-tabs: false
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Statistic/Statistic.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Statistic/Statistic.tsx
 storybook: '/brand/storybook/?path=/story/components-statistic--default'
 a11yReviewed: false
 thumbnail: '/images/thumbnails/statistic-thumbnail.png'

--- a/apps/next-docs/content/components/SubNav/index.mdx
+++ b/apps/next-docs/content/components/SubNav/index.mdx
@@ -4,7 +4,7 @@ description: A sub nav is a secondary navigation element, typically positioned b
 keywords: ['navigation', 'secondary', 'second level']
 show-tabs: false
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/SubNav/SubNav.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/SubNav/SubNav.tsx
 storybook: '/brand/storybook/?path=/story/components-subnav--default'
 thumbnail: '/images/thumbnails/sub-nav-thumbnail.png'
 thumbnail_darkMode: '/images/thumbnails/sub-nav-thumbnail-dark.png'

--- a/apps/next-docs/content/components/Tabs/index.mdx
+++ b/apps/next-docs/content/components/Tabs/index.mdx
@@ -5,7 +5,7 @@ keywords: ['tabs', 'tab panels', 'navigation', 'tabbed interface']
 show-tabs: false
 ready: true
 source: https://github.com/primer/brand/blob/main/packages/react/src/Tabs/Tabs.tsx
-storybook: '/brand/storybook/?path=/story/components-Tabs--playground'
+storybook: '/brand/storybook/?path=/story/components-tabs--playground'
 thumbnail: '/images/thumbnails/tabs-thumbnail.png'
 thumbnail_darkMode: '/images/thumbnails/tabs-thumbnail-dark.png'
 ---

--- a/apps/next-docs/content/components/Testimonial/react.mdx
+++ b/apps/next-docs/content/components/Testimonial/react.mdx
@@ -7,7 +7,7 @@ tab-label: React
 ready: true
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/Primer-Brand?node-id=1852%3A27522'
 source: https://github.com/primer/brand/blob/main/packages/react/src/Testimonial/Testimonial.tsx
-storybook: '/brand/storybook/?path=/story/components-testimonial'
+storybook: '/brand/storybook/?path=/story/components-testimonial--playground'
 ---
 
 import {

--- a/apps/next-docs/content/components/Timeline/index.mdx
+++ b/apps/next-docs/content/components/Timeline/index.mdx
@@ -3,7 +3,7 @@ title: Timeline
 description: Use the timeline component to display a list of connected items as a vertical timeline.
 show-tabs: false
 ready: true
-source: https://github.com/primer/brand/tree/main/packages/react/src/Timeline/Timeline.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Timeline/Timeline.tsx
 storybook: '/brand/storybook/?path=/story/components-timeline--default'
 thumbnail: '/images/thumbnails/timeline-thumbnail.png'
 thumbnail_darkMode: '/images/thumbnails/timeline-thumbnail-dark.png'

--- a/apps/next-docs/content/components/Token/index.mdx
+++ b/apps/next-docs/content/components/Token/index.mdx
@@ -87,5 +87,5 @@ Use a leading visual when it helps users scan the Token more quickly. Octicons, 
 ## Related components
 
 - [Label](/components/Label): For larger non-interactive status and metadata treatments.
-- [Link](https://primer.style/brand/storybook/?path=/story/components-link--default): For inline navigational text.
+- [Link](/brand/storybook/?path=/story/components-link--default): For inline navigational text.
 - [Button](/components/Button): For higher-emphasis actions.

--- a/apps/next-docs/content/components/Token/index.mdx
+++ b/apps/next-docs/content/components/Token/index.mdx
@@ -87,5 +87,5 @@ Use a leading visual when it helps users scan the Token more quickly. Octicons, 
 ## Related components
 
 - [Label](/components/Label): For larger non-interactive status and metadata treatments.
-- [Link](/components/Link): For inline navigational text.
+- [Link](https://primer.style/brand/storybook/?path=/story/components-link--default): For inline navigational text.
 - [Button](/components/Button): For higher-emphasis actions.

--- a/apps/next-docs/content/components/Tooltip/index.mdx
+++ b/apps/next-docs/content/components/Tooltip/index.mdx
@@ -2,7 +2,7 @@
 title: Tooltip
 description: Use the tooltip component to display a short message when a user hovers or focuses an interactive element.
 keywords: ['tooltip', 'help', 'popup', 'information', 'hint']
-source: https://github.com/primer/brand/tree/main/packages/react/src/Tooltip/Tooltip.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/Tooltip/Tooltip.tsx
 storybook: '/brand/storybook/?path=/story/components-tooltip--playground'
 show-tabs: false
 ready: true

--- a/apps/next-docs/content/components/Tooltip/index.mdx
+++ b/apps/next-docs/content/components/Tooltip/index.mdx
@@ -63,8 +63,4 @@ Use this with caution. It is generally better to use a visible label for better 
 
 ## Related components
 
-- [Popover](/components/Popover): For displaying more complex interactive content that appears when triggered
-- [Button](/components/Button): Often used in conjunction with tooltips
-
-- [Popover](/components/Popover): For displaying more complex interactive content that appears when triggered
-- [Button](/components/Button): Often used in conjunction with tooltips
+- [Button](/components/Button): Often used in conjunction with tooltips.

--- a/apps/next-docs/content/components/UnorderedList/react.mdx
+++ b/apps/next-docs/content/components/UnorderedList/react.mdx
@@ -6,7 +6,7 @@ show-tabs: true
 tab-label: React
 ready: true
 figma: 'https://www.figma.com/file/BJ95AjraesmRCWsKA013GS/branch/NzBMPIfPrFU9I87d3k7KVq/Primer-Brand?node-id=4045%3A17093&t=XJ9W58VgtbVo74gb-0'
-source: https://github.com/primer/brand/tree/main/packages/react/src/list/UnorderedList/UnorderedList.tsx
+source: https://github.com/primer/brand/blob/main/packages/react/src/list/UnorderedList/UnorderedList.tsx
 storybook: '/brand/storybook/?path=/story/components-unorderedlist--playground'
 ---
 

--- a/apps/next-docs/content/components/UnorderedList/react.mdx
+++ b/apps/next-docs/content/components/UnorderedList/react.mdx
@@ -88,4 +88,4 @@ import {UnorderedList} from '@primer/react-brand'
 | `leadingVisualFill`      | `string`                               | `undefined` | Sets a custom color value for the leading visual                                                    |
 | `leadingVisualAriaLabel` | `string`                               | `undefined` | Sets `aria-label` on the leading visual icon                                                        |
 
-Also forwards the `variant` prop from the [Text component](/components/Text).
+Also forwards the `variant` prop from the [Text component](/typography/Text).

--- a/apps/next-docs/content/index.tsx
+++ b/apps/next-docs/content/index.tsx
@@ -90,10 +90,12 @@ export default function HomepageComponent() {
                   </Card>
                 </Grid.Column>
                 <Grid.Column span={{xsmall: 12, large: 6, xlarge: 4}}>
-                  <Card href="/brand/storybook" hasBorder fullWidth ctaText="Go to Storybook">
-                    <Card.Heading as="h2">Storybook</Card.Heading>
-                    <Card.Description>For GitHub Staff only</Card.Description>
-                  </Card>
+                  <NextLink href="/storybook" legacyBehavior passHref>
+                    <Card href="/storybook" hasBorder fullWidth ctaText="Go to Storybook">
+                      <Card.Heading as="h2">Storybook</Card.Heading>
+                      <Card.Description>For GitHub Staff only</Card.Description>
+                    </Card>
+                  </NextLink>
                 </Grid.Column>
               </Grid>
             </Stack>

--- a/apps/next-docs/content/introduction/animation.mdx
+++ b/apps/next-docs/content/introduction/animation.mdx
@@ -111,7 +111,7 @@ Use `animationTrigger="immediate"` to run animations as soon as the component mo
 </AnimationProvider>
 ```
 
-[See Storybook for more examples of animation](/brand/storybook/?path=/story/components-animations--playground).
+[See Storybook for more examples of animation](/storybook/?path=/story/components-animations--playground).
 
 ## Props
 

--- a/apps/next-docs/content/layout/Stack/index.mdx
+++ b/apps/next-docs/content/layout/Stack/index.mdx
@@ -10,7 +10,7 @@ tab-label: Guidelines
 
 ## Usage
 
-Use the stack component to distribute space and alignment between items in a vertical or horizontal direction (one-dimensional layout)[^1]. If you need both vertical and horizontal layout (two-dimensional layout), use the [grid](/components/Grid) component instead. When in doubt, we recommend reading the [grid vs stack](/layout/Grid/#grid-vs-stack) documentation.
+Use the stack component to distribute space and alignment between items in a vertical or horizontal direction (one-dimensional layout)[^1]. If you need both vertical and horizontal layout (two-dimensional layout), use the [grid](/layout/Grid) component instead. When in doubt, we recommend reading the [grid vs stack](/layout/Grid/#grid-vs-stack) documentation.
 
 We recommend using the stack component for inline or text based elements. Stack enables items to scale, wrap, and shrink depending on each item's content and the available space.
 

--- a/apps/next-docs/content/layout/Stack/index.mdx
+++ b/apps/next-docs/content/layout/Stack/index.mdx
@@ -10,7 +10,7 @@ tab-label: Guidelines
 
 ## Usage
 
-Use the stack component to distribute space and alignment between items in a vertical or horizontal direction (one-dimensional layout)[^1]. If you need both vertical and horizontal layout (two-dimensional layout), use the [grid](/components/Grid) component instead. When in doubt, we recommend reading the [grid vs stack](/brand/layout/Grid/#grid-vs-stack) documentation.
+Use the stack component to distribute space and alignment between items in a vertical or horizontal direction (one-dimensional layout)[^1]. If you need both vertical and horizontal layout (two-dimensional layout), use the [grid](/components/Grid) component instead. When in doubt, we recommend reading the [grid vs stack](/layout/Grid/#grid-vs-stack) documentation.
 
 We recommend using the stack component for inline or text based elements. Stack enables items to scale, wrap, and shrink depending on each item's content and the available space.
 

--- a/apps/next-docs/content/typography/Heading/index.mdx
+++ b/apps/next-docs/content/typography/Heading/index.mdx
@@ -60,4 +60,4 @@ Headings allow assistive technology users to quickly navigate around a page. Nav
 
 ## Related components
 
-- [Text](/components/Text): to render body content
+- [Text](/typography/Text): to render body content

--- a/apps/next-docs/mdx-components.js
+++ b/apps/next-docs/mdx-components.js
@@ -22,25 +22,12 @@ import NextLink from 'next/link'
 // eslint-disable-next-line import/extensions
 import {Pre} from './src/components/Pre/Pre.tsx'
 
-const isInternalPath = href => href.startsWith('/') && !href.startsWith('//')
+const isInternalRoute = href =>
+  typeof href === 'string' && href.startsWith('/') && !href.startsWith('//') && !href.startsWith('/brand/')
 
-const hasFileExtension = pathname => /\/[^/]+\.[^/]+$/.test(pathname)
-
-const withTrailingSlash = href => {
-  const [, pathname, suffix = ''] = href.match(/^([^?#]*)([?#].*)?$/)
-
-  if (!pathname || pathname === '/' || pathname.endsWith('/') || hasFileExtension(pathname)) {
-    return href
-  }
-
-  return `${pathname}/${suffix}`
-}
-
-export const Link = ({href = '', children, ...props}) => {
-  const normalizedHref = isInternalPath(href) ? withTrailingSlash(href) : href
-
-  return isInternalPath(href) ? (
-    <NextLink href={normalizedHref} {...props}>
+export const Link = ({href = '', children, ...props}) =>
+  isInternalRoute(href) ? (
+    <NextLink href={href} {...props}>
       {children}
     </NextLink>
   ) : (
@@ -48,7 +35,6 @@ export const Link = ({href = '', children, ...props}) => {
       {children}
     </a>
   )
-}
 
 export function useMDXComponents(customComponents) {
   return {

--- a/apps/next-docs/mdx-components.js
+++ b/apps/next-docs/mdx-components.js
@@ -24,9 +24,23 @@ import {Pre} from './src/components/Pre/Pre.tsx'
 
 const isInternalPath = href => href.startsWith('/') && !href.startsWith('//')
 
+const hasFileExtension = pathname => /\/[^/]+\.[^/]+$/.test(pathname)
+
+const withTrailingSlash = href => {
+  const [, pathname, suffix = ''] = href.match(/^([^?#]*)([?#].*)?$/)
+
+  if (!pathname || pathname === '/' || pathname.endsWith('/') || hasFileExtension(pathname)) {
+    return href
+  }
+
+  return `${pathname}/${suffix}`
+}
+
 export const Link = ({href = '', children, ...props}) => {
+  const normalizedHref = isInternalPath(href) ? withTrailingSlash(href) : href
+
   return isInternalPath(href) ? (
-    <NextLink href={href} {...props}>
+    <NextLink href={normalizedHref} {...props}>
       {children}
     </NextLink>
   ) : (

--- a/apps/next-docs/mdx-components.js
+++ b/apps/next-docs/mdx-components.js
@@ -24,8 +24,8 @@ import {Pre} from './src/components/Pre/Pre.tsx'
 
 const isInternalPath = href => href.startsWith('/') && !href.startsWith('//')
 
-export const Link = ({href = '', children, ...props}) =>
-  isInternalPath(href) ? (
+export const Link = ({href = '', children, ...props}) => {
+  return isInternalPath(href) ? (
     <NextLink href={href} {...props}>
       {children}
     </NextLink>
@@ -34,6 +34,7 @@ export const Link = ({href = '', children, ...props}) =>
       {children}
     </a>
   )
+}
 
 export function useMDXComponents(customComponents) {
   return {

--- a/apps/next-docs/mdx-components.js
+++ b/apps/next-docs/mdx-components.js
@@ -22,7 +22,18 @@ import NextLink from 'next/link'
 // eslint-disable-next-line import/extensions
 import {Pre} from './src/components/Pre/Pre.tsx'
 
-export const Link = ({href = '', ...props}) => <NextLink href={href} {...props} />
+const isInternalPath = href => href.startsWith('/') && !href.startsWith('//')
+
+export const Link = ({href = '', children, ...props}) =>
+  isInternalPath(href) ? (
+    <NextLink href={href} {...props}>
+      {children}
+    </NextLink>
+  ) : (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  )
 
 export function useMDXComponents(customComponents) {
   return {
@@ -45,6 +56,7 @@ export function useMDXComponents(customComponents) {
     PropTableValues,
     TableWrapper,
     Link,
+    a: Link,
     h2: props => <HeadingLink tag="h2" {...props} />,
     h3: props => <HeadingLink tag="h3" {...props} />,
     h4: props => <HeadingLink tag="h4" {...props} />,

--- a/apps/next-docs/src/global.css
+++ b/apps/next-docs/src/global.css
@@ -1,3 +1,8 @@
+html,
+html:focus-within {
+  scroll-behavior: auto;
+}
+
 .bg-red-lines {
   display: inline-block;
   border: var(--brand-borderWidth-thin) solid var(--base-color-scale-red-2);

--- a/apps/next-docs/src/global.css
+++ b/apps/next-docs/src/global.css
@@ -1,8 +1,3 @@
-html,
-html:focus-within {
-  scroll-behavior: auto;
-}
-
 .bg-red-lines {
   display: inline-block;
   border: var(--brand-borderWidth-thin) solid var(--base-color-scale-red-2);


### PR DESCRIPTION
## Summary

Fixes internal links in the docs so they work in both local dev and the production base path (`/brand`), and resolves intermittent scroll jank on navigation.

## List of notable changes:

- **fixed** internal markdown links to use `next/link`, so they respect the base path and resolve to current docs routes
- **fixed** broken link targets in component docs (e.g. `/components/Heading`, `/components/Link`, `EyebrowText`, `Popover`) and outdated Storybook story IDs
- ~**added** trailing-slash normalization for internal links to match the `trailingSlash: true` static export and avoid 308 redirects~
- **fixed** scroll-to-top on navigation by adding `data-scroll-behavior="smooth"` to `<html>` (so Next.js disables smooth scroll during route transitions)

## What should reviewers focus on?

- Internal links resolve correctly in dev and in production under the `/brand` base path
- Clicking links reliably scrolls to the top, while in-page anchor/TOC links still scroll smoothly

## Steps to test:

1. Run the docs locally + check the [preview deployment](https://primer-bb7e877539-26139705.drafts.github.io/brand/)
2. Open a component page, scroll down, on "Related components" links → page should navigate directly and jump to the top
3. Click a table-of-contents/heading anchor → should scroll smoothly within the page

## Supporting resources (related issues, external links, etc):

- https://nextjs.org/docs/messages/missing-data-scroll-behavior
