### PR TITLE
Update Tiles small viewport density

### DIFF
--- a/.changeset/fresh-tiles-sparkle.md
+++ b/.changeset/fresh-tiles-sparkle.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Updates compact Tiles density so mobile shows four items per row with smaller icons, while tablet shows six items per row.
+Updates compact `Tiles` density so mobile shows four items per row with smaller icons, while tablet shows six items per row.

--- a/.changeset/fresh-tiles-sparkle.md
+++ b/.changeset/fresh-tiles-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Updates compact Tiles density so mobile shows four items per row with smaller icons, while tablet shows six items per row.

--- a/.changeset/fresh-tiles-sparkle.md
+++ b/.changeset/fresh-tiles-sparkle.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Updates compact `Tiles` density so mobile shows four items per row with smaller icons, while tablet shows six items per row.
+Updates compact `Tiles` density so narrow viewports shows four items per row with smaller icons, while medium (tablet) show six items per row.

--- a/packages/react/src/Tiles/Tiles.module.css
+++ b/packages/react/src/Tiles/Tiles.module.css
@@ -13,6 +13,10 @@
   padding: 0;
 }
 
+.Tiles--layout-compact .Tiles-grid {
+  --tiles-columns: 4;
+}
+
 @media screen and (min-width: 48rem) {
   .Tiles--layout-default .Tiles-grid {
     --tiles-columns: 4;
@@ -33,7 +37,7 @@
 
 @media screen and (min-width: 48rem) {
   .Tiles--layout-compact .Tiles-grid {
-    --tiles-columns: 4;
+    --tiles-columns: 6;
   }
 }
 
@@ -137,7 +141,14 @@
 
 .Tiles--layout-compact .Tiles-item-media svg,
 .Tiles--layout-compact .Tiles-item-media img {
-  height: var(--base-size-32);
+  height: var(--base-size-28);
+}
+
+@media screen and (min-width: 48rem) {
+  .Tiles--layout-compact .Tiles-item-media svg,
+  .Tiles--layout-compact .Tiles-item-media img {
+    height: var(--base-size-32);
+  }
 }
 
 .Tiles-item-label {


### PR DESCRIPTION
## Summary

Resolves https://github.com/orgs/github/projects/23995/views/5?pane=issue&itemId=209289621

Updates compact Tiles density so mobile shows four items per row with smaller icons, while tablet shows six items per row.

## List of notable changes:

- **updated** compact Tiles layout density for mobile and tablet viewports.
- **updated** compact Tiles icon sizing for mobile only.

## What should reviewers focus on?

- Verify compact Tiles show four items per row on mobile and six on tablet.
- Verify compact icons are 28px on mobile and 32px at tablet and above.

## Steps to test:

1. Open the Compact Layout story in Storybook.
1. Check mobile viewport sizing.
1. Check tablet viewport sizing.

## Supporting resources (related issues, external links, etc):

- https://github.com/orgs/github/projects/23995/views/5?pane=issue&itemId=209289621

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

**Mobile**

<img src="https://gist.githubusercontent.com/danielguillan/8c46c39988029a2f65f3312f2500eb11/raw/312c6e29181fe71d91c5c051f0dd34a0eb8f32a6/before-mobile.svg" alt="Before mobile compact Tiles" width="360" />

**Tablet**

<img src="https://gist.githubusercontent.com/danielguillan/8c46c39988029a2f65f3312f2500eb11/raw/8efde26293b220a04146b3a4325568167e25ebd6/before-tablet.svg" alt="Before tablet compact Tiles" width="360" />

</td>
<td valign="top">

**Mobile**

<img src="https://gist.githubusercontent.com/danielguillan/8c46c39988029a2f65f3312f2500eb11/raw/9ff51cdba01f8648d982161d2e962c2bb6768685/after-mobile.svg" alt="After mobile compact Tiles" width="360" />

**Tablet**

<img src="https://gist.githubusercontent.com/danielguillan/8c46c39988029a2f65f3312f2500eb11/raw/3befadef0f3b3d15c8b724ef7ab11250c6f0cc2e/after-tablet.svg" alt="After tablet compact Tiles" width="360" />

</td>
</tr>
</table>
