### PR TITLE
Export `useFocusTrap` hook

### DIFF
--- a/.changeset/tidy-traps-focus.md
+++ b/.changeset/tidy-traps-focus.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': minor
+---
+
+Exported `useFocusTrap` from the package root and created stable container and initial-focus refs when they are not provided.

--- a/packages/react/src/hooks/useFocusTrap.ssr.test.tsx
+++ b/packages/react/src/hooks/useFocusTrap.ssr.test.tsx
@@ -1,0 +1,16 @@
+/** @jest-environment node */
+
+import React from 'react'
+import {renderToString} from 'react-dom/server'
+import {useFocusTrap} from './useFocusTrap'
+
+describe('useFocusTrap SSR', () => {
+  it('renders without a document', () => {
+    const TestComponent = () => {
+      useFocusTrap()
+      return null
+    }
+
+    expect(() => renderToString(<TestComponent />)).not.toThrow()
+  })
+})

--- a/packages/react/src/hooks/useFocusTrap.test.tsx
+++ b/packages/react/src/hooks/useFocusTrap.test.tsx
@@ -10,6 +10,17 @@ jest.mock('@primer/behaviors', () => ({
 const mockFocusTrap = jest.mocked(focusTrap)
 
 describe('useFocusTrap', () => {
+  const TestComponent = ({
+    disabled,
+    restoreFocusOnCleanUp = false,
+  }: {
+    disabled: boolean
+    restoreFocusOnCleanUp?: boolean
+  }) => {
+    const {containerRef} = useFocusTrap<HTMLDivElement>({disabled, restoreFocusOnCleanUp})
+    return <div ref={containerRef} />
+  }
+
   beforeEach(() => {
     mockFocusTrap.mockReturnValue(new AbortController())
   })
@@ -62,11 +73,6 @@ describe('useFocusTrap', () => {
     const abortSpy = jest.spyOn(abortController, 'abort')
     mockFocusTrap.mockReturnValue(abortController)
 
-    const TestComponent = ({disabled}: {disabled: boolean}) => {
-      const {containerRef} = useFocusTrap<HTMLDivElement>({disabled})
-      return <div ref={containerRef} />
-    }
-
     const {rerender} = render(<TestComponent disabled />)
 
     expect(mockFocusTrap).not.toHaveBeenCalled()
@@ -89,20 +95,15 @@ describe('useFocusTrap', () => {
     const nextFocusedElement = document.createElement('button')
     document.body.append(nextFocusedElement)
 
-    const TestComponent = ({disabled}: {disabled: boolean}) => {
-      const {containerRef} = useFocusTrap<HTMLDivElement>({disabled, restoreFocusOnCleanUp: true})
-      return <div ref={containerRef} />
-    }
+    const {rerender} = render(<TestComponent disabled={false} restoreFocusOnCleanUp />)
 
-    const {rerender} = render(<TestComponent disabled={false} />)
-
-    rerender(<TestComponent disabled />)
+    rerender(<TestComponent disabled restoreFocusOnCleanUp />)
     nextFocusedElement.focus()
 
     const focusSpy = jest.spyOn(nextFocusedElement, 'focus')
 
-    rerender(<TestComponent disabled={false} />)
-    rerender(<TestComponent disabled />)
+    rerender(<TestComponent disabled={false} restoreFocusOnCleanUp />)
+    rerender(<TestComponent disabled restoreFocusOnCleanUp />)
 
     expect(focusSpy).toHaveBeenCalled()
 

--- a/packages/react/src/hooks/useFocusTrap.test.tsx
+++ b/packages/react/src/hooks/useFocusTrap.test.tsx
@@ -33,8 +33,8 @@ describe('useFocusTrap', () => {
   })
 
   it('preserves provided refs', () => {
-    const containerRef = React.createRef<HTMLElement>()
-    const initialFocusRef = React.createRef<HTMLElement>()
+    const containerRef = React.createRef<HTMLDivElement>()
+    const initialFocusRef = React.createRef<HTMLButtonElement>()
     const {result} = renderHook(() => useFocusTrap({containerRef, initialFocusRef, disabled: true}))
 
     expect(result.current.containerRef).toBe(containerRef)
@@ -43,11 +43,11 @@ describe('useFocusTrap', () => {
 
   it('passes generated ref elements to the focus trap', () => {
     const TestComponent = () => {
-      const {containerRef, initialFocusRef} = useFocusTrap()
+      const {containerRef, initialFocusRef} = useFocusTrap<HTMLDivElement, HTMLButtonElement>()
 
       return (
-        <div ref={containerRef as React.RefObject<HTMLDivElement | null>}>
-          <button ref={initialFocusRef as React.RefObject<HTMLButtonElement | null>} />
+        <div ref={containerRef}>
+          <button ref={initialFocusRef} />
         </div>
       )
     }
@@ -55,5 +55,58 @@ describe('useFocusTrap', () => {
     const {container} = render(<TestComponent />)
 
     expect(mockFocusTrap).toHaveBeenCalledWith(container.querySelector('div'), container.querySelector('button'))
+  })
+
+  it('starts and aborts the focus trap when disabled changes', () => {
+    const abortController = new AbortController()
+    const abortSpy = jest.spyOn(abortController, 'abort')
+    mockFocusTrap.mockReturnValue(abortController)
+
+    const TestComponent = ({disabled}: {disabled: boolean}) => {
+      const {containerRef} = useFocusTrap<HTMLDivElement>({disabled})
+      return <div ref={containerRef} />
+    }
+
+    const {rerender} = render(<TestComponent disabled />)
+
+    expect(mockFocusTrap).not.toHaveBeenCalled()
+
+    rerender(<TestComponent disabled={false} />)
+
+    expect(mockFocusTrap).toHaveBeenCalledTimes(1)
+
+    rerender(<TestComponent disabled />)
+
+    expect(abortSpy).toHaveBeenCalled()
+  })
+
+  it('captures fresh focus after cleaning up a non-HTMLElement active element', () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('tabindex', '0')
+    document.body.append(svg)
+    svg.focus()
+
+    const nextFocusedElement = document.createElement('button')
+    document.body.append(nextFocusedElement)
+
+    const TestComponent = ({disabled}: {disabled: boolean}) => {
+      const {containerRef} = useFocusTrap<HTMLDivElement>({disabled, restoreFocusOnCleanUp: true})
+      return <div ref={containerRef} />
+    }
+
+    const {rerender} = render(<TestComponent disabled={false} />)
+
+    rerender(<TestComponent disabled />)
+    nextFocusedElement.focus()
+
+    const focusSpy = jest.spyOn(nextFocusedElement, 'focus')
+
+    rerender(<TestComponent disabled={false} />)
+    rerender(<TestComponent disabled />)
+
+    expect(focusSpy).toHaveBeenCalled()
+
+    svg.remove()
+    nextFocusedElement.remove()
   })
 })

--- a/packages/react/src/hooks/useFocusTrap.test.tsx
+++ b/packages/react/src/hooks/useFocusTrap.test.tsx
@@ -10,7 +10,7 @@ jest.mock('@primer/behaviors', () => ({
 const mockFocusTrap = jest.mocked(focusTrap)
 
 describe('useFocusTrap', () => {
-  const TestComponent = ({
+  const ToggleFocusTrapTestComponent = ({
     disabled,
     restoreFocusOnCleanUp = false,
   }: {
@@ -73,15 +73,15 @@ describe('useFocusTrap', () => {
     const abortSpy = jest.spyOn(abortController, 'abort')
     mockFocusTrap.mockReturnValue(abortController)
 
-    const {rerender} = render(<TestComponent disabled />)
+    const {rerender} = render(<ToggleFocusTrapTestComponent disabled />)
 
     expect(mockFocusTrap).not.toHaveBeenCalled()
 
-    rerender(<TestComponent disabled={false} />)
+    rerender(<ToggleFocusTrapTestComponent disabled={false} />)
 
     expect(mockFocusTrap).toHaveBeenCalledTimes(1)
 
-    rerender(<TestComponent disabled />)
+    rerender(<ToggleFocusTrapTestComponent disabled />)
 
     expect(abortSpy).toHaveBeenCalled()
   })
@@ -95,15 +95,15 @@ describe('useFocusTrap', () => {
     const nextFocusedElement = document.createElement('button')
     document.body.append(nextFocusedElement)
 
-    const {rerender} = render(<TestComponent disabled={false} restoreFocusOnCleanUp />)
+    const {rerender} = render(<ToggleFocusTrapTestComponent disabled={false} restoreFocusOnCleanUp />)
 
-    rerender(<TestComponent disabled restoreFocusOnCleanUp />)
+    rerender(<ToggleFocusTrapTestComponent disabled restoreFocusOnCleanUp />)
     nextFocusedElement.focus()
 
     const focusSpy = jest.spyOn(nextFocusedElement, 'focus')
 
-    rerender(<TestComponent disabled={false} restoreFocusOnCleanUp />)
-    rerender(<TestComponent disabled restoreFocusOnCleanUp />)
+    rerender(<ToggleFocusTrapTestComponent disabled={false} restoreFocusOnCleanUp />)
+    rerender(<ToggleFocusTrapTestComponent disabled restoreFocusOnCleanUp />)
 
     expect(focusSpy).toHaveBeenCalled()
 

--- a/packages/react/src/hooks/useFocusTrap.test.tsx
+++ b/packages/react/src/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import {focusTrap} from '@primer/behaviors'
+import {render, renderHook} from '@testing-library/react'
+import {useFocusTrap} from './useFocusTrap'
+
+jest.mock('@primer/behaviors', () => ({
+  focusTrap: jest.fn(),
+}))
+
+const mockFocusTrap = jest.mocked(focusTrap)
+
+describe('useFocusTrap', () => {
+  beforeEach(() => {
+    mockFocusTrap.mockReturnValue(new AbortController())
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('creates stable refs when refs are not provided', () => {
+    const {result, rerender} = renderHook(() => useFocusTrap({disabled: true}))
+    const initialContainerRef = result.current.containerRef
+    const initialFocusRef = result.current.initialFocusRef
+
+    expect(initialContainerRef.current).toBeNull()
+    expect(initialFocusRef.current).toBeNull()
+
+    rerender()
+
+    expect(result.current.containerRef).toBe(initialContainerRef)
+    expect(result.current.initialFocusRef).toBe(initialFocusRef)
+  })
+
+  it('preserves provided refs', () => {
+    const containerRef = React.createRef<HTMLElement>()
+    const initialFocusRef = React.createRef<HTMLElement>()
+    const {result} = renderHook(() => useFocusTrap({containerRef, initialFocusRef, disabled: true}))
+
+    expect(result.current.containerRef).toBe(containerRef)
+    expect(result.current.initialFocusRef).toBe(initialFocusRef)
+  })
+
+  it('passes generated ref elements to the focus trap', () => {
+    const TestComponent = () => {
+      const {containerRef, initialFocusRef} = useFocusTrap()
+
+      return (
+        <div ref={containerRef as React.RefObject<HTMLDivElement | null>}>
+          <button ref={initialFocusRef as React.RefObject<HTMLButtonElement | null>} />
+        </div>
+      )
+    }
+
+    const {container} = render(<TestComponent />)
+
+    expect(mockFocusTrap).toHaveBeenCalledWith(container.querySelector('div'), container.querySelector('button'))
+  })
+})

--- a/packages/react/src/hooks/useFocusTrap.ts
+++ b/packages/react/src/hooks/useFocusTrap.ts
@@ -1,18 +1,19 @@
 import React from 'react'
 import {focusTrap} from '@primer/behaviors'
+import {useProvidedRefOrCreate} from './useRef'
 
 export interface FocusTrapHookSettings {
   /**
    * Ref that will be used for the trapping container. If not provided, one will
    * be created by this hook and returned.
    */
-  containerRef: React.RefObject<HTMLElement | null>
+  containerRef?: React.Ref<HTMLElement>
 
   /**
    * Ref for the element that should receive focus when the focus trap is first enabled.
    * If not provided, one will be created by this hook and returned. Its use is optional.
    */
-  initialFocusRef?: React.RefObject<HTMLElement | null>
+  initialFocusRef?: React.Ref<HTMLElement>
 
   /**
    * Set to true to disable the focus trap and clean up listeners. Can be re-enabled at any time.
@@ -34,11 +35,11 @@ export function useFocusTrap(
   settings?: FocusTrapHookSettings,
   dependencies: React.DependencyList = [],
 ): {
-  containerRef: React.RefObject<HTMLElement | null> | undefined
-  initialFocusRef: React.RefObject<HTMLElement | null> | undefined
+  containerRef: React.RefObject<HTMLElement | null>
+  initialFocusRef: React.RefObject<HTMLElement | null>
 } {
-  const containerRef = settings?.containerRef
-  const initialFocusRef = settings?.initialFocusRef
+  const containerRef = useProvidedRefOrCreate<HTMLElement | null>(settings?.containerRef)
+  const initialFocusRef = useProvidedRefOrCreate<HTMLElement | null>(settings?.initialFocusRef)
   const disabled = settings?.disabled
   const abortController = React.useRef<AbortController | null>(null)
   const previousFocusedElement = React.useRef<Element | null>(null)
@@ -61,9 +62,9 @@ export function useFocusTrap(
 
   React.useEffect(
     () => {
-      if (containerRef?.current instanceof HTMLElement) {
+      if (containerRef.current instanceof HTMLElement) {
         if (!disabled) {
-          abortController.current = focusTrap(containerRef.current, initialFocusRef?.current ?? undefined) ?? null
+          abortController.current = focusTrap(containerRef.current, initialFocusRef.current ?? undefined) ?? null
           return () => {
             disableTrap()
           }

--- a/packages/react/src/hooks/useFocusTrap.ts
+++ b/packages/react/src/hooks/useFocusTrap.ts
@@ -44,12 +44,6 @@ export function useFocusTrap(
   const abortController = React.useRef<AbortController | null>(null)
   const previousFocusedElement = React.useRef<Element | null>(null)
 
-  // If we are enabling a focus trap and haven't already stored the previously focused element
-  // go ahead an do that so we can restore later when the trap is disabled.
-  if (typeof document !== 'undefined' && !previousFocusedElement.current && !settings?.disabled) {
-    previousFocusedElement.current = document.activeElement
-  }
-
   // This function removes the event listeners that enable the focus trap and restores focus
   // to the previously-focused element (if necessary).
   function disableTrap() {
@@ -64,6 +58,9 @@ export function useFocusTrap(
     () => {
       if (containerRef.current instanceof HTMLElement) {
         if (!disabled) {
+          if (!previousFocusedElement.current) {
+            previousFocusedElement.current = document.activeElement
+          }
           abortController.current = focusTrap(containerRef.current, initialFocusRef.current ?? undefined) ?? null
           return () => {
             disableTrap()

--- a/packages/react/src/hooks/useFocusTrap.ts
+++ b/packages/react/src/hooks/useFocusTrap.ts
@@ -4,16 +4,16 @@ import {useProvidedRefOrCreate} from './useRef'
 
 export interface FocusTrapHookSettings {
   /**
-   * Ref that will be used for the trapping container. If not provided, one will
+   * Ref object that will be used for the trapping container. If not provided, one will
    * be created by this hook and returned.
    */
-  containerRef?: React.Ref<HTMLElement>
+  containerRef?: React.RefObject<HTMLElement | null>
 
   /**
-   * Ref for the element that should receive focus when the focus trap is first enabled.
+   * Ref object for the element that should receive focus when the focus trap is first enabled.
    * If not provided, one will be created by this hook and returned. Its use is optional.
    */
-  initialFocusRef?: React.Ref<HTMLElement>
+  initialFocusRef?: React.RefObject<HTMLElement | null>
 
   /**
    * Set to true to disable the focus trap and clean up listeners. Can be re-enabled at any time.
@@ -46,7 +46,7 @@ export function useFocusTrap(
 
   // If we are enabling a focus trap and haven't already stored the previously focused element
   // go ahead an do that so we can restore later when the trap is disabled.
-  if (!previousFocusedElement.current && !settings?.disabled) {
+  if (typeof document !== 'undefined' && !previousFocusedElement.current && !settings?.disabled) {
     previousFocusedElement.current = document.activeElement
   }
 

--- a/packages/react/src/hooks/useFocusTrap.ts
+++ b/packages/react/src/hooks/useFocusTrap.ts
@@ -2,18 +2,21 @@ import React from 'react'
 import {focusTrap} from '@primer/behaviors'
 import {useProvidedRefOrCreate} from './useRef'
 
-export interface FocusTrapHookSettings {
+export interface FocusTrapHookSettings<
+  ContainerElement extends HTMLElement = HTMLElement,
+  InitialFocusElement extends HTMLElement = HTMLElement,
+> {
   /**
    * Ref object that will be used for the trapping container. If not provided, one will
    * be created by this hook and returned.
    */
-  containerRef?: React.RefObject<HTMLElement | null>
+  containerRef?: React.RefObject<ContainerElement | null>
 
   /**
    * Ref object for the element that should receive focus when the focus trap is first enabled.
    * If not provided, one will be created by this hook and returned. Its use is optional.
    */
-  initialFocusRef?: React.RefObject<HTMLElement | null>
+  initialFocusRef?: React.RefObject<InitialFocusElement | null>
 
   /**
    * Set to true to disable the focus trap and clean up listeners. Can be re-enabled at any time.
@@ -31,15 +34,18 @@ export interface FocusTrapHookSettings {
  * that should trap focus.
  * @param settings {FocusTrapHookSettings}
  */
-export function useFocusTrap(
-  settings?: FocusTrapHookSettings,
+export function useFocusTrap<
+  ContainerElement extends HTMLElement = HTMLElement,
+  InitialFocusElement extends HTMLElement = HTMLElement,
+>(
+  settings?: FocusTrapHookSettings<ContainerElement, InitialFocusElement>,
   dependencies: React.DependencyList = [],
 ): {
-  containerRef: React.RefObject<HTMLElement | null>
-  initialFocusRef: React.RefObject<HTMLElement | null>
+  containerRef: React.RefObject<ContainerElement | null>
+  initialFocusRef: React.RefObject<InitialFocusElement | null>
 } {
-  const containerRef = useProvidedRefOrCreate<HTMLElement | null>(settings?.containerRef)
-  const initialFocusRef = useProvidedRefOrCreate<HTMLElement | null>(settings?.initialFocusRef)
+  const containerRef = useProvidedRefOrCreate<ContainerElement | null>(settings?.containerRef)
+  const initialFocusRef = useProvidedRefOrCreate<InitialFocusElement | null>(settings?.initialFocusRef)
   const disabled = settings?.disabled
   const abortController = React.useRef<AbortController | null>(null)
   const previousFocusedElement = React.useRef<Element | null>(null)
@@ -50,8 +56,8 @@ export function useFocusTrap(
     abortController.current?.abort()
     if (settings?.restoreFocusOnCleanUp && previousFocusedElement.current instanceof HTMLElement) {
       previousFocusedElement.current.focus()
-      previousFocusedElement.current = null
     }
+    previousFocusedElement.current = null
   }
 
   React.useEffect(

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -59,4 +59,5 @@ export * from './TextCursorAnimation'
 export * from './Tiles'
 
 // hooks
+export * from './hooks/useFocusTrap'
 export * from './hooks/useWindowSize'


### PR DESCRIPTION
## Summary

Resolves #1399

Exports `useFocusTrap` from the `@primer/react-brand` package.

The hook now creates missing refs automatically and captures previous focus when the trap activates.

## List of notable changes:

- **exported** `useFocusTrap` and `FocusTrapHookSettings` from the package root
- **updated** `useFocusTrap` to create missing refs while preserving supplied object refs
- **added** typed refs that work directly with specific HTML elements
- **moved** previous-focus capture into `useEffect` so rendering remains SSR-safe
- **reset** stored previous focus after cleanup so later activations capture the current element
- **added** direct hook, lifecycle, and SSR regression coverage

## Supporting resources (related issues, external links, etc):

- #1399

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there are not other open Pull Requests for the same update/change

## Screenshots:

N/A



