### PR TITLE
Fix Card arrow overflow in Safari

### DIFF
--- a/.changeset/public-breads-melt.md
+++ b/.changeset/public-breads-melt.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixes an issue where a `Card` with `ctaVariant="arrow"` and a long `ctaText` overflowed and reflowed its content in Safari.

--- a/packages/react/src/Card/Card.module.css
+++ b/packages/react/src/Card/Card.module.css
@@ -388,7 +388,7 @@
 
   margin-block-start: var(--base-size-20);
   min-height: var(--base-size-40);
-  width: fit-content;
+  width: auto;
   min-inline-size: 0;
   max-inline-size: calc(100% - var(--Card-arrowAction-endInset));
   justify-content: flex-start;


### PR DESCRIPTION
## Summary

<!--
A few sentences describing the changes being proposed in this pull request.
-->

Fixes #1371 

Resolves an issue where a `Card` with +ctaVariant="arrow" and a long `ctaText` overflowed and reflowed its content in Safari/WebKit.

## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

-  Fix: Set `width: auto` instead. The pill is `inline-flex`, so it still shrink-wraps but no longer increases the card's intrinsic width. Safari now truncates correctly and keeps card width stable.

## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile).
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Verify that the fix works in Safari and does not introduce regressions

## Supporting resources (related issues, external links, etc):

- https://github.com/primer/brand/issues/1371

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

 https://github.com/user-attachments/assets/238ec6f8-9509-4d0b-837d-f0ea6ec6fddb
 
</td>
<td valign="top">

https://github.com/user-attachments/assets/7f39bed5-2414-4b06-a47d-676593f56d7c


</td>
</tr>
</table>
