### PR TITLE
Add inline padding to FAQ gridline variant

### DIFF
--- a/.changeset/wide-faq-gridlines.md
+++ b/.changeset/wide-faq-gridlines.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Updated the `FAQ` gridline variant to include inline padding by default for narrow viewports.

--- a/packages/react/src/FAQ/FAQ.module.css
+++ b/packages/react/src/FAQ/FAQ.module.css
@@ -10,11 +10,13 @@
 }
 
 .FAQ__content-wrapper--gridline {
+  padding-inline: var(--base-size-20);
   max-width: var(--brand-FAQ-maxWidth-list);
   margin: 0 auto;
 }
 
 .FAQ__heading-wrapper--gridline {
+  padding-inline: var(--base-size-20);
   border-block-end: var(--brand-color-border-muted) var(--brand-borderWidth-thin) solid;
   margin-block-end: var(--base-size-40);
 }
@@ -69,7 +71,19 @@
   margin: 0;
 }
 
+@media screen and (min-width: 48rem) {
+  .FAQ__content-wrapper--gridline,
+  .FAQ__heading-wrapper--gridline {
+    padding-inline: var(--base-size-36);
+  }
+}
+
 @media screen and (min-width: 63.25rem) {
+  .FAQ__content-wrapper--gridline,
+  .FAQ__heading-wrapper--gridline {
+    padding-inline: 0;
+  }
+
   .FAQ__heading-wrapper--gridline {
     margin-block-end: var(--base-size-48);
   }


### PR DESCRIPTION
## Summary

Towards https://github.com/github/marketing-engineering/issues/6047

Adds inline padding to FAQ where`variant="gridline"`. Only applies to mobile and tablet.

🔗 [Preview](https://primer-8a7ea28126-26139705.drafts.github.io/brand/storybook/?path=/story/components-faq-features--gridline-variant)


## List of notable changes:

<!--
E.g.

- **added** # for # component because #
- **removed** props for # component because #
- **updated** documentation for # component because #
-->

- 20px at mobile
- 36px at tablet
- 0 at desktop

## What should reviewers focus on?

<!--
Help reviewers check the changes applied.

E.g. For site designers

Verify that the implementation is aligned with the design proposal:
- Ensure the layout and the spacing are correct in different viewport sizes (desktop, tablet and mobile).
- Check dark and light color modes.
- Check the interactive states, such as hover, focus or active ones.
-->

- Confirm values for spacing are correct


## Steps to test:

<!--
Help reviewers test the feature by providing steps to reproduce the behavior.

E.g.

1. Open the # component in CI-deployed preview environment
2. Go to # story in Storybook
3. Verify that # behaves as described in the following issue.
-->

1. Use this story at different breakpoints

## Supporting resources (related issues, external links, etc):

-
-

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
<img width="497" height="506" alt="Screenshot 2026-08-10 at 18 02 42" src="https://github.com/user-attachments/assets/223a77a3-35d3-4eb5-9280-08544f6dcf75" />

 </td>
<td valign="top">
<img width="495" height="478" alt="Screenshot 2026-08-10 at 18 02 04" src="https://github.com/user-attachments/assets/f886506e-eacb-4a08-8133-485c202a63f3" />

</td>
</tr>
</table>
