### PR TITLE
Add accessible labels for pricing tooltips

### DIFF
--- a/.changeset/add-pricing-tooltip-label.md
+++ b/.changeset/add-pricing-tooltip-label.md
@@ -2,4 +2,4 @@
 '@primer/react-brand': patch
 ---
 
-Added `infoTooltipAriaLabel` to `PricingOptions.FeatureListItem` so consumers can distinguish info tooltip triggers when feature content uses rich React children.
+Added `infoTooltipAriaLabel` to `PricingOptions.FeatureListItem` to customize the tooltip trigger's accessible label.

--- a/.changeset/add-pricing-tooltip-label.md
+++ b/.changeset/add-pricing-tooltip-label.md
@@ -1,0 +1,5 @@
+---
+'@primer/react-brand': patch
+---
+
+Added `infoTooltipAriaLabel` to `PricingOptions.FeatureListItem` so consumers can distinguish info tooltip triggers when feature content uses rich React children.

--- a/apps/next-docs/content/components/PricingOptions/index.mdx
+++ b/apps/next-docs/content/components/PricingOptions/index.mdx
@@ -380,6 +380,9 @@ Use `PricingOptions.FeatureListItem` with `variant="included"` and `variant="exc
 ### Info tooltips
 
 Use `infoTooltip` on `PricingOptions.FeatureListItem` to add a supplementary tooltip to a feature.
+When the feature's `children` are rich React content instead of a plain string, provide
+`infoTooltipAriaLabel` with the full accessible name for the trigger button. This keeps multiple
+tooltip triggers distinguishable without changing the tooltip text.
 
 ```jsx live
 <PricingOptions>
@@ -391,8 +394,11 @@ Use `infoTooltip` on `PricingOptions.FeatureListItem` to add a supplementary too
     </PricingOptions.Price>
     <PricingOptions.FeatureList>
       <PricingOptions.FeatureListItem>Code completions</PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem infoTooltip="Interact with Copilot using natural language.">
-        Chat in IDE and Mobile
+      <PricingOptions.FeatureListItem
+        infoTooltip="Interact with Copilot using natural language."
+        infoTooltipAriaLabel="More information about Chat in IDE and Mobile"
+      >
+        <span>Chat in IDE and Mobile</span>
       </PricingOptions.FeatureListItem>
       <PricingOptions.FeatureListItem infoTooltip="Get help directly in your terminal.">
         CLI assistance
@@ -510,11 +516,12 @@ One item per pricing plan to be displayed. Maximum of 4 items.
 
 ### PricingOptions.FeatureListItem
 
-| Name          | Type                                         |   Default   | required | Description                                               |
-| :------------ | :------------------------------------------- | :---------: | :------: | :-------------------------------------------------------- |
-| `children`    | `ReactNode`                                  | `undefined` |  `true`  | The item of the feature list set                          |
-| `infoTooltip` | `string`                                     | `undefined` | `false`  | Tooltip text shown on hover/focus via an info icon button |
-| `variant`     | <PricingOptionsFeatureListItemVariantProp /> | `included`  | `false`  | The variant of the feature list set                       |
+| Name                   | Type                                         |   Default   | required | Description                                                                                      |
+| :--------------------- | :------------------------------------------- | :---------: | :------: | :----------------------------------------------------------------------------------------------- |
+| `children`             | `ReactNode`                                  | `undefined` |  `true`  | The item of the feature list set                                                                 |
+| `infoTooltip`          | `string`                                     | `undefined` | `false`  | Tooltip text shown on hover/focus via an info icon button                                        |
+| `infoTooltipAriaLabel` | `string`                                     | `undefined` | `false`  | Full accessible name for the info tooltip trigger. Recommended when `children` is not a `string` |
+| `variant`              | <PricingOptionsFeatureListItemVariantProp /> | `included`  | `false`  | The variant of the feature list set                                                              |
 
 ### PricingOptions.MenuAction
 

--- a/apps/next-docs/content/components/PricingOptions/index.mdx
+++ b/apps/next-docs/content/components/PricingOptions/index.mdx
@@ -379,10 +379,9 @@ Use `PricingOptions.FeatureListItem` with `variant="included"` and `variant="exc
 
 ### Info tooltips
 
-Use `infoTooltip` on `PricingOptions.FeatureListItem` to add a supplementary tooltip to a feature.
-When the feature's `children` are rich React content instead of a plain string, provide
-`infoTooltipAriaLabel` with the full accessible name for the trigger button. This keeps multiple
-tooltip triggers distinguishable without changing the tooltip text.
+Use `infoTooltip` on `PricingOptions.FeatureListItem` to add an optional tooltip to a feature.
+
+An `aria-label` is automatically applied to the tooltip trigger. Use `infoTooltipAriaLabel` to customize it.
 
 ```jsx live
 <PricingOptions>
@@ -394,11 +393,8 @@ tooltip triggers distinguishable without changing the tooltip text.
     </PricingOptions.Price>
     <PricingOptions.FeatureList>
       <PricingOptions.FeatureListItem>Code completions</PricingOptions.FeatureListItem>
-      <PricingOptions.FeatureListItem
-        infoTooltip="Interact with Copilot using natural language."
-        infoTooltipAriaLabel="More information about Chat in IDE and Mobile"
-      >
-        <span>Chat in IDE and Mobile</span>
+      <PricingOptions.FeatureListItem infoTooltip="Interact with Copilot using natural language.">
+        Chat in IDE and Mobile
       </PricingOptions.FeatureListItem>
       <PricingOptions.FeatureListItem infoTooltip="Get help directly in your terminal.">
         CLI assistance
@@ -408,6 +404,25 @@ tooltip triggers distinguishable without changing the tooltip text.
     <PricingOptions.PrimaryAction href="/buy">Start a free trial</PricingOptions.PrimaryAction>
   </PricingOptions.Item>
 </PricingOptions>
+```
+
+Use a custom trigger label when conditionally rendered content prevents the feature text from being used as the
+automatically generated label:
+
+```jsx
+function FeatureWithCustomContent({customContent}) {
+  return (
+    <PricingOptions.FeatureListItem
+      infoTooltip="Interact with Copilot using natural language."
+      infoTooltipAriaLabel="More information about Chat in IDE and Mobile"
+    >
+      <>
+        Chat in IDE and Mobile
+        {customContent ? <Text>Custom footnote</Text> : null}
+      </>
+    </PricingOptions.FeatureListItem>
+  )
+}
 ```
 
 ### Actions message
@@ -516,12 +531,12 @@ One item per pricing plan to be displayed. Maximum of 4 items.
 
 ### PricingOptions.FeatureListItem
 
-| Name                   | Type                                         |   Default   | required | Description                                                                                      |
-| :--------------------- | :------------------------------------------- | :---------: | :------: | :----------------------------------------------------------------------------------------------- |
-| `children`             | `ReactNode`                                  | `undefined` |  `true`  | The item of the feature list set                                                                 |
-| `infoTooltip`          | `string`                                     | `undefined` | `false`  | Tooltip text shown on hover/focus via an info icon button                                        |
-| `infoTooltipAriaLabel` | `string`                                     | `undefined` | `false`  | Full accessible name for the info tooltip trigger. Recommended when `children` is not a `string` |
-| `variant`              | <PricingOptionsFeatureListItemVariantProp /> | `included`  | `false`  | The variant of the feature list set                                                              |
+| Name                   | Type                                         |   Default   | required | Description                                                                         |
+| :--------------------- | :------------------------------------------- | :---------: | :------: | :---------------------------------------------------------------------------------- |
+| `children`             | `ReactNode`                                  | `undefined` |  `true`  | The item of the feature list set                                                    |
+| `infoTooltip`          | `string`                                     | `undefined` | `false`  | Tooltip text shown on hover/focus via an info icon button                           |
+| `infoTooltipAriaLabel` | `string`                                     | `undefined` | `false`  | Overrides the automatically generated accessible label for the info tooltip trigger |
+| `variant`              | <PricingOptionsFeatureListItemVariantProp /> | `included`  | `false`  | The variant of the feature list set                                                 |
 
 ### PricingOptions.MenuAction
 

--- a/packages/react/src/PricingOptions/PricingOptions.features.stories.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.features.stories.tsx
@@ -1312,8 +1312,11 @@ export const WithInfoTooltips: Story = {
         <PricingOptions.Price trailingText="per month / $100 per year">10</PricingOptions.Price>
         <PricingOptions.FeatureList>
           <PricingOptions.FeatureListItem>Code completions</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem infoTooltip="Interact with Copilot using natural language.">
-            Chat in IDE and Mobile
+          <PricingOptions.FeatureListItem
+            infoTooltip="Interact with Copilot using natural language."
+            infoTooltipAriaLabel="More information about Chat in IDE and Mobile"
+          >
+            <span>Chat in IDE and Mobile</span>
           </PricingOptions.FeatureListItem>
           <PricingOptions.FeatureListItem infoTooltip="Get help directly in your terminal.">
             CLI assistance

--- a/packages/react/src/PricingOptions/PricingOptions.features.stories.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.features.stories.tsx
@@ -1312,11 +1312,8 @@ export const WithInfoTooltips: Story = {
         <PricingOptions.Price trailingText="per month / $100 per year">10</PricingOptions.Price>
         <PricingOptions.FeatureList>
           <PricingOptions.FeatureListItem>Code completions</PricingOptions.FeatureListItem>
-          <PricingOptions.FeatureListItem
-            infoTooltip="Interact with Copilot using natural language."
-            infoTooltipAriaLabel="More information about Chat in IDE and Mobile"
-          >
-            <span>Chat in IDE and Mobile</span>
+          <PricingOptions.FeatureListItem infoTooltip="Interact with Copilot using natural language.">
+            Chat in IDE and Mobile
           </PricingOptions.FeatureListItem>
           <PricingOptions.FeatureListItem infoTooltip="Get help directly in your terminal.">
             CLI assistance
@@ -1385,6 +1382,39 @@ export const WithInfoTooltips: Story = {
       </PricingOptions.Item>
     </PricingOptions>
   ),
+}
+
+function PricingOptionsWithCustomTriggerLabel({customContent}: {customContent?: React.ReactNode}) {
+  return (
+    <PricingOptions>
+      <PricingOptions.Item>
+        <PricingOptions.Heading>Copilot Individual</PricingOptions.Heading>
+        <PricingOptions.Description>
+          Code completions, Chat, and more for indie developers and freelancers.
+        </PricingOptions.Description>
+        <PricingOptions.Price trailingText="per month / $100 per year">10</PricingOptions.Price>
+        <PricingOptions.FeatureList>
+          <PricingOptions.FeatureListItem
+            infoTooltip="Interact with Copilot using natural language."
+            infoTooltipAriaLabel="More information about Chat in IDE and Mobile"
+          >
+            <>
+              Chat in IDE and Mobile
+              {customContent ? <Text>{customContent}</Text> : null}
+            </>
+          </PricingOptions.FeatureListItem>
+          <PricingOptions.FeatureListItem>Code completions</PricingOptions.FeatureListItem>
+        </PricingOptions.FeatureList>
+        <PricingOptions.PrimaryAction as="a" href="#">
+          Start a free trial
+        </PricingOptions.PrimaryAction>
+      </PricingOptions.Item>
+    </PricingOptions>
+  )
+}
+
+export const WithInfoTooltipsAndCustomTriggerLabel: Story = {
+  render: () => <PricingOptionsWithCustomTriggerLabel customContent="Custom footnote" />,
 }
 
 export const WithMenuAction: Story = {

--- a/packages/react/src/PricingOptions/PricingOptions.test.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.test.tsx
@@ -556,6 +556,53 @@ describe('PricingOptions', () => {
     expect(infoButton).toHaveAttribute('aria-describedby')
   })
 
+  it('uses an explicit info tooltip aria label for ReactNode feature content', () => {
+    mockUseWindowSize.mockReturnValue(mediumBreakpoint)
+
+    const {getByRole} = render(
+      <PricingOptions>
+        <PricingOptions.Item>
+          <PricingOptions.FeatureList>
+            <PricingOptions.FeatureListItem
+              infoTooltip="Interact with Copilot using natural language."
+              infoTooltipAriaLabel="More information about Chat in IDE"
+            >
+              <span>Chat in IDE</span>
+            </PricingOptions.FeatureListItem>
+            <PricingOptions.FeatureListItem
+              infoTooltip="Get help directly in your terminal."
+              infoTooltipAriaLabel="More information about CLI assistance"
+            >
+              <span>CLI assistance</span>
+            </PricingOptions.FeatureListItem>
+          </PricingOptions.FeatureList>
+        </PricingOptions.Item>
+      </PricingOptions>,
+    )
+
+    expect(getByRole('button', {name: 'More information about Chat in IDE'})).toBeInTheDocument()
+    expect(getByRole('button', {name: 'More information about CLI assistance'})).toBeInTheDocument()
+  })
+
+  it('uses the existing generic info tooltip aria label for ReactNode feature content by default', () => {
+    mockUseWindowSize.mockReturnValue(mediumBreakpoint)
+
+    const {getByRole} = render(
+      <PricingOptions>
+        <PricingOptions.Item>
+          <PricingOptions.FeatureList>
+            <PricingOptions.FeatureListItem infoTooltip="Interact with Copilot using natural language.">
+              <span>Chat in IDE</span>
+            </PricingOptions.FeatureListItem>
+            <PricingOptions.FeatureListItem>Another feature</PricingOptions.FeatureListItem>
+          </PricingOptions.FeatureList>
+        </PricingOptions.Item>
+      </PricingOptions>,
+    )
+
+    expect(getByRole('button', {name: 'More information about this feature'})).toBeInTheDocument()
+  })
+
   it('does not render an info button when infoTooltip is not provided', () => {
     mockUseWindowSize.mockReturnValue(mediumBreakpoint)
 

--- a/packages/react/src/PricingOptions/PricingOptions.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.tsx
@@ -584,8 +584,7 @@ type PricingOptionsFeatureListItemProps = PropsWithChildren<BaseProps<HTMLLIElem
   'data-testid'?: string
   infoTooltip?: string
   /**
-   * Provides an accessible label for the info tooltip trigger. Use when children is not a string so that repeated
-   * tooltip triggers remain distinguishable.
+   * Optional accessible label for the info tooltip trigger. Overrides the automatically generated label.
    */
   infoTooltipAriaLabel?: string
   variant?: 'included' | 'excluded'
@@ -635,9 +634,9 @@ const PricingOptionsFeatureListItem = forwardRef<HTMLLIElement, PricingOptionsFe
               type="button"
               className={styles['PricingOptions__feature-list-item-info']}
               aria-label={
-                infoTooltipAriaLabel !== undefined
-                  ? infoTooltipAriaLabel
-                  : `More information about ${typeof children === 'string' ? children : 'this feature'}`
+                infoTooltipAriaLabel ??
+                // eslint-disable-next-line i18n-text/no-en
+                `More information about ${typeof children === 'string' ? children : 'this feature'}`
               }
             >
               <svg viewBox="0 0 4 8" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">

--- a/packages/react/src/PricingOptions/PricingOptions.tsx
+++ b/packages/react/src/PricingOptions/PricingOptions.tsx
@@ -583,6 +583,11 @@ const PricingOptionsFeatureListGroupHeading = forwardRef<
 type PricingOptionsFeatureListItemProps = PropsWithChildren<BaseProps<HTMLLIElement>> & {
   'data-testid'?: string
   infoTooltip?: string
+  /**
+   * Provides an accessible label for the info tooltip trigger. Use when children is not a string so that repeated
+   * tooltip triggers remain distinguishable.
+   */
+  infoTooltipAriaLabel?: string
   variant?: 'included' | 'excluded'
 } & Omit<ListItemProps, 'variant'>
 
@@ -592,6 +597,7 @@ const PricingOptionsFeatureListItem = forwardRef<HTMLLIElement, PricingOptionsFe
       children,
       className,
       infoTooltip,
+      infoTooltipAriaLabel,
       leadingVisual,
       leadingVisualFill,
       variant = 'included',
@@ -628,7 +634,11 @@ const PricingOptionsFeatureListItem = forwardRef<HTMLLIElement, PricingOptionsFe
             <button
               type="button"
               className={styles['PricingOptions__feature-list-item-info']}
-              aria-label={`More information about ${typeof children === 'string' ? children : 'this feature'}`}
+              aria-label={
+                infoTooltipAriaLabel !== undefined
+                  ? infoTooltipAriaLabel
+                  : `More information about ${typeof children === 'string' ? children : 'this feature'}`
+              }
             >
               <svg viewBox="0 0 4 8" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path


### PR DESCRIPTION
## Summary

Adds an optional accessible label for `PricingOptions.FeatureListItem` tooltip triggers when feature content uses rich React children. Existing labels, tooltip behavior, visuals, and markup remain unchanged by default.

Addresses #1450

## List of notable changes:

- **added** `infoTooltipAriaLabel` for assigning the tooltip trigger's full accessible name
- **updated** focused tests, feature story, API documentation, and patch changeset

## What should reviewers focus on?

- Confirm the API follows existing single-control `*AriaLabel` conventions
- Confirm omitted labels retain the existing string and non-string fallbacks

## Steps to test:

1. Run `npm run build:lib`
1. Run `npm run test --workspace=packages/react -- --runInBand src/PricingOptions/PricingOptions.test.tsx`
1. Run the React and documentation type, lint, and formatting checks

## Supporting resources (related issues, external links, etc):

- https://github.com/github/github-ui/pull/30773#discussion_r3821499611

## Contributor checklist:

- [ ] All new and existing CI checks pass
- [x] Tests prove that the feature works and covers both happy and unhappy paths
- [x] Any drop in coverage, breaking changes or regressions have been documented above
- [ ] UI Changes contain new visual snapshots (generated by adding `update snapshots` label to the PR)
- [x] All developer debugging and non-functional logging has been removed
- [x] Related issues have been referenced in the PR description

## Reviewer checklist:

- [ ] Check that pull request and proposed changes adhere to our [contribution guidelines](../../CONTRIBUTING.md) and [code of conduct](../../CODE_OF_CONDUCT.md)
- [ ] Check that tests prove the feature works and covers both happy and unhappy paths
- [ ] Check that there aren't other open Pull Requests for the same update/change