### PR TITLE
upgrade doctocat to fix videoplay bug

### DIFF
--- a/apps/next-docs/package.json
+++ b/apps/next-docs/package.json
@@ -31,7 +31,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@primer/doctocat-nextjs": "0.10.0",
+    "@primer/doctocat-nextjs": "0.11.0",
     "@primer/octicons-react": "19.23.1",
     "next": "16.2.2",
     "react": "19.2.4",

--- a/apps/next-docs/package.json
+++ b/apps/next-docs/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@primer/doctocat-nextjs": "0.11.0",
-    "@primer/octicons-react": "19.23.1",
+    "@primer/octicons-react": "19.33.0",
     "next": "16.2.2",
     "react": "19.2.4",
     "react-dom": "19.2.4"
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@github/prettier-config": "^0.0.6",
     "@primer/brand-primitives": "^0.73.0",
-    "@primer/react": "38.18.0",
+    "@primer/react": "38.35.1",
     "@primer/react-brand": "0.73.0",
     "@swc/core": "^1.15.21",
     "@types/node": "24.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,10 +51,10 @@
     },
     "apps/next-docs": {
       "name": "@primer/brand-docs",
-      "version": "0.71.0",
+      "version": "0.73.0",
       "license": "MIT",
       "dependencies": {
-        "@primer/doctocat-nextjs": "0.10.0",
+        "@primer/doctocat-nextjs": "0.11.0",
         "@primer/octicons-react": "19.23.1",
         "next": "16.2.2",
         "react": "19.2.4",
@@ -62,9 +62,9 @@
       },
       "devDependencies": {
         "@github/prettier-config": "^0.0.6",
-        "@primer/brand-primitives": "^0.71.0",
+        "@primer/brand-primitives": "^0.73.0",
         "@primer/react": "38.18.0",
-        "@primer/react-brand": "0.71.0",
+        "@primer/react-brand": "0.73.0",
         "@swc/core": "^1.15.21",
         "@types/node": "24.12.0",
         "@types/react": "^19.2.6",
@@ -155,7 +155,7 @@
     },
     "apps/storybook": {
       "name": "@primer/brand-storybook",
-      "version": "0.71.0",
+      "version": "0.73.0",
       "license": "MIT",
       "dependencies": {
         "@storybook/addon-links": "10.3.4",
@@ -6511,6 +6511,7 @@
       "version": "4.8.2",
       "resolved": "https://registry.npmjs.org/@github/tab-container-element/-/tab-container-element-4.8.2.tgz",
       "integrity": "sha512-WkaM4mfs8x7dXRWEaDb5deC0OhH6sGQ5cw8i/sVw25gikl4f8C7mHj0kihL5k3eKIIqmGT1Fdswdoi+9ZLDpRA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@hapi/hoek": {
@@ -8903,9 +8904,9 @@
       }
     },
     "node_modules/@next/mdx": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-16.2.2.tgz",
-      "integrity": "sha512-2CbRTXE6sJ7zDAaKXknb5FrrPs46iJeMPzuoBXsAOV/XVnxABGD4mSDusn0VuCoII/KjUZ+zsuo2VFbchYQXng==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-16.3.0.tgz",
+      "integrity": "sha512-Vpfuf928ACvx4AOdDXWx/cj13Ak6xlvMn3QCkjvfQMmLnQWCesQTeY01CPDbIyZvjY+NOwP7bvbvJ2ghkj/3GA==",
       "license": "MIT",
       "dependencies": {
         "source-map": "^0.7.0"
@@ -10072,9 +10073,9 @@
       }
     },
     "node_modules/@primer/behaviors": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.10.2.tgz",
-      "integrity": "sha512-93juWZbWg2DRhC11+7RT7hMpY1VD3lBosLmccqEZ65yrCHqkBCjI8Uj8wxs3y0U+wWE07LAoLHAPylyWbifg5A==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.10.3.tgz",
+      "integrity": "sha512-cxxWDeR5IE7vdL0Ca0RAAAuPVrU+Bo8CSP1WfawGo4rEP1sZTi7hwl5i7TT0jCTCR0C9IfnQBfSPAkz0oznxUw==",
       "license": "MIT"
     },
     "node_modules/@primer/brand-config": {
@@ -10110,20 +10111,20 @@
       "link": true
     },
     "node_modules/@primer/doctocat-nextjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@primer/doctocat-nextjs/-/doctocat-nextjs-0.10.0.tgz",
-      "integrity": "sha512-50qNVxVOet5NPgsIObPk3kZY2ne2Za9sTZbXccb3qAyvnjsTjKeh7w72hbrI4gkC4ZlXHcy9Yyc0jCfapYAXcw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@primer/doctocat-nextjs/-/doctocat-nextjs-0.11.0.tgz",
+      "integrity": "sha512-cgzTtE1HmzSQ/zKqw/71JcpdQ/XUqME5MJjn17Jed9kDRjeYCHJaiTWAI+6PjgdUkqMt4nF1yj4DP+8JAmEZug==",
       "license": "MIT",
       "dependencies": {
-        "@next/mdx": "16.2.2",
-        "@primer/octicons-react": "19.23.1",
-        "@primer/react": "^38.18.0",
+        "@next/mdx": "16.3.0",
+        "@primer/octicons-react": "19.33.0",
+        "@primer/react": "^38.35.1",
         "@types/lodash.debounce": "^4.0.9",
-        "framer-motion": "12.38.0",
+        "framer-motion": "12.43.0",
         "lodash.debounce": "^4.0.8",
         "nextra": "4.6.1",
         "react-focus-on": "^3.10.2",
-        "react-is": "^19.2.4",
+        "react-is": "^19.2.8",
         "react-live": "^4.1.8"
       },
       "peerDependencies": {
@@ -10134,31 +10135,55 @@
       }
     },
     "node_modules/@primer/doctocat-nextjs/node_modules/@github/relative-time-element": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-5.0.0.tgz",
-      "integrity": "sha512-L/2r0DNR/rMbmHWcsdmhtOiy2gESoGOhItNFD4zJ3nZfHl79Dx3N18Vfx/pYr2lruMOdk1cJZb4wEumm+Dxm1w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-5.3.1.tgz",
+      "integrity": "sha512-f++QCIXxGH7rMbpTASRfLyCyPydd4HqwOmATBb/sAUCq72HEZN0MX9znmJSp7NKYxuQxF8j0Mv3ez9P32c70vw==",
       "license": "MIT"
+    },
+    "node_modules/@primer/doctocat-nextjs/node_modules/@primer/live-region-element": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.8.0.tgz",
+      "integrity": "sha512-DIp04IeZvZ+gwCUcBchIvRwJA2PikP/6hnFhcLKgwttcg5OYjBH9t0cZjLnv10Aq1jN0rAFFG+WPMd3bw4hXcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.1"
+      }
+    },
+    "node_modules/@primer/doctocat-nextjs/node_modules/@primer/octicons-react": {
+      "version": "19.33.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.33.0.tgz",
+      "integrity": "sha512-7VL8WuLXXZvUV/DP895ESFXPl/FJq816amCT3KZcmpQgxM1uv6lJGCcsEFpLX3K6SE+3qcmsftPpxn3ctr06+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.3"
+      }
     },
     "node_modules/@primer/doctocat-nextjs/node_modules/@primer/primitives": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-11.7.1.tgz",
-      "integrity": "sha512-+ch43fCGwMHe22AOvgVEg9UTCbqU3XevnnMzxk7J+jajPA0GouIJPrLFLN00uV7Fp6ZxqTj3F3vxigumEIg6Kw==",
-      "license": "MIT"
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/@primer/primitives/-/primitives-11.10.0.tgz",
+      "integrity": "sha512-ihZxIst4Izry284StKFjpbYvX6R/IBFTLu+qiuAmR93PsKF2hdjoabhSYwKI8iCxOUx94jVP55bI3NoY7STjYQ==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "docs/storybook"
+      ]
     },
     "node_modules/@primer/doctocat-nextjs/node_modules/@primer/react": {
-      "version": "38.20.0",
-      "resolved": "https://registry.npmjs.org/@primer/react/-/react-38.20.0.tgz",
-      "integrity": "sha512-jH1IC07uC4vn0NKLE/Wr+ziw+K3WSDPkQtjmQLkYj1JzVGH9imEKcglNqIXaP5mBItLkhzJCMRI2ODRlK8fWvw==",
+      "version": "38.35.1",
+      "resolved": "https://registry.npmjs.org/@primer/react/-/react-38.35.1.tgz",
+      "integrity": "sha512-zid4w1b3ax5DBCxZkzPXUE3xpXw4h/+LeaTbF8MYBoUYb76+os7ip/LTLWqPOHmrdrl6wRtDo4ysoUsWnoHODQ==",
       "license": "MIT",
       "dependencies": {
         "@github/mini-throttle": "^2.1.1",
         "@github/relative-time-element": "^5.0.0",
-        "@github/tab-container-element": "^4.8.2",
         "@lit-labs/react": "1.2.1",
         "@oddbird/popover-polyfill": "^0.5.2",
-        "@primer/behaviors": "^1.10.2",
-        "@primer/live-region-element": "^0.7.1",
-        "@primer/octicons-react": "^19.21.0",
+        "@primer/behaviors": "^1.10.3",
+        "@primer/live-region-element": "^0.8.0",
+        "@primer/octicons-react": "^19.28.1",
         "@primer/primitives": "10.x || 11.x",
         "@tanstack/react-virtual": "^3.13.18",
         "clsx": "^2.1.1",
@@ -10170,7 +10195,7 @@
         "lodash.isempty": "^4.4.0",
         "lodash.isobject": "^3.0.2",
         "react-compiler-runtime": "^1.0.0",
-        "react-intersection-observer": "^9.16.0"
+        "react-intersection-observer": "^10.0.3"
       },
       "engines": {
         "node": ">=12",
@@ -10205,16 +10230,32 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
       }
     },
+    "node_modules/@primer/doctocat-nextjs/node_modules/react-intersection-observer": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-10.1.0.tgz",
+      "integrity": "sha512-V8HDu3+Llg6OEhOxx8LnUSS0t4VS+1Xk9ZatkI8Jct/H0CwKnqFTCu8NT3q7ghJTghTdIrEMPSWr2dkKPG+gdQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@primer/doctocat-nextjs/node_modules/react-is": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
-      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "license": "MIT"
     },
     "node_modules/@primer/live-region-element": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.7.2.tgz",
       "integrity": "sha512-wdxCHfcJzE1IPPjZNFR4RTwRcSWb7TN0fRdMH5HcxphLEnuZBWy0TAxk3xPA+/6lwiN3uEJ+ZWV4UF/glXh43A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.0"
@@ -20798,13 +20839,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
-      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.38.0",
-        "motion-utils": "^12.36.0",
+        "motion-dom": "^12.43.0",
+        "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -27090,18 +27131,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.36.0"
+        "motion-utils": "^12.39.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/mri": {
@@ -30746,6 +30787,7 @@
       "version": "9.16.0",
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
       "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -36848,7 +36890,7 @@
     },
     "packages/css": {
       "name": "@primer/brand-css",
-      "version": "0.71.0",
+      "version": "0.73.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "@types/node": "24.12.0",
@@ -36864,7 +36906,7 @@
     },
     "packages/design-tokens": {
       "name": "@primer/brand-primitives",
-      "version": "0.71.0",
+      "version": "0.73.0",
       "license": "MIT",
       "devDependencies": {
         "@primer/primitives": "9.1.1",
@@ -36878,7 +36920,7 @@
     },
     "packages/e2e": {
       "name": "@primer/brand-e2e",
-      "version": "0.71.0",
+      "version": "0.73.0",
       "license": "MIT",
       "devDependencies": {
         "@github/axe-github": "^0.8.1",
@@ -36894,7 +36936,7 @@
     },
     "packages/fonts": {
       "name": "@primer/brand-fonts",
-      "version": "0.71.0",
+      "version": "0.73.0",
       "license": "MIT",
       "engines": {
         "node": ">=24.0.0",
@@ -36903,7 +36945,7 @@
     },
     "packages/mcp": {
       "name": "@primer/brand-mcp",
-      "version": "0.71.0",
+      "version": "0.73.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.0",
@@ -36922,7 +36964,7 @@
     },
     "packages/react": {
       "name": "@primer/react-brand",
-      "version": "0.71.0",
+      "version": "0.73.0",
       "license": "MIT",
       "dependencies": {
         "@oddbird/popover-polyfill": "0.5.2",
@@ -37069,7 +37111,7 @@
     },
     "packages/repo-configs": {
       "name": "@primer/brand-config",
-      "version": "0.71.0",
+      "version": "0.73.0",
       "license": "MIT"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
       "license": "MIT",
       "dependencies": {
         "@primer/doctocat-nextjs": "0.11.0",
-        "@primer/octicons-react": "19.23.1",
+        "@primer/octicons-react": "19.33.0",
         "next": "16.2.2",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -63,7 +63,7 @@
       "devDependencies": {
         "@github/prettier-config": "^0.0.6",
         "@primer/brand-primitives": "^0.73.0",
-        "@primer/react": "38.18.0",
+        "@primer/react": "38.35.1",
         "@primer/react-brand": "0.73.0",
         "@swc/core": "^1.15.21",
         "@types/node": "24.12.0",
@@ -81,25 +81,37 @@
         "react-dom": "^19.2.0"
       }
     },
+    "apps/next-docs/node_modules/@primer/octicons-react": {
+      "version": "19.33.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.33.0.tgz",
+      "integrity": "sha512-7VL8WuLXXZvUV/DP895ESFXPl/FJq816amCT3KZcmpQgxM1uv6lJGCcsEFpLX3K6SE+3qcmsftPpxn3ctr06+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.3"
+      }
+    },
     "apps/next-docs/node_modules/@primer/primitives": {
       "version": "11.3.2",
       "dev": true,
       "license": "MIT"
     },
     "apps/next-docs/node_modules/@primer/react": {
-      "version": "38.18.0",
+      "version": "38.35.1",
+      "resolved": "https://registry.npmjs.org/@primer/react/-/react-38.35.1.tgz",
+      "integrity": "sha512-zid4w1b3ax5DBCxZkzPXUE3xpXw4h/+LeaTbF8MYBoUYb76+os7ip/LTLWqPOHmrdrl6wRtDo4ysoUsWnoHODQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@github/mini-throttle": "^2.1.1",
-        "@github/relative-time-element": "^4.5.0",
-        "@github/tab-container-element": "^4.8.2",
+        "@github/relative-time-element": "^5.0.0",
         "@lit-labs/react": "1.2.1",
-        "@oddbird/css-anchor-positioning": "^0.9.0",
         "@oddbird/popover-polyfill": "^0.5.2",
-        "@primer/behaviors": "^1.10.2",
-        "@primer/live-region-element": "^0.7.1",
-        "@primer/octicons-react": "^19.21.0",
+        "@primer/behaviors": "^1.10.3",
+        "@primer/live-region-element": "^0.8.0",
+        "@primer/octicons-react": "^19.28.1",
         "@primer/primitives": "10.x || 11.x",
         "@tanstack/react-virtual": "^3.13.18",
         "clsx": "^2.1.1",
@@ -111,7 +123,7 @@
         "lodash.isempty": "^4.4.0",
         "lodash.isobject": "^3.0.2",
         "react-compiler-runtime": "^1.0.0",
-        "react-intersection-observer": "^9.16.0"
+        "react-intersection-observer": "^10.0.3"
       },
       "engines": {
         "node": ">=12",
@@ -145,6 +157,22 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
+      }
+    },
+    "apps/next-docs/node_modules/@primer/react/node_modules/react-intersection-observer": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-10.1.0.tgz",
+      "integrity": "sha512-V8HDu3+Llg6OEhOxx8LnUSS0t4VS+1Xk9ZatkI8Jct/H0CwKnqFTCu8NT3q7ghJTghTdIrEMPSWr2dkKPG+gdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "apps/next-docs/node_modules/react-is": {
@@ -6501,17 +6529,9 @@
       "license": "MIT"
     },
     "node_modules/@github/relative-time-element": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.5.1.tgz",
-      "integrity": "sha512-uxCxCwe9vdwUDmRmM84tN0UERlj8MosLV44+r/VDj7DZUVUSTP4vyWlE9mRK6vHelOmT8DS3RMlaMrLlg1h1PQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@github/tab-container-element": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/@github/tab-container-element/-/tab-container-element-4.8.2.tgz",
-      "integrity": "sha512-WkaM4mfs8x7dXRWEaDb5deC0OhH6sGQ5cw8i/sVw25gikl4f8C7mHj0kihL5k3eKIIqmGT1Fdswdoi+9ZLDpRA==",
-      "dev": true,
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-5.3.1.tgz",
+      "integrity": "sha512-f++QCIXxGH7rMbpTASRfLyCyPydd4HqwOmATBb/sAUCq72HEZN0MX9znmJSp7NKYxuQxF8j0Mv3ez9P32c70vw==",
       "license": "MIT"
     },
     "node_modules/@hapi/hoek": {
@@ -9674,19 +9694,6 @@
         "node": "^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/@oddbird/css-anchor-positioning": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@oddbird/css-anchor-positioning/-/css-anchor-positioning-0.9.0.tgz",
-      "integrity": "sha512-G5nfb4sU0auxJH7VHafPwVJjr1GhH5uPSkmytGqhNftCpT3QEh8pFtMd4YHt1dRwb4o9qVZxlGSKUIc4TIrysQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.5",
-        "@types/css-tree": "^2.3.11",
-        "css-tree": "^3.1.0",
-        "nanoid": "^5.1.6"
-      }
-    },
     "node_modules/@oddbird/popover-polyfill": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.5.2.tgz",
@@ -10134,21 +10141,6 @@
         "react-dom": ">=18.0.0 <20.0.0"
       }
     },
-    "node_modules/@primer/doctocat-nextjs/node_modules/@github/relative-time-element": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-5.3.1.tgz",
-      "integrity": "sha512-f++QCIXxGH7rMbpTASRfLyCyPydd4HqwOmATBb/sAUCq72HEZN0MX9znmJSp7NKYxuQxF8j0Mv3ez9P32c70vw==",
-      "license": "MIT"
-    },
-    "node_modules/@primer/doctocat-nextjs/node_modules/@primer/live-region-element": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.8.0.tgz",
-      "integrity": "sha512-DIp04IeZvZ+gwCUcBchIvRwJA2PikP/6hnFhcLKgwttcg5OYjBH9t0cZjLnv10Aq1jN0rAFFG+WPMd3bw4hXcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.1"
-      }
-    },
     "node_modules/@primer/doctocat-nextjs/node_modules/@primer/octicons-react": {
       "version": "19.33.0",
       "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.33.0.tgz",
@@ -10252,19 +10244,19 @@
       "license": "MIT"
     },
     "node_modules/@primer/live-region-element": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.7.2.tgz",
-      "integrity": "sha512-wdxCHfcJzE1IPPjZNFR4RTwRcSWb7TN0fRdMH5HcxphLEnuZBWy0TAxk3xPA+/6lwiN3uEJ+ZWV4UF/glXh43A==",
-      "dev": true,
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@primer/live-region-element/-/live-region-element-0.8.0.tgz",
+      "integrity": "sha512-DIp04IeZvZ+gwCUcBchIvRwJA2PikP/6hnFhcLKgwttcg5OYjBH9t0cZjLnv10Aq1jN0rAFFG+WPMd3bw4hXcA==",
       "license": "MIT",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.2.1"
       }
     },
     "node_modules/@primer/octicons-react": {
       "version": "19.23.1",
       "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.23.1.tgz",
       "integrity": "sha512-Ldiu3zZ46YGKj4PawrbnbPxwKs+8+2Zz0J24bV4PPYPrqbNo9sSbd9aHtIAyWs8PaMohlsJGfxQtHMyKt7odjg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13135,13 +13127,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/css-tree": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/@types/css-tree/-/css-tree-2.3.11.tgz",
-      "integrity": "sha512-aEokibJOI77uIlqoBOkVbaQGC9zII0A+JH1kcTNKW2CwyYWD8KM6qdo+4c77wD3wZOQfJuNWAr9M4hdk+YhDIg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",
@@ -16966,20 +16951,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/css.escape": {
@@ -26124,13 +26095,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -30779,22 +30743,6 @@
           "optional": true
         },
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-intersection-observer": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
-      "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
           "optional": true
         }
       }


### PR DESCRIPTION
## Summary

Video player docs are broken. Fixed through Doctocat release where live preview now supports basePath for video attributes


## Contributor checklist:

- [ ] All new and existing CI checks pass
- [ ] Tests prove that the feature works and covers both happy and unhappy paths
- [ ] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [ ] All developer debugging and non-functional logging has been removed
- [ ] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change

## Screenshots:

> Please try to provide before and after screenshots or videos

<table>
<tr>
<th> Before</th> <th> After </th>
</tr>
<tr>
<td valign="top">
<img width="1002" height="936" alt="Screenshot 2026-08-12 at 12 46 22" src="https://github.com/user-attachments/assets/6685adbb-6de5-4539-b17f-582f39b6cd9c" />

 </td>
<td valign="top">
<img width="1015" height="959" alt="Screenshot 2026-08-12 at 12 46 09" src="https://github.com/user-attachments/assets/a435b4fe-ecbb-42e0-a3be-addb480c1321" />

</td>
</tr>
</table>
