### PR TITLE
Fix missing form-control color tokens in the ESM build

### DIFF
--- a/.changeset/fix-esm-control-color-tokens.md
+++ b/.changeset/fix-esm-control-color-tokens.md
@@ -1,0 +1,7 @@
+---
+'@primer/react-brand': patch
+---
+
+Fixed missing form-control color tokens in the ESM build. `TextInput`, `Textarea`, `Select`, `Checkbox`, `Radio`, and `FormControl` now bundle the `--brand-control-*` color tokens directly, so their borders and boxes render correctly for consumers that import from `@primer/react-brand/esm` without also loading the global `@primer/react-brand/lib/css/main.css` stylesheet.
+
+Previously these tokens only reached CSS through a shared side-effect import in the forms barrel (`forms/index.ts`), which the ESM build drops. On ESM-only pages this left `var(--brand-control-*)` undefined, collapsing control borders (and rendering checkboxes and radios invisible). This affected the `0.70.0` and `0.71.0` releases; consumers using `@primer/react-brand/esm` should upgrade to this release.

--- a/.changeset/fix-esm-control-color-tokens.md
+++ b/.changeset/fix-esm-control-color-tokens.md
@@ -2,6 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Fixed missing form-control color tokens in the ESM build. `TextInput`, `Textarea`, `Select`, `Checkbox`, `Radio`, and `FormControl` now bundle the `--brand-control-*` color tokens directly, so their borders and boxes render correctly for consumers that import from `@primer/react-brand/esm` without also loading the global `@primer/react-brand/lib/css/main.css` stylesheet.
-
-Previously these tokens only reached CSS through a shared side-effect import in the forms barrel (`forms/index.ts`), which the ESM build drops. On ESM-only pages this left `var(--brand-control-*)` undefined, collapsing control borders (and rendering checkboxes and radios invisible). This affected the `0.70.0` and `0.71.0` releases; consumers using `@primer/react-brand/esm` should upgrade to this release.
+Fixed missing styles for ESM form controls, where the dependent design tokens were missing . Affects `TextInput`, `Textarea`, `Select`, `Checkbox`, `Radio`, and `FormControl`.

--- a/packages/react/src/forms/Checkbox/Checkbox.tsx
+++ b/packages/react/src/forms/Checkbox/Checkbox.tsx
@@ -6,6 +6,7 @@ import type {BaseProps} from '../../component-helpers'
 import type {FormValidationStatus} from '../form-types'
 import useLayoutEffect from '../../hooks/useIsomorphicLayoutEffect'
 
+import '@primer/brand-primitives/lib/design-tokens/css/tokens/functional/components/control/colors-with-modes.css'
 import styles from './Checkbox.module.css'
 import {useProvidedRefOrCreate} from '../../hooks/useRef'
 

--- a/packages/react/src/forms/FormControl/FormControl.tsx
+++ b/packages/react/src/forms/FormControl/FormControl.tsx
@@ -13,6 +13,7 @@ import {Textarea} from '../Textarea'
 import {Radio} from '../Radio'
 import {Text} from '../../Text'
 
+import '@primer/brand-primitives/lib/design-tokens/css/tokens/functional/components/control/colors-with-modes.css'
 import styles from './FormControl.module.css'
 
 export type FormControlProps = BaseProps<HTMLElement> & {

--- a/packages/react/src/forms/Radio/Radio.tsx
+++ b/packages/react/src/forms/Radio/Radio.tsx
@@ -5,6 +5,7 @@ import {useProvidedRefOrCreate} from '../../hooks/useRef'
 
 import type {BaseProps} from '../../component-helpers'
 
+import '@primer/brand-primitives/lib/design-tokens/css/tokens/functional/components/control/colors-with-modes.css'
 import styles from './Radio.module.css'
 
 export type RadioProps = {

--- a/packages/react/src/forms/Select/Select.tsx
+++ b/packages/react/src/forms/Select/Select.tsx
@@ -4,6 +4,7 @@ import {clsx} from 'clsx'
 import type {BaseProps} from '../../component-helpers'
 import type {FormInputSizes, FormValidationStatus} from '../form-types'
 
+import '@primer/brand-primitives/lib/design-tokens/css/tokens/functional/components/control/colors-with-modes.css'
 import styles from './Select.module.css'
 
 export type SelectProps = {

--- a/packages/react/src/forms/TextInput/TextInput.tsx
+++ b/packages/react/src/forms/TextInput/TextInput.tsx
@@ -6,6 +6,7 @@ import type {BaseProps} from '../../component-helpers'
 import type {FormInputSizes, FormValidationStatus} from '../form-types'
 import {Text} from '../../Text'
 
+import '@primer/brand-primitives/lib/design-tokens/css/tokens/functional/components/control/colors-with-modes.css'
 import styles from './TextInput.module.css'
 import type {Icon} from '@primer/octicons-react'
 

--- a/packages/react/src/forms/Textarea/Textarea.tsx
+++ b/packages/react/src/forms/Textarea/Textarea.tsx
@@ -4,6 +4,7 @@ import {clsx} from 'clsx'
 import type {BaseProps} from '../../component-helpers'
 import type {FormInputSizes, FormValidationStatus} from '../form-types'
 
+import '@primer/brand-primitives/lib/design-tokens/css/tokens/functional/components/control/colors-with-modes.css'
 import styles from './Textarea.module.css'
 
 export const DEFAULT_TEXTAREA_ROWS = 7

--- a/packages/react/src/forms/index.ts
+++ b/packages/react/src/forms/index.ts
@@ -1,8 +1,3 @@
-/**
- * Shared form (control) design tokens
- */
-import '@primer/brand-primitives/lib/design-tokens/css/tokens/functional/components/control/colors-with-modes.css'
-
 export * from './Checkbox'
 export * from './Textarea'
 export * from './TextInput'


### PR DESCRIPTION
## Summary

The `@primer/react-brand/esm` build never shipped the `--brand-control-*` **color** token family, so pure-ESM consumers that drop the global `lib/css/main.css` lose every form-control border and box: `TextInput` / `Select` / `Textarea` borders disappear and `Checkbox` / `Radio` render invisible (this is what broke the ContactSales form on github.com/enterprise/contact).

The control color tokens reached CSS only through a single side-effect import in the `forms/index.ts` re-export barrel. The ESM build (Vite + rolldown, `preserveModules`) rewrites the package entry to import the leaf component modules directly and never emits `esm/forms/index.js`, so that barrel's CSS side-effect — and the tokens with it — silently vanished from the ESM output. Every other component (Button, Card, Label, …) already co-locates its own `colors-with-modes.css` import inside the component, so its tokens ride along with the component module; the forms family was the lone exception relying on the barrel.

This moves the control-token import into each of the six form components to match that established per-component pattern, and drops the now-redundant barrel import. `lib/css/main.css` (the monolithic CSS-class build) is unaffected.

Both released `0.70.0` and `0.71.0` ship the ESM build without these tokens — no released version has ever shipped working ESM control tokens — so consumers on the ESM entry will need to upgrade to the release containing this fix.

## List of notable changes:

- **added** the `functional/components/control/colors-with-modes.css` import to `TextInput`, `Textarea`, `Select`, `Checkbox`, `Radio` and `FormControl`, so the `--brand-control-*` color tokens ship with the components in the ESM build (mirrors the existing `Button` pattern)
- **removed** the shared control-token import from `forms/index.ts`, since the ESM build drops that re-export barrel and it therefore never delivered the tokens to ESM consumers

## What should reviewers focus on?

- That the co-located import matches the existing per-component convention (e.g. `Button.tsx`), rather than the barrel-level import it replaces.
- That `lib/css/main.css` is unchanged in content — the fix only changes what the ESM build emits (the CSS-class build was already self-contained).
- That the control **sizing/animation** tokens (`--brand-control-large-*`, `--brand-control-medium-*`, `--brand-control-animation-*`), which already shipped in ESM, are not regressed.

## Steps to test:

1. Build the library: `npm run build:lib`.
2. Inspect `packages/react/esm/`: each of the six form component `.js` files now side-effect-imports a `functional/components/control/colors-with-modes-*.css`, and that token CSS is emitted into `esm/` (previously it was absent entirely).
3. Run the reference-vs-definition check over the built `esm/**/*.css`: **0** `--brand-control-*` tokens are now used without a definition (was **32**).
4. Or reproduce as a consumer: import `FormControl` / `TextInput` / `Select` / `Checkbox` / `Radio` from `@primer/react-brand/esm` in a bundler **without** importing `main.css`. Controls now render with borders/boxes; before this fix the borders collapsed and checkboxes/radios were invisible.

<details>
<summary>Reference-vs-definition check (run from <code>packages/react</code>, prints 0 after the fix)</summary>

```js
node -e "const fs=require('fs'),p=require('path'),f=[];(function w(d){for(const e of fs.readdirSync(d,{withFileTypes:1})){const q=p.join(d,e.name);e.isDirectory()?w(q):e.name.endsWith('.css')&&f.push(q)}})('esm');const D=/--(?:brand|base)-[\w-]+\s*:/g,R=/var\(\s*(--(?:brand|base)-[\w-]+)\s*([,)])/g,defs=new Set(),refs=new Map();for(const x of f){const s=fs.readFileSync(x,'utf8');let m;while(m=D.exec(s))defs.add(m[0].replace(/\s*:$/,''));while(m=R.exec(s)){const t=m[1];if(!refs.has(t))refs.set(t,0);if(m[2]===')')refs.set(t,1)}}console.log([...refs].filter(([t,n])=>n&&!defs.has(t)&&t.includes('control')).length)"
```

</details>

## Supporting resources (related issues, external links, etc):

- Affects released `@primer/react-brand@0.70.0` and `@0.71.0` — both ship the ESM build without the `--brand-control-*` color tokens. Consumers using the ESM entry should upgrade once this ships.

## Contributor checklist:

- [x] All new and existing CI checks pass (`tsc`, ESLint with 0 warnings, Prettier, `jest src/forms` — 82 tests)
- [ ] Tests prove that the feature works and covers both happy and unhappy paths — N/A: this is a build/packaging fix with no unit-test surface; validated against the built `esm/` output (reference check + an ESM-only consumer harness)
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots — N/A: no component markup/style changes; `main.css` is unchanged
- [x] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description — N/A

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Same ContactSales-style form rendered from `@primer/react-brand/esm` with **no** `main.css`, production-bundled.

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">

<img width="755" height="713" alt="Before" src="https://github.com/user-attachments/assets/f910a8c0-a3f9-4db9-a76b-2aea70b1a5e1" />

 </td>
<td valign="top">

<img width="756" height="701" alt="After" src="https://github.com/user-attachments/assets/5c23183c-e02b-45f2-8f29-8ccc91a900e4" />

</td>
</tr>
</table>